### PR TITLE
create connector znodes when instance starts

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -119,8 +119,10 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
   public void start() {
     _eventThread.start();
     _adapter.connect();
-    _strategies.forEach((connector, strategy) -> connector.start(_eventCollectorFactory));
-
+    _strategies.forEach((connector, strategy) -> {
+      _adapter.ensureConnectorZNode(connector.getConnectorType());
+      connector.start(_eventCollectorFactory);
+    });
   }
 
   public void stop() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -420,7 +420,7 @@ public class ZkAdapter {
 
     // get the old assignment from zookeeper
     Set<String> oldAssignmentNames;
-    try{
+    try {
       oldAssignmentNames = new HashSet<>(_zkclient.getChildren(KeyBuilder.instance(_cluster, instance)));
     } catch (ZkException zke) {
       // in case the instance is already cleaned up at this moment. We should not proceed
@@ -543,6 +543,11 @@ public class ZkAdapter {
     String instanceName = _hostname + "-" + _liveInstanceName;
     _zkclient.ensurePath(KeyBuilder.instance(_cluster, instanceName));
     return _hostname + "-" + _liveInstanceName;
+  }
+
+  public void ensureConnectorZNode(String connectorType) {
+    String path = KeyBuilder.connector(_cluster, connectorType);
+    _zkclient.ensurePath(path);
   }
 
   /**


### PR DESCRIPTION
The current behavior is that when we deploy a new datastream cluster, there are no children under the "connectors" tree even though there are connectors deployed. This is because we create the znode tree lazily when DSM create datastreams for these connectors. This can cause confusion when deploying a new cluster. 

This change is to create the znodes for each defined connector at the time of instance start even if there are no datastream defined. Test coverage included. 
