### PR TITLE
Removing Datastream field from DatastreamEvent

### DIFF
--- a/datastream-common/src/main/avro/com/linkedin/datastream/common/DatastreamEvent.avsc
+++ b/datastream-common/src/main/avro/com/linkedin/datastream/common/DatastreamEvent.avsc
@@ -6,11 +6,6 @@
     "type": "record",
     "fields": [
         {
-            "name": "datastream",
-            "doc": "Name of the datastream that this event is generated for.",
-            "type": "string"
-        },
-        {
             "name": "metadata",
             "doc": "Event metadata.",
             "type": {

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamEvent.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamEvent.java
@@ -6,65 +6,36 @@
 package com.linkedin.datastream.common;
 
 @SuppressWarnings("all")
-public class DatastreamEvent extends org.apache.avro.specific.SpecificRecordBase implements
-    org.apache.avro.specific.SpecificRecord {
-  public static final org.apache.avro.Schema SCHEMA$ =
-      org.apache.avro.Schema
-          .parse("{\"type\":\"record\",\"name\":\"DatastreamEvent\",\"namespace\":\"com.linkedin.datastream.common\",\"fields\":[{\"name\":\"datastream\",\"type\":\"string\",\"doc\":\"Name of the datastream that this event is generated for.\"},{\"name\":\"metadata\",\"type\":{\"type\":\"map\",\"values\":\"string\"},\"doc\":\"Event metadata.\"},{\"name\":\"key\",\"type\":\"bytes\",\"doc\":\"serialized key.\"},{\"name\":\"payload\",\"type\":\"bytes\",\"doc\":\"serialized payload data.\"},{\"name\":\"previous_payload\",\"type\":\"bytes\",\"doc\":\"serialized previous payload data.\"}]}");
-  /** Name of the datastream that this event is generated for. */
-  public java.lang.CharSequence datastream;
+public class DatastreamEvent extends org.apache.avro.specific.SpecificRecordBase implements org.apache.avro.specific.SpecificRecord {
+  public static final org.apache.avro.Schema SCHEMA$ = org.apache.avro.Schema.parse("{\"type\":\"record\",\"name\":\"DatastreamEvent\",\"namespace\":\"com.linkedin.datastream.common\",\"fields\":[{\"name\":\"metadata\",\"type\":{\"type\":\"map\",\"values\":\"string\"},\"doc\":\"Event metadata.\"},{\"name\":\"key\",\"type\":\"bytes\",\"doc\":\"serialized key.\"},{\"name\":\"payload\",\"type\":\"bytes\",\"doc\":\"serialized payload data.\"},{\"name\":\"previous_payload\",\"type\":\"bytes\",\"doc\":\"serialized previous payload data.\"}]}");
   /** Event metadata. */
-  public java.util.Map<java.lang.CharSequence, java.lang.CharSequence> metadata;
+  public java.util.Map<java.lang.CharSequence,java.lang.CharSequence> metadata;
   /** serialized key. */
   public java.nio.ByteBuffer key;
   /** serialized payload data. */
   public java.nio.ByteBuffer payload;
   /** serialized previous payload data. */
   public java.nio.ByteBuffer previous_payload;
-
-  public org.apache.avro.Schema getSchema() {
-    return SCHEMA$;
-  }
-
+  public org.apache.avro.Schema getSchema() { return SCHEMA$; }
   // Used by DatumWriter.  Applications should not call. 
   public java.lang.Object get(int field$) {
     switch (field$) {
-      case 0:
-        return datastream;
-      case 1:
-        return metadata;
-      case 2:
-        return key;
-      case 3:
-        return payload;
-      case 4:
-        return previous_payload;
-      default:
-        throw new org.apache.avro.AvroRuntimeException("Bad index");
+    case 0: return metadata;
+    case 1: return key;
+    case 2: return payload;
+    case 3: return previous_payload;
+    default: throw new org.apache.avro.AvroRuntimeException("Bad index");
     }
   }
-
   // Used by DatumReader.  Applications should not call. 
-  @SuppressWarnings(value = "unchecked")
+  @SuppressWarnings(value="unchecked")
   public void put(int field$, java.lang.Object value$) {
     switch (field$) {
-      case 0:
-        datastream = (java.lang.CharSequence) value$;
-        break;
-      case 1:
-        metadata = (java.util.Map<java.lang.CharSequence, java.lang.CharSequence>) value$;
-        break;
-      case 2:
-        key = (java.nio.ByteBuffer) value$;
-        break;
-      case 3:
-        payload = (java.nio.ByteBuffer) value$;
-        break;
-      case 4:
-        previous_payload = (java.nio.ByteBuffer) value$;
-        break;
-      default:
-        throw new org.apache.avro.AvroRuntimeException("Bad index");
+    case 0: metadata = (java.util.Map<java.lang.CharSequence,java.lang.CharSequence>)value$; break;
+    case 1: key = (java.nio.ByteBuffer)value$; break;
+    case 2: payload = (java.nio.ByteBuffer)value$; break;
+    case 3: previous_payload = (java.nio.ByteBuffer)value$; break;
+    default: throw new org.apache.avro.AvroRuntimeException("Bad index");
     }
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamEventProducer.java
@@ -83,7 +83,6 @@ public class TestDatastreamEventProducer {
 
   private DatastreamEventRecord createEventRecord(Datastream datastream, DatastreamTask task, Integer partition) {
     DatastreamEvent event = new DatastreamEvent();
-    event.datastream = datastream.getName();
     event.key = ByteBuffer.allocate(1);
     event.payload = ByteBuffer.allocate(1);
     ++_eventSeed;

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/eventGenerator/DatastreamEventGenerator.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/eventGenerator/DatastreamEventGenerator.java
@@ -86,7 +86,6 @@ public class DatastreamEventGenerator extends GenericEventGenerator {
   @Override
   protected Object getNextEvent(EventType eventType, int partNum) throws UnknownTypeException, IOException {
     DatastreamEvent datastreamEvent = new DatastreamEvent();
-    datastreamEvent.datastream = _datastreamName;
     datastreamEvent.payload = getPayload();
     datastreamEvent.previous_payload = null;
     DatastreamEvent preEvent = null;


### PR DESCRIPTION
DatastreamEvent that is being created may corresponding to several datastreams due to the de-duping we do. So it doesn't make sense for the DatastreamEvent to contain the datastreamName. 
