### PR TITLE
Move getSafeCheckpoints from Producer to Task

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
@@ -1,11 +1,8 @@
 package com.linkedin.datastream.server;
 
-import java.util.Map;
-
 import org.apache.avro.Schema;
 
 import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryException;
-import com.linkedin.datastream.server.api.transport.TransportException;
 
 
 /**
@@ -21,16 +18,10 @@ import com.linkedin.datastream.server.api.transport.TransportException;
  */
 public interface DatastreamEventProducer {
   /**
-   * Policy for checkpoint handling
-   */
-  enum CheckpointPolicy { DATASTREAM, CUSTOM }
-
-  /**
    * Send event onto the transport
    * @param event
    */
-  void send(DatastreamEventRecord event)
-      throws TransportException;
+  void send(DatastreamEventRecord event);
 
   /**
    * Register the schema in schema registry. If the schema already exists in the registry
@@ -43,15 +34,8 @@ public interface DatastreamEventProducer {
       throws SchemaRegistryException;
 
   /**
-   * @return a map of safe checkpoints which are guaranteed
-   * to have been flushed onto the transport. The checkpoints
-   * are per-partition and the second level key is partition
-   * number.
+   * Flush the transport for the pending events. This can be a slow and heavy operation.
+   * As such, it is not efficient to be invoked very frequently.
    */
-  Map<DatastreamTask, Map<Integer, String>> getSafeCheckpoints();
-
-  /**
-   * Shutdown the producer and cleanup any resources.
-   */
-  void shutdown();
+  void flush();
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -4,6 +4,7 @@ import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamSource;
 
 import java.util.List;
+import java.util.Map;
 
 
 public interface DatastreamTask {
@@ -69,4 +70,11 @@ public interface DatastreamTask {
    * @return the list of partitions this task covers.
    */
   List<Integer> getPartitions();
+
+  /**
+   * @return a map of safe checkpoints which are guaranteed
+   * to have been flushed onto the transport. Key is partition
+   * number, and value is the safe checkpoint for it.
+   */
+  Map<Integer, String> getCheckpoints();
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -141,6 +141,16 @@ public class DatastreamTaskImpl implements DatastreamTask {
     return _partitions;
   }
 
+  @JsonIgnore
+  @Override
+  public Map<Integer, String> getCheckpoints() {
+    // There is only one implementation of EventProducer so it's safe to cast
+    DatastreamEventProducerImpl impl = (DatastreamEventProducerImpl)_eventProducer;
+    // Checkpoint map of the owning task must be present in the producer
+    Validate.isTrue(impl.getSafeCheckpoints().containsKey(this), "null checkpoints for task: " + this);
+    return ((DatastreamEventProducerImpl)_eventProducer).getSafeCheckpoints().get(this);
+  }
+
   public void setDatastream(Datastream datastream) {
     _datastream = datastream;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
@@ -105,7 +105,8 @@ public class EventProducerPool {
     for (String destination : unusedProducers.keySet()) {
       producersForConnectorType.remove(destination);
     }
-    // TODO: Call producer shutdown once event producer interface is ready
+
+    unusedProducers.values().forEach((producer) -> ((DatastreamEventProducerImpl)producer).shutdown());
     unusedProducers.clear();
 
     return taskProducerMapping;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamEventProducer.java
@@ -8,6 +8,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
 
+import com.linkedin.datastream.common.DatastreamException;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.codehaus.jackson.type.TypeReference;
@@ -128,7 +129,7 @@ public class TestDatastreamEventProducer {
 
   @Test
   public void testSendWithCustomCheckpoint()
-      throws TransportException, InterruptedException {
+      throws DatastreamException, TransportException, InterruptedException {
     setup(true);
     DatastreamTask task;
     Integer partition;
@@ -170,7 +171,7 @@ public class TestDatastreamEventProducer {
 
   @Test
   public void testSendWithDatastreamCheckpoint()
-      throws InterruptedException, TransportException {
+      throws DatastreamException, InterruptedException, TransportException {
 
     setup(false);
 


### PR DESCRIPTION
Each event producer serves multiple datastream tasks that share
the same destination and is accessible to connectors with the
DatastreamTask.getEventProducer() interface. Whenever connector
calls task.getEventProducer().getSafeCheckpoints, it is only
interested in the checkpoints pertaining to the current task.
As such, returning a task -> checkpoints map isn't sensible.

We can think checkpoints as a property of a task given they
are persisted under the task node. So a natural change would
be exposing the safe checkpoints via the task interface.

This change does exactly this.
