### PR TITLE
Bump up the zkClient version

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -11,7 +11,7 @@ ext {
     avroVersion = "1.4.0"
     guavaVersion = "15.0"
     pegasusVersion = "2.6.0"
-    zkclientVersion = "0.3"
+    zkclientVersion = "0.5"
     zookeeperVersion = "3.4.6"
     testngVersion = "6.4"
 }


### PR DESCRIPTION
ZkClientVersion 0.3 is created against the server zk 3.3.4. But we are using the zk server of 3.4.6, So bumping the zkClient version to 0.5
