### PR TITLE
hook up new datastream event

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -7,15 +7,28 @@ public class CoordinatorEvent {
 
   public enum EventName {
     LEADER_DO_ASSIGNMENT,
-    HANDLE_ASSIGNMENT_CHANGE
+    HANDLE_ASSIGNMENT_CHANGE,
+    HANDLE_NEW_DATASTREAM
   }
 
   private final EventName _eventName;
   private final Map<String, Object> _eventAttributeMap;
 
-  public CoordinatorEvent(EventName eventName) {
+  private CoordinatorEvent(EventName eventName) {
     _eventName = eventName;
     _eventAttributeMap = new HashMap<>();
+  }
+
+  public static CoordinatorEvent createLeaderDoAssignmentEvent() {
+    return new CoordinatorEvent(EventName.LEADER_DO_ASSIGNMENT);
+  }
+
+  public static CoordinatorEvent createHandleAssignmentChangeEvent() {
+    return new CoordinatorEvent(EventName.HANDLE_ASSIGNMENT_CHANGE);
+  }
+
+  public static CoordinatorEvent createHandleNewDatastreamEvent() {
+    return new CoordinatorEvent(EventName.HANDLE_NEW_DATASTREAM);
   }
 
   public EventName getName() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -90,7 +90,7 @@ public enum DatastreamServer {
         _bootstrapConnectors.put(connectorStr, bootstrapConnector);
       }
 
-      // Read the assignment startegy from the config; if not found, use default strategy
+      // Read the assignment strategy from the config; if not found, use default strategy
       AssignmentStrategy assignmentStrategyInstance;
       String strategy = connectorProperties.getProperty(CONFIG_CONNECTOR_ASSIGNMENT_STRATEGY, "");
       if (!strategy.isEmpty()) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -16,6 +16,7 @@ import java.util.Set;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamJSonUtil;
 import com.linkedin.datastream.server.DatastreamTask;
+import org.I0Itec.zkclient.DataUpdater;
 import org.I0Itec.zkclient.IZkChildListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -354,6 +355,18 @@ public class ZkAdapter {
     }
 
     return result;
+  }
+
+  public boolean updateDatastream(Datastream datastream) {
+    String path = KeyBuilder.datastream(_cluster, datastream.getName());
+    if (!_zkclient.exists(path)) {
+      LOG.warn("trying to update znode of datastream that does not exist. Datastream name: " + datastream.getName());
+      return false;
+    }
+
+    String data = DatastreamJSonUtil.getJSonStringFromDatastream(datastream);
+    _zkclient.updateDataSerialized(path, old -> data);
+    return true;
   }
 
   public List<String> getLiveInstances() {


### PR DESCRIPTION
When a new datastream is created by DSM, the coordinator will consult with the corresponding connector by calling Connector.getDatastreamTarget() to obtain the target. The coordinator would then persist the target information back to the DSM znode.

Also, a datastream is only assignable when the target information is persisted. That is, if a datastream is created but the connector respond with null target, it means the connector does not know where the event would be send to, so the coordinator should not assign these datastreams with null target to connectors. This is to make sure that the connector would not send messages to message collector that does not have a downstream topic. Test coverage is included.

The logic to create the target topic is not included. We will wait for the right abstraction of the transportation layer. 
