### PR TITLE
Adding getDatastreamSource and getDatastreamDestination to the DatastreamTask interface

### DIFF
--- a/datastream-connector/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-connector/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -1,6 +1,7 @@
 package com.linkedin.datastream.server;
 
-import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamDestination;
+import com.linkedin.datastream.common.DatastreamSource;
 
 
 public interface DatastreamTask {
@@ -51,4 +52,14 @@ public interface DatastreamTask {
    * @return the name of the datastream task.
    */
   String getDatastreamTaskName();
+
+  /**
+   * @return the Datastream source.
+   */
+  DatastreamSource getDatastreamSource();
+
+  /**
+   * @return the Datastream destination.
+   */
+  DatastreamDestination getDatastreamDestination();
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -1,6 +1,8 @@
 package com.linkedin.datastream.server;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamDestination;
+import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 
 import org.apache.commons.lang.Validate;
@@ -95,6 +97,18 @@ public class DatastreamTaskImpl implements DatastreamTask {
   @JsonIgnore
   public String getDatastreamTaskName() {
     return _id.equals("") ? _datastreamName : _datastreamName + "_" + _id;
+  }
+
+  @JsonIgnore
+  @Override
+  public DatastreamSource getDatastreamSource() {
+    return _datastream.getSource();
+  }
+
+  @JsonIgnore
+  @Override
+  public DatastreamDestination getDatastreamDestination() {
+    return _datastream.getDestination();
   }
 
   public void setDatastream(Datastream datastream) {


### PR DESCRIPTION
DatastreamTask represents event producing task that produces events from a source to the destination. Right now this interface doesn't expose source and destination. Adding those methods so that connector can use the getSource to read events from the source. EventProducer can use getDestination to produce events to the destination.
