### PR TITLE
Coordinator event loop

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -10,12 +10,14 @@ public class CoordinatorConfig {
   private final int _zkSessionTimeout;
   private final int _zkConnectionTimeout;
   private final VerifiableProperties _config;
+  private final int _retryIntervalMS;
 
   private static final String PREFIX = "datastream.server.coordinator.";
   public static final String CONFIG_CLUSTER = PREFIX + "cluster";
   public static final String CONFIG_ZK_ADDRESS = PREFIX + "zkAddress";
   public static final String CONFIG_ZK_SESSION_TIMEOUT = PREFIX + "zkSessionTimeout";
   public static final String CONFIG_ZK_CONNECTION_TIMEOUT = PREFIX + "zkConnectionTimeout";
+  public static final String CONFIG_RETRY_INTERVAL = PREFIX + "retryIntervalMS";
 
   public CoordinatorConfig(VerifiableProperties properties) {
     _config = properties;
@@ -23,6 +25,8 @@ public class CoordinatorConfig {
     _zkAddress = properties.getString(CONFIG_ZK_ADDRESS);
     _zkSessionTimeout = properties.getInt(CONFIG_ZK_SESSION_TIMEOUT, ZkClient.DEFAULT_SESSION_TIMEOUT);
     _zkConnectionTimeout = properties.getInt(CONFIG_ZK_CONNECTION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
+    _retryIntervalMS = properties.getInt(CONFIG_RETRY_INTERVAL, 1000 /* 1 second */);
+
   }
 
   public VerifiableProperties getConfigProperties() {
@@ -43,5 +47,9 @@ public class CoordinatorConfig {
 
   public final int getZkConnectionTimeout() {
     return _zkConnectionTimeout;
+  }
+
+  public final int getRetryIntervalMS() {
+    return _retryIntervalMS;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -1,0 +1,40 @@
+package com.linkedin.datastream.server;
+
+import java.util.Map;
+import java.util.HashMap;
+
+public class CoordinatorEvent {
+
+  public enum EventName {
+    LEADER_DO_ASSIGNMENT,
+    HANDLE_ASSIGNMENT_CHANGE
+  }
+
+  private final EventName _eventName;
+  private final Map<String, Object> _eventAttributeMap;
+
+  public CoordinatorEvent(EventName eventName) {
+    _eventName = eventName;
+    _eventAttributeMap = new HashMap<>();
+  }
+
+  public EventName getName() {
+    return _eventName;
+  }
+
+  @Override
+  public String toString() {
+    StringBuilder sb = new StringBuilder();
+    sb.append("name:" + _eventName.toString());
+
+    if (_eventAttributeMap.size() > 0) {
+      sb.append("\n");
+    }
+
+    for(String key : _eventAttributeMap.keySet()) {
+      sb.append(key).append(":").append(_eventAttributeMap.get(key)).append("\n");
+    }
+    return sb.toString();
+  }
+
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -1,0 +1,73 @@
+package com.linkedin.datastream.server;
+
+import java.util.Map;
+import java.util.EnumMap;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.Queue;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class CoordinatorEventBlockingQueue {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CoordinatorEventBlockingQueue.class.getName());
+  private final Map<CoordinatorEvent.EventName, CoordinatorEvent> _eventMap;
+  private final Queue<CoordinatorEvent> _eventQueue;
+
+  public CoordinatorEventBlockingQueue() {
+    _eventMap = new EnumMap<>(CoordinatorEvent.EventName.class);
+    _eventQueue = new LinkedBlockingQueue<>();
+  }
+
+  /**
+  * Add a single event to the queue, overwriting events with the same name
+  * @param event CoordinatorEvent event to add to the queue
+  */
+  public synchronized void put(CoordinatorEvent event) {
+    if (!_eventMap.containsKey(event.getName())) {
+      // only insert if there isn't an event present in the queue with the same name
+      boolean result = _eventQueue.offer(event);
+      if (!result) {
+        return;
+      }
+    }
+
+    // always overwrite the event in the map
+    _eventMap.put(event.getName(), event);
+    LOG.debug("Putting event " + event.getName());
+    LOG.debug("Event queue size " + _eventQueue.size());
+    notify();
+  }
+
+  public synchronized CoordinatorEvent take() throws InterruptedException {
+    while(_eventQueue.isEmpty()) {
+      wait();
+    }
+
+    CoordinatorEvent queuedEvent = _eventQueue.poll();
+
+    if (queuedEvent != null) {
+      LOG.debug("Taking event " + queuedEvent.getName());
+      LOG.debug("Event queue size: " + _eventQueue.size());
+      return _eventMap.remove(queuedEvent.getName());
+    }
+
+    return null;    
+  }
+
+  public synchronized CoordinatorEvent peek() {
+    CoordinatorEvent queuedEvent = _eventQueue.peek();
+    if (queuedEvent != null) {
+      return _eventMap.get(queuedEvent.getName());
+    }
+    return null;
+  }
+
+  public int size() {
+    return _eventQueue.size();
+  }
+
+  public boolean isEmpty() {
+    return _eventQueue.isEmpty();
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContext.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContext.java
@@ -4,6 +4,9 @@ import com.linkedin.datastream.server.DatastreamTask;
 
 
 public interface DatastreamContext {
+  // obtain the instance name
+  String getInstanceName();
+
   // obtain the last known persisted DatastreamState. The Connector
   // implementation can use this method to obtain the last know
   // checkpoint.
@@ -12,4 +15,6 @@ public interface DatastreamContext {
   // persiste the datastreamstate. The Connector implementation can
   // use this method to persist the last known checkpoint in zookeeper
   void saveState(DatastreamTask datastream, String key, String value);
+
+
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContextImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContextImpl.java
@@ -20,4 +20,9 @@ public class DatastreamContextImpl implements DatastreamContext {
   public void saveState(DatastreamTask datastreamTask, String key, String value) {
     _adapter.setDatastreamTaskStateForKey(datastreamTask, key, value);
   }
+
+  @Override
+  public String getInstanceName() {
+    return _adapter.getInstanceName();
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -146,4 +146,10 @@ public class DatastreamTask {
   public int hashCode() {
     return Objects.hash(_connectorType, _id, _datastreamName, _datastream, _properties);
   }
+
+  @Override
+  public String toString() {
+    // toString() is mainly for loggign purpose, feel free to modify the content/format
+    return String.format("%s(%s)", this.getDatastreamTaskName(), this._connectorType);
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkClient.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkClient.java
@@ -168,7 +168,7 @@ public class ZkClient extends org.I0Itec.zkclient.ZkClient {
     String content = super.readData(path, false);
 
     long totalWait = 0;
-    long nextWait = 0;
+    long nextWait;
 
     while (content == null && totalWait < timeout) {
       counter++;


### PR DESCRIPTION
This changeset contains the following changes:
- Add an event loop to coordinator. The goal of the event loop is to (1) serialize the event ordering so it is easier to reason the activity from the log, (2) easily reduce duplicate operations and (3) easily do retry, incremental retry, and cancel retry when necessary. See DDSDBUS-6338 for details.
- Hook up the failure retry for task assignment to the event loop.  
