### PR TITLE
Add validateDatastream method to connector API

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Connector.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Connector.java
@@ -40,4 +40,12 @@ public interface Connector {
      * @return populated DatastreamTarget
      */
     DatastreamTarget getDatastreamTarget(Datastream stream);
+
+    /**
+     * Validate the datastream. Datastream management service call this before writing the
+     * Datastream into zookeeper. DMS ensureS that stream.source has sufficient details.
+     * @param stream: Datastream model
+     * @return validation result
+     */
+    DatastreamValidationResult validateDatastream(Datastream stream);
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamValidationResult.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamValidationResult.java
@@ -1,0 +1,37 @@
+package com.linkedin.datastream.server;
+
+/**
+ * This class represents the validation result of a Datastream requested by DMS to Connector.
+ */
+public class DatastreamValidationResult {
+  private final boolean _success;
+  private final String _errorMsg;
+
+  public DatastreamValidationResult() {
+    this(true, "");
+  }
+
+  public DatastreamValidationResult(String errorMsg) {
+    this(false, errorMsg);
+  }
+
+  public DatastreamValidationResult(boolean success, String errorMsg) {
+    assert success || errorMsg != "";
+    _success = success;
+    _errorMsg = errorMsg;
+  }
+
+  /**
+   * @return whether the validation is successful.
+   */
+  public boolean getSuccess() {
+    return _success;
+  }
+
+  /**
+   * @return detailed error message if unsuccessful.
+   */
+  public String getErrorMsg() {
+    return _errorMsg;
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -82,6 +82,11 @@ public class TestCoordinator {
         }
 
         @Override
+        public DatastreamValidationResult validateDatastream(Datastream stream) {
+            return new DatastreamValidationResult();
+        }
+
+        @Override
         public String getConnectorType() {
             return "TestConnector";
         }


### PR DESCRIPTION
This method is needed by DMS to validate a Datastream creation request.
