### PR TITLE
Rethrow exception from connectorWrapper

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -68,6 +68,7 @@ public class ConnectorWrapper {
       _connector.start();
     } catch (Exception ex) {
       logErrorAndException("start", ex);
+      throw ex;
     }
 
     logApiEnd("start");
@@ -80,6 +81,7 @@ public class ConnectorWrapper {
       _connector.stop();
     } catch (Exception ex) {
       logErrorAndException("stop", ex);
+      throw ex;
     }
 
     logApiEnd("stop");
@@ -96,6 +98,7 @@ public class ConnectorWrapper {
       _connector.onAssignmentChange(tasks);
     } catch (Exception ex) {
       logErrorAndException("onAssignmentChange", ex);
+      throw ex;
     }
 
     logApiEnd("onAssignmentChange");


### PR DESCRIPTION
ConnectorWrapper swallows all the exceptions from the connector calls. Now we expose it so that the caller can handle them.
