### PR TITLE
BroadcastStrategy creates a new datastream task everytime it is called

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -1,10 +1,10 @@
 package com.linkedin.datastream.server;
 
-import com.linkedin.datastream.common.DatastreamDestination;
-import com.linkedin.datastream.common.DatastreamSource;
-
 import java.util.List;
 import java.util.Map;
+
+import com.linkedin.datastream.common.DatastreamDestination;
+import com.linkedin.datastream.common.DatastreamSource;
 
 
 public interface DatastreamTask {
@@ -77,4 +77,9 @@ public interface DatastreamTask {
    * number, and value is the safe checkpoint for it.
    */
   Map<Integer, String> getCheckpoints();
+
+  /**
+   * @return the list of datastream names for which this task is producing events for.
+   */
+  List<String> getDatastreams();
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentStrategy.java
@@ -2,6 +2,7 @@ package com.linkedin.datastream.server;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import com.linkedin.datastream.common.Datastream;
 
@@ -28,6 +29,6 @@ public interface AssignmentStrategy {
    * @param currentAssignment existing assignment
    * @return
    */
-  Map<String, List<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
-      Map<String, List<DatastreamTask>> currentAssignment);
+  Map<String, Set<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
+      Map<String, Set<DatastreamTask>> currentAssignment);
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -10,6 +10,7 @@ import com.linkedin.datastream.server.api.transport.TransportProviderFactory;
 import com.linkedin.datastream.server.providers.CheckpointProvider;
 import com.linkedin.datastream.server.providers.ZookeeperCheckpointProvider;
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.Executors;
@@ -482,7 +483,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
       List<Datastream> datastreamsPerConnectorType = new ArrayList<>(streamsByConnectorType.get(connectorType).values());
 
       // Get the list of tasks per instance for the given connectortype
-      Map<String, List<DatastreamTask>> tasksByConnectorAndInstance =
+      Map<String, Set<DatastreamTask>> tasksByConnectorAndInstance =
           strategy.assign(datastreamsPerConnectorType, liveInstances, null);
 
       for(String instance: tasksByConnectorAndInstance.keySet()){

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -14,6 +14,7 @@ import org.apache.commons.lang.Validate;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import java.util.HashMap;
@@ -145,10 +146,16 @@ public class DatastreamTaskImpl implements DatastreamTask {
   @Override
   public Map<Integer, String> getCheckpoints() {
     // There is only one implementation of EventProducer so it's safe to cast
-    DatastreamEventProducerImpl impl = (DatastreamEventProducerImpl)_eventProducer;
+    DatastreamEventProducerImpl impl = (DatastreamEventProducerImpl) _eventProducer;
     // Checkpoint map of the owning task must be present in the producer
     Validate.isTrue(impl.getSafeCheckpoints().containsKey(this), "null checkpoints for task: " + this);
-    return ((DatastreamEventProducerImpl)_eventProducer).getSafeCheckpoints().get(this);
+    return ((DatastreamEventProducerImpl) _eventProducer).getSafeCheckpoints().get(this);
+  }
+
+  @JsonIgnore
+  @Override
+  public List<String> getDatastreams() {
+    return Arrays.asList(_datastreamName);
   }
 
   public void setDatastream(Datastream datastream) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -1,31 +1,57 @@
 package com.linkedin.datastream.server.assignment;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.server.AssignmentStrategy;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 
 public class BroadcastStrategy implements AssignmentStrategy {
-  @Override
-  public Map<String, List<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
-      Map<String, List<DatastreamTask>> currentAssignment) {
-    Map<String, List<DatastreamTask>> assignment = new HashMap<>();
 
-    List<DatastreamTask> templateAssignment = new ArrayList<>();
-    for (Datastream stream : datastreams) {
-      templateAssignment.add(new DatastreamTaskImpl(stream));
-    }
+  private static final Logger LOG = LoggerFactory.getLogger(BroadcastStrategy.class.getName());
+
+  @Override
+  public Map<String, Set<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
+      Map<String, Set<DatastreamTask>> currentAssignment) {
+
+    Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
 
     for (String instance : instances) {
-      // make a clone from the template so they are not sharing the same references
-      List<DatastreamTask> clone = new ArrayList<>(templateAssignment);
-      assignment.put(instance, clone);
+
+      Set<DatastreamTask> newAssignmentForInstance = new HashSet<>();
+      assignment.put(instance, newAssignmentForInstance);
+
+      if (currentAssignment != null && currentAssignment.containsKey(instance)) {
+        Map<String, DatastreamTask> datastreamToTaskMap = new HashMap<>();
+        Collection<DatastreamTask> currentAssignmentForInstance = currentAssignment.get(instance);
+        for(DatastreamTask datastreamTask : currentAssignmentForInstance) {
+          datastreamTask.getDatastreams().stream().forEach(d -> datastreamToTaskMap.put(d, datastreamTask));
+        }
+        for (Datastream datastream : datastreams) {
+          DatastreamTask foundDatastreamTask = datastreamToTaskMap.get(datastream.getName());
+
+          if (foundDatastreamTask == null) {
+            newAssignmentForInstance.add(new DatastreamTaskImpl(datastream));
+          } else {
+            newAssignmentForInstance.add(foundDatastreamTask);
+          }
+        }
+      } else {
+        // When there is no existing assignment for the instance. Create new datastream tasks.
+        for (Datastream datastream : datastreams) {
+          newAssignmentForInstance.add(new DatastreamTaskImpl(datastream));
+        }
+      }
     }
 
     return assignment;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/SimpleStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/SimpleStrategy.java
@@ -11,8 +11,8 @@ import java.util.*;
 public class SimpleStrategy implements AssignmentStrategy {
 
   @Override
-  public Map<String, List<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
-      Map<String, List<DatastreamTask>> currentAssignment) {
+  public Map<String, Set<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
+      Map<String, Set<DatastreamTask>> currentAssignment) {
     // if there are no live instances, return empty assignment
     if (instances.size() == 0) {
       return new HashMap<>();
@@ -21,7 +21,7 @@ public class SimpleStrategy implements AssignmentStrategy {
     Collections.sort(instances);
     datastreams = sortDatastreams(datastreams);
 
-    Map<String, List<DatastreamTask>> assignment = new HashMap<>();
+    Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
 
     for (int i = 0; i < datastreams.size(); i++) {
       int instanceIndex = i % instances.size();
@@ -47,10 +47,10 @@ public class SimpleStrategy implements AssignmentStrategy {
     return result;
   }
 
-  private void assign(String instance, Datastream datastream, Map<String, List<DatastreamTask>> assignment) {
+  private void assign(String instance, Datastream datastream, Map<String, Set<DatastreamTask>> assignment) {
     DatastreamTask datastreamTask = new DatastreamTaskImpl(datastream);
     if (!assignment.containsKey(instance)) {
-      assignment.put(instance, new ArrayList<>());
+      assignment.put(instance, new HashSet<>());
     }
     assignment.get(instance).add(datastreamTask);
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
@@ -1,0 +1,115 @@
+package com.linkedin.datastream.server.assignment;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamSource;
+import com.linkedin.datastream.connectors.DummyConnector;
+import com.linkedin.datastream.server.DatastreamTask;
+
+
+public class TestBroadcastStrategy {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BroadcastStrategy.class.getName());
+
+  @Test
+  public void testBroadcastStrategy_createsAssignmentAcrossAllInstances() {
+    String[] instances = new String[] {"instance1", "instance2", "instance3"};
+    List<Datastream> datastreams = generateDatastreams("ds", 5);
+    BroadcastStrategy strategy = new BroadcastStrategy();
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+    for(String instance : instances) {
+      Assert.assertEquals(assignment.get(instance).size(), datastreams.size());
+    }
+  }
+
+  private List<Datastream> generateDatastreams(String namePrefix, int numberOfDatastreams) {
+    List<Datastream> datastreams = new ArrayList<>();
+    for(int index =0; index < numberOfDatastreams; index++) {
+      Datastream ds = new Datastream();
+      ds.setName(namePrefix + index);
+      ds.setConnectorType(DummyConnector.CONNECTOR_TYPE);
+      ds.setSource(new DatastreamSource());
+      ds.getSource().setConnectionString("DummySource");
+      StringMap metadata = new StringMap();
+      metadata.put("owner", "person_" + index);
+      ds.setMetadata(metadata);
+      datastreams.add(ds);
+    }
+
+    return datastreams;
+  }
+
+  @Test
+  public void testBroadcastStrategy_doesntCreateNewTasks_WhenCalledSecondTime() {
+    String[] instances = new String[] {"instance1", "instance2", "instance3"};
+    List<Datastream> datastreams = generateDatastreams("ds", 5);
+    BroadcastStrategy strategy = new BroadcastStrategy();
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
+    for(String instance: instances) {
+      Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
+      Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
+      Assert.assertEquals(oldAssignmentTasks.size(), newAssignmentTasks.size());
+      LOG.info("New assignment : " + newAssignmentTasks);
+      LOG.info("Old assignment : " + oldAssignmentTasks);
+      Assert.assertTrue(newAssignmentTasks.containsAll(oldAssignmentTasks));
+    }
+  }
+
+  @Test
+  public void testBroadcastStrategy_createsNewTasksOnlyForNewDatastream_WhenDatastreamIsCreated() {
+    List<String> instances = Arrays.asList(new String[]{"instance1", "instance2", "instance3"});
+    List<Datastream> datastreams = generateDatastreams("ds", 5);
+    BroadcastStrategy strategy = new BroadcastStrategy();
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, new HashMap<>());
+
+    List<Datastream> newDatastreams = new ArrayList<>(datastreams);
+    Datastream newDatastream = generateDatastreams("newds", 1).get(0);
+    newDatastreams.add(newDatastream);
+
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(newDatastreams, instances, assignment);
+
+    // Ensure that the datastream tasks for the existing instances didn't change.
+    for(String instance: instances) {
+      Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
+      Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
+      Assert.assertEquals(oldAssignmentTasks.size() + 1, newAssignmentTasks.size());
+      Assert.assertTrue(oldAssignmentTasks.stream().allMatch(x -> x.getDatastreams().contains(newDatastream.getName()) ||
+          newAssignmentTasks.contains(x)));
+    }
+  }
+
+  @Test
+  public void testBroadcastStrategy_createsNewTasksOnlyForNewInstance_WhenInstanceIsAdded() {
+    List<String> instances = Arrays.asList(new String[] {"instance1", "instance2", "instance3"});
+    String instance4 = "instance4";
+    List<Datastream> datastreams = generateDatastreams("ds", 5);
+    BroadcastStrategy strategy = new BroadcastStrategy();
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, new HashMap<>());
+    List<String> newInstances = new ArrayList<>(instances);
+    newInstances.add(instance4);
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, newInstances, assignment);
+
+    // Ensure that the datastream tasks for the existing instances didn't change.
+    for(String instance: instances) {
+      Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
+      Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
+      Assert.assertEquals(oldAssignmentTasks.size(), newAssignmentTasks.size());
+      Assert.assertTrue(oldAssignmentTasks.stream().allMatch(x -> newAssignmentTasks.contains(x)));
+    }
+
+    Assert.assertEquals(newAssignment.get(instance4).size(), datastreams.size());
+  }
+}

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/EmbeddedDatastreamCluster.java
@@ -84,7 +84,9 @@ public class EmbeddedDatastreamCluster {
 
 
     properties.putAll(getDomainConnectorProperties(connectorProperties));
-    properties.putAll(override);
+    if(override != null) {
+      properties.putAll(override);
+    }
     _datastreamServerProperties = properties;
   }
 


### PR DESCRIPTION
Right now BroadcastStrategy creates a new datastream task everytime it is called. Datastreamtask is immutable and it should be deleted only when the datastreams are deleted. Fixing the Broadcast strategy so that it looks at the current assignment before creating a new datastream task.
