### PR TITLE
Re-enable stress tests, add more test coverage, add SimpleStrategy for

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -263,7 +263,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
      */
     public void addConnector(Connector connector, AssignmentStrategy strategy) {
         String connectorType = connector.getConnectorType();
-        LOG.info("Add new connector of type " + connectorType + " to coordinator");
+        LOG.info("Add new connector of type " + connectorType + " to coordinator instance: " + getInstanceName());
 
         if (_connectors.containsKey(connectorType)) {
             String err = "A connector of type " + connectorType + " already exists.";

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/SimpleStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/SimpleStrategy.java
@@ -1,0 +1,54 @@
+package com.linkedin.datastream.server.assignment;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.server.AssignmentStrategy;
+import com.linkedin.datastream.server.DatastreamTask;
+
+import java.util.*;
+
+public class SimpleStrategy implements AssignmentStrategy {
+
+    @Override
+    public Map<String, List<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances, Map<String, List<DatastreamTask>> currentAssignment) {
+        // if there are no live instances, return empty assignment
+        if (instances.size() == 0) {
+            return new HashMap<>();
+        }
+
+        Collections.sort(instances);
+        datastreams = sortDatastreams(datastreams);
+
+        Map<String, List<DatastreamTask>> assignment = new HashMap<>();
+
+        for(int i = 0; i < datastreams.size(); i++) {
+            int instanceIndex = i % instances.size();
+            assign(instances.get(instanceIndex), datastreams.get(i), assignment);
+        }
+
+        return assignment;
+    }
+
+    private List<Datastream> sortDatastreams(List<Datastream> datastreams) {
+        Map<String, Datastream> m = new HashMap<>();
+        List<String> keys = new ArrayList<>();
+        datastreams.forEach(ds -> {
+            m.put(ds.getName(), ds);
+            keys.add(ds.getName());
+        });
+
+        Collections.sort(keys);
+
+        List<Datastream> result = new ArrayList<>();
+        keys.forEach(k -> result.add(m.get(k)));
+
+        return result;
+    }
+
+    private void assign(String instance, Datastream datastream, Map<String, List<DatastreamTask>> assignment) {
+        DatastreamTask datastreamTask = new DatastreamTask(datastream);
+        if (!assignment.containsKey(instance)) {
+            assignment.put(instance, new ArrayList<>());
+        }
+        assignment.get(instance).add(datastreamTask);
+    }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkClient.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkClient.java
@@ -297,6 +297,12 @@ public class ZkClient extends org.I0Itec.zkclient.ZkClient {
 
     while (!pstack.empty()) {
       String p = pstack.pop();
+
+      // double check the existence of the path to avoid herd effect
+      if (this.exists(p)) {
+        continue;
+      }
+
       LOG.info("creating path in zookeeper: " + p);
       try{
         this.createPersistent(p);


### PR DESCRIPTION
This changeset include the following:
- Add SimpleStrategy, which assigns each Datastream to one live instance
- Fixed a corner case to remove potentially large number of warnings.
- Add test coverages for coordination assignment strategies.
