### PR TITLE
Fix gradle idea task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,16 +2,6 @@ apply from: file('gradle/license.gradle')
 apply from: file('gradle/environment.gradle')
 apply from: file("gradle/dependency-versions.gradle")
 
-apply plugin: 'eclipse'
-apply plugin: 'idea'
-
-idea {
-  project {
-    jdkName = '1.8'
-    languageLevel = '1.8'
-  }
-}
-
 buildscript {
   repositories {
     mavenCentral()
@@ -22,7 +12,16 @@ buildscript {
 allprojects {
   group = "com.github.datastream"
 
+  apply plugin: 'eclipse'
+  apply plugin: 'idea'
   apply plugin: 'project-report'
+
+  idea {
+    project {
+      jdkName = '1.8'
+      languageLevel = '1.8'
+    }
+  }
 
   repositories {
     mavenCentral()
@@ -32,7 +31,6 @@ allprojects {
 
 subprojects {
   apply plugin: 'java'
-  
   // apply plugin: 'pegasus'
 
     // spec = [


### PR DESCRIPTION
This reverts commit 3537f79526160ba81a69f038255168c774d3f00a.

The above commit causes idea task to fail to generate Intellij IDE
files. Since this is the only thing the change does, we revert the
change as a whole.
