### PR TITLE
Datastream Rest client and corresponding test cases

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -116,6 +116,7 @@ project(':datastream-client') {
   dependencies {
     // compile project(path: ':datastream-common', configuration: 'restClient')
     compile "com.linkedin.pegasus:restli-client:$pegasusVersion"
+    compile "com.linkedin.pegasus:r2-netty:$pegasusVersion"
     compile "com.google.guava:guava:$guavaVersion"
     compile "com.codahale.metrics:metrics-core:$metricsVersion"
     compile "org.apache.kafka:kafka_2.10:$kafkaVersion"
@@ -125,6 +126,7 @@ project(':datastream-client') {
     compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
 
+    testCompile project(':datastream-server')
     compile project(':datastream-common')
   }
 }

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
@@ -1,6 +1,21 @@
 package com.linkedin.datastream;
 
+import java.util.Collections;
+
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamBuilders;
+import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.DatastreamNotFoundException;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.r2.transport.common.Client;
+import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
+import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.restli.client.CreateRequest;
+import com.linkedin.restli.client.GetRequest;
+import com.linkedin.restli.client.Response;
+import com.linkedin.restli.client.ResponseFuture;
+import com.linkedin.restli.client.RestClient;
+import com.linkedin.restli.common.HttpStatus;
 
 
 /**
@@ -8,8 +23,65 @@ import com.linkedin.datastream.common.Datastream;
  */
 public class DatastreamRestClient {
 
-  public Datastream getDatastream(String datastreamName) {
-    return null;
+  private final DatastreamBuilders _builders;
+  private final RestClient _restClient;
+
+  public DatastreamRestClient(String dsmUri){
+    _builders = new DatastreamBuilders();
+
+    final HttpClientFactory http = new HttpClientFactory();
+    final Client r2Client = new TransportClientAdapter(
+        http.getClient(Collections.<String, String>emptyMap()));
+    _restClient = new RestClient(r2Client, dsmUri);
   }
 
+  /**
+   * Get the complete datastream object corresponding to the datastream name. This method makes a GET rest call
+   * to the Datastream management service which inturn fetches this Datastream object from the store (zookeeper).
+   * @param datastreamName
+   *    Name of the datastream that should be retrieved.
+   * @return
+   *    Datastream object corresponding to the datastream. This method will not return null.
+   * @throws DatastreamException
+   *    Throws DatastreamNotFoundException if the datastream doesn't exist,
+   *    Throws DatastreamException for any other errors encountered while fetching the document schema.
+   * @throws com.linkedin.r2.RemoteInvocationException
+   *    If there are any other network/ system level errors while sending the request or receiving the response.
+   */
+  public Datastream getDatastream(String datastreamName) throws DatastreamException, RemoteInvocationException {
+    GetRequest request = _builders.get().id(datastreamName).build();
+    ResponseFuture<Datastream> datastreamResponseFuture = _restClient.sendRequest(request);
+    Response<Datastream> response = datastreamResponseFuture.getResponse();
+
+    if(response.hasError()) {
+      if(response.getStatus() == HttpStatus.S_404_NOT_FOUND.getCode()) {
+        throw new DatastreamNotFoundException(datastreamName);
+      }
+      throw new DatastreamException(String.format("Get Datastream {%s} failed with error %s", datastreamName,
+          response.getError()));
+    }
+    return response.getEntity();
+  }
+
+  /**
+   * Creates a new datastream. Name of the datastream must be unique.
+   * @param datastream
+   *   Datastream that needs to be created.
+   * @throws DatastreamException for any errors encountered while creating the datastream.
+   * @throws com.linkedin.r2.RemoteInvocationException for any network/system level errors encountered
+   *   while sending the request or receiving the response.
+   */
+  public void createDatastream(Datastream datastream) throws DatastreamException, RemoteInvocationException {
+    CreateRequest request = _builders.create().input(datastream).build();
+    ResponseFuture<Datastream> datastreamResponseFuture = _restClient.sendRequest(request);
+    Response<Datastream> response = datastreamResponseFuture.getResponse();
+    if(response.hasError()) {
+      throw new DatastreamException(String.format("Create Datastream {%s} failed with error %s", datastream,
+          response.getError()));
+    }
+  }
+
+  public Datastream createBootstrapDatastream() {
+    return null;
+  }
 }

--- a/datastream-client/src/test/java/com/linkedin/datastream/DummyConnector.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/DummyConnector.java
@@ -1,0 +1,57 @@
+package com.linkedin.datastream;
+
+import java.util.List;
+import java.util.Properties;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.server.Connector;
+import com.linkedin.datastream.server.DatastreamContext;
+import com.linkedin.datastream.server.DatastreamEventCollectorFactory;
+import com.linkedin.datastream.server.DatastreamTarget;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.DatastreamValidationResult;
+
+
+/**
+ * A trivial implementation of connector interface
+ */
+public class DummyConnector implements Connector {
+
+  private Properties _properties;
+
+  public DummyConnector(Properties properties) throws Exception {
+    _properties = properties;
+    String dummyConfigValue = _properties.getProperty("dummyProperty", "");
+    if (!dummyConfigValue.equals("dummyValue")) {
+      throw new Exception("Invalid config value for dummyProperty. Expected: dummyValue");
+    }
+  }
+
+  @Override
+  public void start(DatastreamEventCollectorFactory factory) {
+  }
+
+  @Override
+  public void stop() {
+  }
+
+  @Override
+  public String getConnectorType() {
+    return "com.linkedin.datastream.server.connectors.DummyConnector";
+  }
+
+  @Override
+  public void onAssignmentChange(DatastreamContext context, List<DatastreamTask> tasks) {
+
+  }
+
+  @Override
+  public DatastreamTarget getDatastreamTarget(Datastream stream) {
+    return null;
+  }
+
+  @Override
+  public DatastreamValidationResult validateDatastream(Datastream stream) {
+    return null;
+  }
+}

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDsm.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDsm.java
@@ -1,0 +1,89 @@
+package com.linkedin.datastream;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.log4j.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.server.DatastreamServer;
+import com.linkedin.datastream.server.DummyDatastreamEventCollector;
+import com.linkedin.datastream.server.assignment.BroadcastStrategy;
+import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.r2.RemoteInvocationException;
+
+import junit.framework.Assert;
+
+
+@Test(singleThreaded=true)
+public class TestDsm {
+  Logger LOG = LoggerFactory.getLogger(TestDsm.class);
+  // "com.linkedin.datastream.server.DummyDatastreamEventCollector"
+  private static final String COLLECTOR_CLASS = DummyDatastreamEventCollector.class.getTypeName();
+  // "com.linkedin.datastream.server.connectors.DummyConnector"
+  private static final String DUMMY_CONNECTOR = DummyConnector.class.getTypeName();
+  // "com.linkedin.datastream.server.assignment.BroadcastStrategy"
+  private static final String BROADCAST_STRATEGY =  BroadcastStrategy.class.getTypeName();
+
+  @BeforeTest
+  public void setUp() throws Exception {
+    DatastreamServer.INSTANCE.shutDown();
+  }
+
+  @AfterTest
+  public void tearDown() throws Exception {
+    DatastreamServer.INSTANCE.shutDown();
+  }
+
+  public static Datastream generateDatastream(int seed) {
+    Datastream ds = new Datastream();
+    ds.setName("name_" + seed);
+    ds.setConnectorType("com.linkedin.datastream.server.connectors.DummyConnector");
+    ds.setSource("db_" + seed);
+    StringMap metadata = new StringMap();
+    metadata.put("owner", "person_" + seed);
+    ds.setMetadata(metadata);
+    return ds;
+  }
+
+  private void setupServer()
+      throws DatastreamException, IOException {
+    EmbeddedZookeeper embeddedZookeeper = new EmbeddedZookeeper();
+    String zkConnectionString = embeddedZookeeper.getConnection();
+    embeddedZookeeper.startup();
+
+    Properties properties = new Properties();
+    properties.put(DatastreamServer.CONFIG_CLUSTER_NAME, "testCluster");
+    properties.put(DatastreamServer.CONFIG_ZK_ADDRESS, zkConnectionString);
+    properties.put(DatastreamServer.CONFIG_EVENT_COLLECTOR_CLASS_NAME, COLLECTOR_CLASS);
+    properties.put(DatastreamServer.CONFIG_HTTP_PORT, "8080");
+    properties.put(DatastreamServer.CONFIG_CONNECTOR_CLASS_NAMES, DUMMY_CONNECTOR);
+    properties.put(DUMMY_CONNECTOR + ".assignmentStrategy", BROADCAST_STRATEGY);
+    properties.put(DUMMY_CONNECTOR + ".dummyProperty", "dummyValue"); // DummyConnector will verify this value being correctly set
+
+    DatastreamServer server = DatastreamServer.INSTANCE;
+    server.init(properties);
+  }
+
+  @Test
+  public void testCreateDatastream()
+      throws DatastreamException, IOException, RemoteInvocationException {
+    setupServer();
+    org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
+    Datastream datastream = generateDatastream(1);
+    LOG.info("Datastream : " + datastream);
+    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
+    restClient.createDatastream(datastream);
+    Datastream createdDatastream = restClient.getDatastream(datastream.getName());
+    LOG.info("Created Datastream : " + createdDatastream);
+    Assert.assertEquals(createdDatastream, datastream);
+  }
+
+}

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamNotFoundException.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamNotFoundException.java
@@ -1,0 +1,10 @@
+package com.linkedin.datastream.common;
+
+/**
+ * Exception when the datastream is not found.
+ */
+public class DatastreamNotFoundException extends DatastreamException {
+  public DatastreamNotFoundException(String datastreamName) {
+    super(String.format("Datastream %s is not found", datastreamName));
+  }
+}


### PR DESCRIPTION
Contains the implementation for createDatastream and getDatastream restClient APIs. Also added happy path test cases which sets up the server and creates a datastream and gets the datastream and compares them. 

Still needs to be done: 
- Negative test cases
- Right now Dummyconnector is present in two different places (datastream-server test code and datastream-client test code) We need to do bit of refactoring to remove this duplication. 
