### PR TITLE
Revise the constructor of eventProducerImpl

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -16,9 +16,9 @@ import java.util.stream.Collectors;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
-import com.linkedin.datastream.common.DatastreamTarget;
-import com.linkedin.datastream.common.KafkaConnection;
 import com.linkedin.datastream.common.ReflectionUtils;
+import com.linkedin.datastream.server.providers.CheckpointProvider;
+import com.linkedin.datastream.server.providers.ZookeeperCheckpointProvider;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 
 import org.slf4j.Logger;
@@ -142,7 +142,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
     }
 
     _destinationManager = new DestinationManager(_transportProvider);
-    _eventProducerPool = new DatastreamEventProducerPool();
+
+    CheckpointProvider cpProvider = new ZookeeperCheckpointProvider(_adapter);
+    _eventProducerPool = new DatastreamEventProducerPool(cpProvider, factory, config.getConfigProperties());
   }
 
   public void start() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerPool.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerPool.java
@@ -1,10 +1,29 @@
 package com.linkedin.datastream.server;
 
+import com.linkedin.datastream.server.providers.CheckpointProvider;
+import org.apache.commons.lang.Validate;
+
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 public class DatastreamEventProducerPool {
+  private final CheckpointProvider _checkpointProvider;
+  private final TransportProviderFactory _transportProviderFactory;
+  private final Properties _globalConfig;
+
+  public DatastreamEventProducerPool(CheckpointProvider checkpointProvider,
+                                     TransportProviderFactory transportProviderFactory,
+                                     Properties globalConfig) {
+    Validate.notNull(checkpointProvider, "null checkpoint provider");
+    Validate.notNull(transportProviderFactory, "null transport provider factory");
+    Validate.notNull(globalConfig, "null config");
+
+    _checkpointProvider = checkpointProvider;
+    _transportProviderFactory = transportProviderFactory;
+    _globalConfig = globalConfig;
+  }
 
   public synchronized Map<DatastreamTask, DatastreamEventProducer> getEventProducers(List<DatastreamTask> tasks) {
     Map<DatastreamTask, DatastreamEventProducer> producerMap = new HashMap<>();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamEventProducer.java
@@ -5,7 +5,6 @@ import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamEvent;
 import com.linkedin.datastream.common.DatastreamSource;
-import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.server.providers.CheckpointProvider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -98,11 +97,11 @@ public class TestDatastreamEventProducer {
 
     // Checkpoint every 50ms
     Properties config = new Properties();
-    config.put(DatastreamEventProducerImpl.CHECKPOINT_PERIOD_MS, "50");
-    VerifiableProperties producerConfig = new VerifiableProperties(config);
+    String key = DatastreamEventProducerImpl.CONFIG_PRODUCER + "." +
+                 DatastreamEventProducerImpl.CHECKPOINT_PERIOD_MS;
+    config.put(key, "50");
 
-    DatastreamEventProducer producer = new DatastreamEventProducerImpl(tasks, transport,
-      cpProvider, DatastreamEventProducer.CheckpointPolicy.DATASTREAM, producerConfig);
+    DatastreamEventProducer producer = new DatastreamEventProducerImpl(tasks, transport, cpProvider, config);
 
     // No checkpoints for brand new tasks
     Assert.assertEquals(producer.getSafeCheckpoints().size(), 0);
@@ -141,8 +140,7 @@ public class TestDatastreamEventProducer {
     producer.shutdown();
 
     // Create a new producer
-    producer = new DatastreamEventProducerImpl(tasks, transport,
-            cpProvider, DatastreamEventProducer.CheckpointPolicy.DATASTREAM, producerConfig);
+    producer = new DatastreamEventProducerImpl(tasks, transport, cpProvider, config);
 
     // Expect saved checkpoint to match that of the last event
     Map<DatastreamTask, String> checkpointsNew = producer.getSafeCheckpoints();


### PR DESCRIPTION
Dropping the policy argument and always perform checkpoint for now
until we figure out the best solution. In addition, Coordinator is
now instantiating the checkpointProvider and pass it down to the
producer pool to be used to constructing eventProducer.
