### PR TITLE
Make the onAssignmentChange call non blocking

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -61,7 +61,7 @@ public class ConnectorWrapper {
         _connectorType, _instanceName, _endTime - _startTime));
   }
 
-  public void start() {
+  public synchronized void start() {
     logApiStart("start");
 
     try {
@@ -74,7 +74,7 @@ public class ConnectorWrapper {
     logApiEnd("start");
   }
 
-  public void stop() {
+  public synchronized void stop() {
     logApiStart("stop");
 
     try {
@@ -91,7 +91,7 @@ public class ConnectorWrapper {
     return _connectorType;
   }
 
-  public void onAssignmentChange(List<DatastreamTask> tasks) {
+  public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
     logApiStart("onAssignmentChange");
 
     try {
@@ -104,7 +104,8 @@ public class ConnectorWrapper {
     logApiEnd("onAssignmentChange");
   }
 
-  public void initializeDatastream(Datastream stream) throws DatastreamValidationException {
+  public synchronized void initializeDatastream(Datastream stream)
+      throws DatastreamValidationException {
     logApiStart("initializeDatastream");
 
     try {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -27,6 +27,7 @@ public final class CoordinatorConfig {
   public static final String CONFIG_SCHEMA_REGISTRY_PROVIDER_FACTORY = "schemaRegistryProviderFactory";
   public static final String CONFIG_REUSE_EXISTING_DESTINATION = "reuseExistingDestination";
   private final String _schemaRegistryProviderFactory;
+  private int _assignmentChangeThreadPoolThreadCount = 1;
 
   public CoordinatorConfig(Properties config) {
     _config = config;
@@ -75,5 +76,13 @@ public final class CoordinatorConfig {
 
   public boolean isReuseExistingDestination() {
     return _reuseExistingDestination;
+  }
+
+  public void setAssignmentChangeThreadPoolThreadCount(int count) {
+    _assignmentChangeThreadPoolThreadCount = count;
+  }
+
+  public int getAssignmentChangeThreadPoolThreadCount() {
+    return _assignmentChangeThreadPoolThreadCount;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -118,16 +118,18 @@ public enum DatastreamServer {
     LOG.info("Start to initialize DatastreamServer. Properties: " + properties);
     LOG.info("Creating coordinator.");
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
-    CoordinatorConfig coordinatorConfig = new CoordinatorConfig(properties);
-    _coordinator = new Coordinator(coordinatorConfig);
 
-    LOG.info("Loading connectors.");
-    String connectorTypes = verifiableProperties.getString(CONFIG_CONNECTOR_TYPES);
-    if (connectorTypes.isEmpty()) {
+    String[] connectorTypes = verifiableProperties.getString(CONFIG_CONNECTOR_TYPES).split(",");
+    if (connectorTypes.length == 0) {
       throw new DatastreamException("No connectors specified in connectorTypes");
     }
+
+    CoordinatorConfig coordinatorConfig = new CoordinatorConfig(properties);
+    coordinatorConfig.setAssignmentChangeThreadPoolThreadCount(connectorTypes.length);
+    _coordinator = new Coordinator(coordinatorConfig);
+    LOG.info("Loading connectors.");
     _bootstrapConnectors = new HashMap<>();
-    for (String connectorStr : connectorTypes.split(",")) {
+    for (String connectorStr : connectorTypes) {
       initializeConnector(connectorStr, verifiableProperties.getDomainProperties(connectorStr));
     }
 


### PR DESCRIPTION
1. Creating Threadpool for calling on the onAssignmentChange for every connectorType in parallel.
2. All the connector calls are synchronized so that connector implementation needn't be thread safe.
