### PR TITLE
Removing the kafka trunk dependency for building datastream

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,18 +9,6 @@ Check out the datastream documentation at <http://go/datastream>
 
 ### Building
 
-To Build datastream, you need to build kafka first.
-
-#### Building and publishing kafka 
-
-Please follow the instructions at <https://github.com/apache/kafka/blob/trunk/README.md> to clone and build kafka on your local machine. Once kafka is built, you can publish the kafka binaires to local maven repository by running 
-
-```shell
-./gradlew install 
-```
-
-Once the kafka binaries are published. 
-
 #### Building and publishing Datastream
 
 Clone the datastream repository into /path/to/Datastream/localrepo and run the following commands
@@ -35,6 +23,16 @@ You can release the datastream binaries into local maven repository by running
 ```shell
 ./gradlew publishToMavenLocal
 ```
+
+### Developing using Idea
+
+You can use intellij for developing datastream. You can build the intellij project files by running
+
+```shell
+./gradlew idea
+```
+
+Once the intellij project files (*.ipr) are created, You can open them using Intellij and Start developing.
 
 ### Contributing and submitting patches
 

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -6,7 +6,7 @@ ext {
     jsonVersion = "20090211"
     metricsVersion = "3.0.1"
     commonsVersion = "1.5"
-    kafkaVersion = "0.8.3-SNAPSHOT"
+    kafkaVersion = "0.8.2.1"
     jacksonVersion = "1.8.5"
     avroVersion = "1.4.0"
     guavaVersion = "15.0"


### PR DESCRIPTION
Since we are not using the kafka's new api for load balancing consumer. We don't need to build datastream against the kafka trunk. 
