### PR TITLE
Ensure zookeeper znodes are created and deleted appropriately

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -66,9 +66,19 @@ public class KeyBuilder {
     return String.format(_datastreamTaskState, cluster, connectorType, datastreamName, taskId).replaceAll("//", "/");
   }
 
+  // zookeeper path: /{cluster}/{connectorType}/{datastream}/state
+  public static String datastreamTaskState(String cluster, String connectorType, String datastreamName) {
+    return datastreamTaskState(cluster, connectorType, datastreamName, "");
+  }
+
   // zookeeper path: /{cluster}/{connectorType}/{datastream}/{taskId}/config
   public static String datastreamTaskConfig(String cluster, String connectorType, String datastreamName, String taskId) {
     return String.format(_datastreamTaskConfig, cluster, connectorType, datastreamName, taskId).replaceAll("//", "/");
+  }
+
+  // zookeeper path: /{cluster}/{connectorType}/{datastream}/config
+  public static String datastreamTaskConfig(String cluster, String connectorType, String datastreamName) {
+    return datastreamTaskConfig(cluster, connectorType, datastreamName, "");
   }
 
   // zookeeper path: /{cluster}/{connectorType}/{datastream}/{taskId}/state

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -7,7 +7,7 @@ ext {
     metricsVersion = "3.0.1"
     commonsVersion = "1.5"
     kafkaVersion = "0.8.2.1"
-    jacksonVersion = "1.8.5"
+    jacksonVersion = "1.9.13"
     avroVersion = "1.4.0"
     guavaVersion = "15.0"
     pegasusVersion = "2.6.0"


### PR DESCRIPTION
This change list includes the following features:
- Make sure that corresponding zookeeper nodes are created and deleted at appropriate time.
- Add test coverages for znodes creation and cleanup
- Fixed race condition bug uncovered by the tests.
- Upgrade Jackson version. 
