### PR TITLE
Error handling for Coordinator and Connector

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -1,0 +1,140 @@
+package com.linkedin.datastream.server;
+
+import com.linkedin.datastream.common.Datastream;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+
+/**
+ * ConnectorWrapper wraps the Connector interface. It is a utility class used by the Coordinator.
+ * The Coordinator should call the Connector API methods through this wrapper, which centralize
+ * some bookkeeping features like logging and try-catch error handling.
+ */
+public class ConnectorWrapper {
+  private static final Logger LOG = LoggerFactory.getLogger(ConnectorWrapper.class.getName());
+
+  private String _instanceName;
+  private Connector _connector;
+  private String _lastError;
+
+  private long _startTime;
+  private long _endTime;
+
+  public ConnectorWrapper(Connector connector) {
+    _connector = connector;
+  }
+
+  public boolean hasError() {
+    return _lastError != null;
+  }
+
+  public String getLastError() {
+    return _lastError;
+  }
+
+  public void setInstanceName(String instanceName) {
+    _instanceName = instanceName;
+  }
+
+  private void logErrorAndException(String method, Exception ex) {
+    String msg = "Failed to call connector API: Connector::" + method;
+    LOG.error(msg, ex);
+    _lastError = msg + "\n" + ex.getMessage() + "\n" + ex.getStackTrace().toString();
+  }
+
+  private void logApiStart(String method) {
+    LOG.info(String.format("START: Connector::%s. Connector: %s, Instance: %s", method, _connector.getConnectorType(),
+        _instanceName));
+    _startTime = System.currentTimeMillis();
+    _lastError = null;
+  }
+
+  private void logApiEnd(String method) {
+    _endTime = System.currentTimeMillis();
+    LOG.info(String.format("END: Connector::%s. Connector: %s, Instance: %s, Duration: %d milliseconds", method,
+        _connector.getConnectorType(), _instanceName, _endTime - _startTime));
+  }
+
+  public void start(DatastreamEventCollectorFactory collectorFactory) {
+    logApiStart("start");
+
+    try {
+      _connector.start(collectorFactory);
+    } catch (Exception ex) {
+      logErrorAndException("start", ex);
+    }
+
+    logApiEnd("start");
+  }
+
+  public void stop() {
+    logApiStart("stop");
+
+    try {
+      _connector.stop();
+    } catch (Exception ex) {
+      logErrorAndException("stop", ex);
+    }
+
+    logApiEnd("stop");
+  }
+
+  public String getConnectorType() {
+    logApiStart("getConnectorType");
+    String ret = null;
+
+    try {
+      ret = _connector.getConnectorType();
+    } catch (Exception ex) {
+      logErrorAndException("getConnectorType", ex);
+    }
+
+    logApiEnd("getConnectorType");
+    return ret;
+  }
+
+  public void onAssignmentChange(DatastreamContext context, List<DatastreamTask> tasks) {
+    logApiStart("onAssignmentChange");
+
+    try {
+      _connector.onAssignmentChange(context, tasks);
+    } catch (Exception ex) {
+      logErrorAndException("onAssignmentChange", ex);
+    }
+
+    logApiEnd("onAssignmentChange");
+  }
+
+  public DatastreamTarget getDatastreamTarget(Datastream stream) {
+    logApiStart("getDatastreamTarget");
+
+    DatastreamTarget ret = null;
+
+    try {
+      ret = _connector.getDatastreamTarget(stream);
+    } catch (Exception ex) {
+      logErrorAndException("getDatastreamTarget", ex);
+    }
+
+    logApiEnd("getDatastreamTarget");
+
+    return ret;
+  }
+
+  public DatastreamValidationResult validateDatastream(Datastream stream) {
+    logApiStart("validateDatastream");
+    DatastreamValidationResult ret = null;
+
+    try {
+      ret = _connector.validateDatastream(stream);
+    } catch (Exception ex) {
+      logErrorAndException("alidateDatastream", ex);
+    }
+
+    logApiEnd("validateDatastream");
+
+    return ret;
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -3,12 +3,14 @@ package com.linkedin.datastream.server;
 import java.util.Map;
 import java.util.HashMap;
 
+
 public class CoordinatorEvent {
 
   public enum EventName {
     LEADER_DO_ASSIGNMENT,
     HANDLE_ASSIGNMENT_CHANGE,
-    HANDLE_NEW_DATASTREAM
+    HANDLE_NEW_DATASTREAM,
+    HANDLE_INSTANCE_ERROR
   }
 
   private final EventName _eventName;
@@ -31,8 +33,22 @@ public class CoordinatorEvent {
     return new CoordinatorEvent(EventName.HANDLE_NEW_DATASTREAM);
   }
 
+  public static CoordinatorEvent createHandleInstanceErrorEvent(String errorMessage) {
+    CoordinatorEvent event = new CoordinatorEvent(EventName.HANDLE_INSTANCE_ERROR);
+    event.setAttribute("error_message", errorMessage);
+    return event;
+  }
+
   public EventName getName() {
     return _eventName;
+  }
+
+  public Object getAttribute(String attribute) {
+    return _eventAttributeMap.get(attribute);
+  }
+
+  protected void setAttribute(String attribute, Object value) {
+    _eventAttributeMap.put(attribute, value);
   }
 
   @Override
@@ -44,7 +60,7 @@ public class CoordinatorEvent {
       sb.append("\n");
     }
 
-    for(String key : _eventAttributeMap.keySet()) {
+    for (String key : _eventAttributeMap.keySet()) {
       sb.append(key).append(":").append(_eventAttributeMap.get(key)).append("\n");
     }
     return sb.toString();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContext.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContext.java
@@ -16,5 +16,9 @@ public interface DatastreamContext {
   // use this method to persist the last known checkpoint in zookeeper
   void saveState(DatastreamTask datastream, String key, String value);
 
+  // set the status for datastreamtask. This is a way for the connector
+  // implementation to persist the status of the datastream task
+  void setStatus(DatastreamTask datastreamTask, DatastreamTaskStatus status);
 
+  DatastreamTaskStatus getStatus(DatastreamTask datastreamTask);
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContextImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamContextImpl.java
@@ -5,6 +5,8 @@ import com.linkedin.datastream.server.zk.ZkAdapter;
 
 public class DatastreamContextImpl implements DatastreamContext {
 
+  private static final String STATUS = "STATUS";
+
   private ZkAdapter _adapter;
 
   public DatastreamContextImpl(ZkAdapter adapter) {
@@ -24,5 +26,16 @@ public class DatastreamContextImpl implements DatastreamContext {
   @Override
   public String getInstanceName() {
     return _adapter.getInstanceName();
+  }
+
+  @Override
+  public void setStatus(DatastreamTask datastreamTask, DatastreamTaskStatus status) {
+    saveState(datastreamTask, STATUS, status.toString());
+  }
+
+  @Override
+  public DatastreamTaskStatus getStatus(DatastreamTask datastreamTask) {
+    String statusStr = this.getState(datastreamTask, STATUS);
+    return DatastreamTaskStatus.valueOf(statusStr);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskStatus.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskStatus.java
@@ -1,0 +1,14 @@
+package com.linkedin.datastream.server;
+
+public enum DatastreamTaskStatus {
+  OK,
+  ERROR;
+
+  public static boolean isOK(DatastreamTaskStatus status) {
+    return OK == status;
+  }
+
+  public static boolean isFailure(DatastreamTaskStatus status) {
+    return ERROR == status;
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -6,10 +6,11 @@ public class KeyBuilder {
   private static final String _liveInstance = "/%s/liveinstances/%s";
   private static final String _instances = "/%s/instances";
   private static final String _instance = "/%s/instances/%s";
-  private static final String _instanceTask = "/%s/instances/%s/%s";
+  private static final String _instanceAssignments = "/%s/instances/%s/assignments";
+  private static final String _instanceErrors = "/%s/instances/%s/errors";
+  private static final String _instanceAssignment = "/%s/instances/%s/assignments/%s";
   private static final String _datastreams = "/%s/dms";
   private static final String _datastream = "/%s/dms/%s";
-  private static final String _datastreamTask = "/%s/instances/%s/%s";
   private static final String _connectors = "/%s/connectors";
   private static final String _connector = "/%s/connectors/%s";
   private static final String _connectorDatastreamTask = _connector +  "/%s";
@@ -37,8 +38,16 @@ public class KeyBuilder {
     return String.format(_instance, cluster, instanceName);
   }
 
-  public static String instanceTask(String cluster, String instance, String task) {
-    return String.format(_instanceTask, cluster, instance, task);
+  public static String instanceAssignments(String cluster, String instance) {
+    return String.format(_instanceAssignments, cluster, instance);
+  }
+
+  public static String instanceErrors(String cluster, String instance) {
+    return String.format(_instanceErrors, cluster, instance);
+  }
+
+  public static String instanceAssignment(String cluster, String instance, String name) {
+    return String.format(_instanceAssignment, cluster, instance, name);
   }
 
   public static String datastreams(String cluster) {
@@ -47,10 +56,6 @@ public class KeyBuilder {
 
   public static String datastream(String cluster, String stream) {
     return String.format(_datastream, cluster, stream);
-  }
-
-  public static String datastreamTask(String cluster, String instance, String name) {
-    return String.format(_datastreamTask, cluster, instance, name);
   }
 
   public static String connector(String cluster, String connectorType) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamContextImpl.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamContextImpl.java
@@ -78,6 +78,13 @@ public class TestDatastreamContextImpl {
     Assert.assertEquals(value, "binlog.000130");
 
     //
+    // set/get status
+    //
+    context.setStatus(task1, DatastreamTaskStatus.ERROR);
+    DatastreamTaskStatus status = context.getStatus(task1);
+    Assert.assertEquals(status.compareTo(DatastreamTaskStatus.ERROR), 0);
+
+    //
     // cleanup
     //
     adapter.disconnect();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -291,7 +291,8 @@ public class TestZkAdapter {
     //
     // verify that there are 1 znode under the zookeeper /{cluster}/instances/{instance}/
     //
-    List<String> assignment = zkClient.getChildren(KeyBuilder.instance(testCluster, adapter.getInstanceName()));
+    List<String> assignment =
+        zkClient.getChildren(KeyBuilder.instanceAssignments(testCluster, adapter.getInstanceName()));
     Assert.assertEquals(assignment.size(), 1);
     Assert.assertEquals(assignment.get(0), "task1");
 
@@ -306,7 +307,7 @@ public class TestZkAdapter {
     //
     // verify that there are 2 znodes under the zookeeper path /{cluster}/instances/{instance}
     //
-    assignment = zkClient.getChildren(KeyBuilder.instance(testCluster, adapter.getInstanceName()));
+    assignment = zkClient.getChildren(KeyBuilder.instanceAssignments(testCluster, adapter.getInstanceName()));
     Collections.sort(assignment);
     Assert.assertEquals(assignment.size(), 2);
     Assert.assertEquals(assignment.get(0), "task1");
@@ -324,7 +325,7 @@ public class TestZkAdapter {
     //
     // verify that there are still 2 znodes under zookeeper path /{cluster}/instances/{instance}
     //
-    assignment = zkClient.getChildren(KeyBuilder.instance(testCluster, adapter.getInstanceName()));
+    assignment = zkClient.getChildren(KeyBuilder.instanceAssignments(testCluster, adapter.getInstanceName()));
     Assert.assertEquals(assignment.size(), 2);
     Collections.sort(assignment);
     Assert.assertEquals(assignment.get(0), "task1");
@@ -377,7 +378,8 @@ public class TestZkAdapter {
     //
     // verify there are 4 znodes under zookeeper path /{cluster}/instances/{instance}
     //
-    List<String> assignment = zkClient.getChildren(KeyBuilder.instance(testCluster, adapter.getInstanceName()));
+    List<String> assignment =
+        zkClient.getChildren(KeyBuilder.instanceAssignments(testCluster, adapter.getInstanceName()));
     Collections.sort(assignment);
     Assert.assertEquals(assignment.size(), 4);
     Assert.assertEquals(assignment.get(0), "task1_0");


### PR DESCRIPTION
# Coordinator Error Handling

The main logic of this commit is in `ConnectorWrapper.java`: this is a utility class used by the Coordinator to call the Connector API. It provides the try-catch block and logging utilities for each Connector API. It also traps the last error and allows the coordinator to persist the error in zookeeper.

Since this is the server side component and the Connector implementations are expected to be stable, we will not do retries, instead, fail fast and try to log the error so the issue can be resolved at Connector development time. To avoid unnecessary zookeeper traffic, the number of errors persisted in zookeeper for each instance is capped at 10.

The zookeeper data structure is also modified to allow the error nodes. No under each instance node /{cluster}/instances/{instanceName}/, there are two children: "assignments" and "errors". 
# Connector Error Handling

There is a different type of errors that we don't handle the coordinator. For example, for bootstrap connector, one of the datastream might get stuck with corrupted snapshot files and cannot proceed. We only want to pause this datastream, but the rest should be allowed to proceed. Instead of handling this in Coordinator, I think it is best to let the Connector handling it. That is, the coordinator is responsible for assigning the datastreamtask to connector instances, no matter if it has application level error or not. It is the connector's responsibility to save the error state and decide how to proceed. Specifically, when the connector encounter a corrupt snapshot for one datastream, this connector can save the error state using DatastreamContext.saveState(), and when it is assigned a task with bad state, it can decide skipping it.  

To make this a bit easier to use, I added `DatastreamTaskStatus` class based on feedback from @srinipunuru. It only have two status now: OR, and ERROR, as a first-class state for DatatreamTask. 
