### PR TITLE
Removing the getTarget and getConnectorType from the connector interface

### DIFF
--- a/datastream-connector/src/main/java/com/linkedin/datastream/server/Connector.java
+++ b/datastream-connector/src/main/java/com/linkedin/datastream/server/Connector.java
@@ -26,17 +26,6 @@ public interface Connector {
   void stop();
 
   /**
-   * @return the type of the connector. This type should be a globally unique string, because the Coordinator
-   * can only link to one connector instance per connector type.
-   */
-  String getConnectorType();
-
-  /**
-   * @return the datastream target
-   */
-  DatastreamTarget getDatastreamTarget(Datastream datastream);
-
-  /**
    * callback when the datastreams assignment to this instance is changed. This is called whenever
    * there is a change for the assignment. The implementation of the Connector is responsible
    * to keep a state of the previous assignment.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -16,6 +16,7 @@ import java.util.List;
  */
 public class ConnectorWrapper {
   private static final Logger LOG = LoggerFactory.getLogger(ConnectorWrapper.class.getName());
+  private final String _connectorType;
 
   private String _instanceName;
   private Connector _connector;
@@ -24,7 +25,8 @@ public class ConnectorWrapper {
   private long _startTime;
   private long _endTime;
 
-  public ConnectorWrapper(Connector connector) {
+  public ConnectorWrapper(String connectorType, Connector connector) {
+    _connectorType = connectorType;
     _connector = connector;
   }
 
@@ -47,7 +49,7 @@ public class ConnectorWrapper {
   }
 
   private void logApiStart(String method) {
-    LOG.info(String.format("START: Connector::%s. Connector: %s, Instance: %s", method, _connector.getConnectorType(),
+    LOG.info(String.format("START: Connector::%s. Connector: %s, Instance: %s", method, _connectorType,
         _instanceName));
     _startTime = System.currentTimeMillis();
     _lastError = null;
@@ -56,7 +58,7 @@ public class ConnectorWrapper {
   private void logApiEnd(String method) {
     _endTime = System.currentTimeMillis();
     LOG.info(String.format("END: Connector::%s. Connector: %s, Instance: %s, Duration: %d milliseconds", method,
-        _connector.getConnectorType(), _instanceName, _endTime - _startTime));
+        _connectorType, _instanceName, _endTime - _startTime));
   }
 
   public void start(DatastreamEventCollectorFactory collectorFactory) {
@@ -84,17 +86,7 @@ public class ConnectorWrapper {
   }
 
   public String getConnectorType() {
-    logApiStart("getConnectorType");
-    String ret = null;
-
-    try {
-      ret = _connector.getConnectorType();
-    } catch (Exception ex) {
-      logErrorAndException("getConnectorType", ex);
-    }
-
-    logApiEnd("getConnectorType");
-    return ret;
+    return _connectorType;
   }
 
   public void onAssignmentChange(List<DatastreamTask> tasks) {
@@ -107,22 +99,6 @@ public class ConnectorWrapper {
     }
 
     logApiEnd("onAssignmentChange");
-  }
-
-  public DatastreamTarget getDatastreamTarget(Datastream stream) {
-    logApiStart("getDatastreamTarget");
-
-    DatastreamTarget ret = null;
-
-    try {
-      ret = _connector.getDatastreamTarget(stream);
-    } catch (Exception ex) {
-      logErrorAndException("getDatastreamTarget", ex);
-    }
-
-    logApiEnd("getDatastreamTarget");
-
-    return ret;
   }
 
   public DatastreamValidationResult validateDatastream(Datastream stream) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -78,12 +78,6 @@ public enum DatastreamServer {
 
       Connector connectorInstance = connectorFactoryInstance.createConnector(connectorProperties);
 
-      // Verify the connector type of the connector
-      if (!connectorInstance.getConnectorType().equals(connectorStr)) {
-        throw new DatastreamException(String.format("Wrong connector type for %s, expected: %s actual: %s",
-            className, connectorStr, connectorInstance.getConnectorType()));
-      }
-
       // Read the bootstrap connector type for the connector if there is one
       String bootstrapConnector = connectorProperties.getProperty(CONFIG_CONNECTOR_BOOTSTRAP_TYPE, "");
       if (!bootstrapConnector.isEmpty()) {
@@ -103,7 +97,7 @@ public enum DatastreamServer {
       if (assignmentStrategyInstance == null) {
         assignmentStrategyInstance = new SimpleStrategy();
       }
-      _coordinator.addConnector(connectorInstance, assignmentStrategyInstance);
+      _coordinator.addConnector(connectorStr, connectorInstance, assignmentStrategyInstance);
 
     } catch (Exception ex) {
       LOG.error(String.format("Instantiating connector %s failed with exception", connectorStr, ex));

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
@@ -1,14 +1,13 @@
 package com.linkedin.datastream.connectors;
 
+import java.util.List;
+import java.util.Properties;
+
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.server.Connector;
 import com.linkedin.datastream.server.DatastreamEventCollectorFactory;
-import com.linkedin.datastream.common.DatastreamTarget;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamValidationResult;
-
-import java.util.List;
-import java.util.Properties;
 
 
 /**
@@ -33,18 +32,8 @@ public class DummyBootstrapConnector implements Connector {
   }
 
   @Override
-  public String getConnectorType() {
-    return CONNECTOR_TYPE;
-  }
-
-  @Override
   public void onAssignmentChange(List<DatastreamTask> tasks) {
 
-  }
-
-  @Override
-  public DatastreamTarget getDatastreamTarget(Datastream stream) {
-    return null;
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
@@ -1,14 +1,13 @@
 package com.linkedin.datastream.connectors;
 
+import java.util.List;
+import java.util.Properties;
+
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.server.Connector;
 import com.linkedin.datastream.server.DatastreamEventCollectorFactory;
-import com.linkedin.datastream.common.DatastreamTarget;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamValidationResult;
-
-import java.util.List;
-import java.util.Properties;
 
 
 /**
@@ -38,18 +37,8 @@ public class DummyConnector implements Connector {
   }
 
   @Override
-  public String getConnectorType() {
-    return CONNECTOR_TYPE;
-  }
-
-  @Override
   public void onAssignmentChange(List<DatastreamTask> tasks) {
 
-  }
-
-  @Override
-  public DatastreamTarget getDatastreamTarget(Datastream stream) {
-    return null;
   }
 
   @Override


### PR DESCRIPTION
- Based on the new design of datastream using the transport provider. Connector will be agnostic to the transport, So connector will not be able to populate the target. Hence removing the getDatastreamTarget connector API from the interface
- getConnectorType() API doesn't have any particular use case. Because this information comes to the coordinator from the configuration. Removing this API from the interface too.
