### PR TITLE
move dummy EventCollector from test folder to main folder

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DummyDatastreamEventCollector.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DummyDatastreamEventCollector.java
@@ -4,7 +4,7 @@ import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.VerifiableProperties;
 
 /**
- * Dummy implementation of Datastream event collector for unit testing.
+ * Dummy implementation of Datastream event collector.
  */
 public class DummyDatastreamEventCollector implements DatastreamEventCollector {
   public DummyDatastreamEventCollector(Datastream datastream, VerifiableProperties config) {


### PR DESCRIPTION
This is to fix datastream-li deployment issue. Right now the coordinator always requires a valid EventCollector. A dummy EventCollector was created but under the test folder, which is not accessible from datastream-li.

We need to temporarily move it to main folder so that datastream-li war can run. Can move it back when we have some real EventCollector that we can use.
