### PR TITLE
Renaming the TestDsm to TestDatastreamRestClient 

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/DummyConnector.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/DummyConnector.java
@@ -52,6 +52,6 @@ public class DummyConnector implements Connector {
 
   @Override
   public DatastreamValidationResult validateDatastream(Datastream stream) {
-    return null;
+    return new DatastreamValidationResult();
   }
 }

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -23,8 +23,8 @@ import junit.framework.Assert;
 
 
 @Test(singleThreaded=true)
-public class TestDsm {
-  Logger LOG = LoggerFactory.getLogger(TestDsm.class);
+public class TestDatastreamRestClient {
+  Logger LOG = LoggerFactory.getLogger(TestDatastreamRestClient.class);
   // "com.linkedin.datastream.server.DummyDatastreamEventCollector"
   private static final String COLLECTOR_CLASS = DummyDatastreamEventCollector.class.getTypeName();
   // "com.linkedin.datastream.server.connectors.DummyConnector"


### PR DESCRIPTION
- Rename the TestDsm to TestDatastreamRestClient
- Fixing validateDatastream to not return null
