### PR TITLE
Instantiate connectors with properties

### DIFF
--- a/datastream-common/src/test/java/com/linkedin/datastream/common/TestVerifiableProperties.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/common/TestVerifiableProperties.java
@@ -1,0 +1,56 @@
+package com.linkedin.datastream.common;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.Properties;
+
+public class TestVerifiableProperties {
+
+  @Test
+  public void testGetDomainProperties() {
+    /*
+     * BaseProperties:
+     *  "domain1.name1.property1" -> "value1"
+     *  "domain1.name1.property2" -> "value2"
+     *  "domain2.name1.property1" -> "value3"
+     */
+    Properties baseProperties = new Properties();
+    String prefix1 = "domain1.name1";
+    String prefix2 = "domain2.name1";
+    String key1 = prefix1 + ".property1";
+    String key2 = prefix1 + ".property2";
+    String key3 = prefix2 + ".property1";
+    baseProperties.put(key1, "value1");
+    baseProperties.put(key2, "value2");
+    baseProperties.put(key3, "value3");
+    VerifiableProperties verifiableProperties = new VerifiableProperties(baseProperties);
+
+    /*
+     * Preserving the full key string. Expected result:
+     *  "domain1.name1.property1" -> "value1"
+     *  "domain1.name1.property2" -> "value2"
+     */
+    Properties props1 = verifiableProperties.getDomainProperties(prefix1, true);
+    Assert.assertEquals(props1.getProperty(key1), "value1");
+    Assert.assertEquals(props1.getProperty(key2), "value2");
+    Assert.assertEquals(2, props1.size());
+    Assert.assertEquals(props1, verifiableProperties.getDomainProperties(prefix1 + ".", true));
+
+    /*
+     * Stripping the prefix. Expected result:
+     *  "property1" -> "value3"
+     */
+    Properties props2 = verifiableProperties.getDomainProperties(prefix2, false);
+    Assert.assertEquals(props2.getProperty("property1"), "value3");
+    Assert.assertEquals(1, props2.size());
+
+    /*
+     * Retrieve all properties
+     */
+    Properties props3 = verifiableProperties.getDomainProperties("");
+    Assert.assertEquals(props3.getProperty(key1), "value1");
+    Assert.assertEquals(props3.getProperty(key2), "value2");
+    Assert.assertEquals(props3.getProperty(key3), "value3");
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -10,14 +10,19 @@ public class CoordinatorConfig {
   private final int _zkSessionTimeout;
   private final int _zkConnectionTimeout;
   private final VerifiableProperties _config;
+
   private static final String PREFIX = "datastream.server.coordinator.";
+  public static final String CONFIG_CLUSTER = PREFIX + "cluster";
+  public static final String CONFIG_ZK_ADDRESS = PREFIX + "zkAddress";
+  public static final String CONFIG_ZK_SESSION_TIMEOUT = PREFIX + "zkSessionTimeout";
+  public static final String CONFIG_ZK_CONNECTION_TIMEOUT = PREFIX + "zkConnectionTimeout";
 
   public CoordinatorConfig(VerifiableProperties properties) {
     _config = properties;
-    _cluster = properties.getString(PREFIX + "cluster");
-    _zkAddress = properties.getString(PREFIX + "zkAddress");
-    _zkSessionTimeout = properties.getInt(PREFIX + "zkSessionTimeout", ZkClient.DEFAULT_SESSION_TIMEOUT);
-    _zkConnectionTimeout = properties.getInt(PREFIX + "zkConnectionTimeout", ZkClient.DEFAULT_CONNECTION_TIMEOUT);
+    _cluster = properties.getString(CONFIG_CLUSTER);
+    _zkAddress = properties.getString(CONFIG_ZK_ADDRESS);
+    _zkSessionTimeout = properties.getInt(CONFIG_ZK_SESSION_TIMEOUT, ZkClient.DEFAULT_SESSION_TIMEOUT);
+    _zkConnectionTimeout = properties.getInt(CONFIG_ZK_CONNECTION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
   }
 
   public VerifiableProperties getConfigProperties() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventCollectorFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventCollectorFactory.java
@@ -14,7 +14,8 @@ import java.util.Objects;
  * Datastream event collectors based on the configuration.
  */
 public class DatastreamEventCollectorFactory {
-  private static final String PROPERTY_COLLECTOR = "datastream.server.eventCollectorClass";
+  public static final String PREFIX = "datastream.server.";
+  public static final String CONFIG_COLLECTOR_NAME = PREFIX + "eventCollectorClassName";
 
   private final VerifiableProperties _config;
   private final Class _collectorClass;
@@ -22,7 +23,7 @@ public class DatastreamEventCollectorFactory {
   public DatastreamEventCollectorFactory(VerifiableProperties config) throws DatastreamException {
     Objects.requireNonNull(config, "invalid config.");
     _config = config;
-    String className = _config.getProperty(PROPERTY_COLLECTOR);
+    String className = _config.getProperty(CONFIG_COLLECTOR_NAME);
     if (StringUtils.isEmpty(className)) {
       throw new IllegalArgumentException("invalid event collector class in config.");
     }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -41,11 +41,11 @@ public class TestCoordinator {
   private Coordinator createCoordinator(String zkAddr, String cluster, int sessionTimeout, int connectionTimeout)
       throws Exception {
     Properties props = new Properties();
-    props.put("datastream.server.coordinator.cluster", cluster);
-    props.put("datastream.server.coordinator.zkAddress", zkAddr);
-    props.put("datastream.server.coordinator.zkSessionTimeout", String.valueOf(sessionTimeout));
-    props.put("datastream.server.coordinator.zkConnectionTime", String.valueOf(connectionTimeout));
-    props.put("datastream.server.eventCollectorClass", COLLECTOR_CLASS);
+    props.put(CoordinatorConfig.CONFIG_CLUSTER, cluster);
+    props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, zkAddr);
+    props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(sessionTimeout));
+    props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(connectionTimeout));
+    props.put(DatastreamServer.CONFIG_EVENT_COLLECTOR_CLASS_NAME, COLLECTOR_CLASS);
     return new Coordinator(new VerifiableProperties(props));
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -1,13 +1,32 @@
 package com.linkedin.datastream.server;
 
+import com.linkedin.datastream.server.assignment.BroadcastStrategy;
+import com.linkedin.datastream.server.connectors.DummyConnector;
 import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import java.util.Properties;
 
-
+@Test(singleThreaded=true)
 public class TestDatastreamServer {
-  private static final String COLLECTOR_CLASS = "com.linkedin.datastream.server.DummyDatastreamEventCollector";
+  // "com.linkedin.datastream.server.DummyDatastreamEventCollector"
+  private static final String COLLECTOR_CLASS = DummyDatastreamEventCollector.class.getTypeName();
+  // "com.linkedin.datastream.server.connectors.DummyConnector"
+  private static final String DUMMY_CONNECTOR = DummyConnector.class.getTypeName();
+  // "com.linkedin.datastream.server.assignment.BroadcastStrategy"
+  private static final String BROADCAST_STRATEGY =  BroadcastStrategy.class.getTypeName();
+
+  @BeforeTest
+  public void setUp() throws Exception {
+    DatastreamServer.INSTANCE.shutDown();
+  }
+
+  @AfterTest
+  public void tearDown() throws Exception {
+    DatastreamServer.INSTANCE.shutDown();
+  }
 
   @Test
   public void testDatastreamServerBasics() throws Exception {
@@ -16,15 +35,16 @@ public class TestDatastreamServer {
     embeddedZookeeper.startup();
 
     Properties properties = new Properties();
-    properties.put("datastream.server.coordinator.cluster", "testCluster");
-    properties.put("datastream.server.coordinator.zkAddress", zkConnectionString);
-    properties.put("datastream.server.eventCollectorClass", COLLECTOR_CLASS);
-    properties.put("datastream.server.httpport", "8080");
-    properties.put("datastream.server.connectorTypes", "com.linkedin.datastream.server.connectors.DummyConnector");
-    properties.put("com.linkedin.datastream.server.DummyConnector.assignmentStrategy",
-        "com.linkedin.datastream.server.assignment.BroadcastStrategy");
+    properties.put(DatastreamServer.CONFIG_CLUSTER_NAME, "testCluster");
+    properties.put(DatastreamServer.CONFIG_ZK_ADDRESS, zkConnectionString);
+    properties.put(DatastreamServer.CONFIG_EVENT_COLLECTOR_CLASS_NAME, COLLECTOR_CLASS);
+    properties.put(DatastreamServer.CONFIG_HTTP_PORT, "8080");
+    properties.put(DatastreamServer.CONFIG_CONNECTOR_CLASS_NAMES, DUMMY_CONNECTOR);
+    properties.put(DUMMY_CONNECTOR + ".assignmentStrategy", BROADCAST_STRATEGY);
+    properties.put(DUMMY_CONNECTOR + ".dummyProperty", "dummyValue"); // DummyConnector will verify this value being correctly set
 
     DatastreamServer server = DatastreamServer.INSTANCE;
     server.init(properties);
   }
+
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/connectors/DummyConnector.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/connectors/DummyConnector.java
@@ -9,12 +9,24 @@ import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamValidationResult;
 
 import java.util.List;
+import java.util.Properties;
 
 
 /**
  * A trivial implementation of connector interface
  */
 public class DummyConnector implements Connector {
+
+  private Properties _properties;
+
+  public DummyConnector(Properties properties) throws Exception {
+    _properties = properties;
+    String dummyConfigValue = _properties.getProperty("dummyProperty", "");
+    if (!dummyConfigValue.equals("dummyValue")) {
+      throw new Exception("Invalid config value for dummyProperty. Expected: dummyValue");
+    }
+  }
+
   @Override
   public void start(DatastreamEventCollectorFactory factory) {
   }


### PR DESCRIPTION
When instantiating a connector, look for a declared constructor that takes a Properties object as parameter and use that to create the connector.

Adding new feature in VerifiableProperties to support returning a list of properties under certain domain.
