### PR TITLE
Removing the singleton design of the datastream server to enable better testability

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -35,17 +35,17 @@ public class TestDatastreamRestClient {
 
   private static final String DUMMY_CONNECTOR = DummyConnector.CONNECTOR_TYPE;
   private static final String DUMMY_BOOTSTRAP_CONNECTOR = DummyBootstrapConnector.CONNECTOR_TYPE;
+  private DatastreamServer _datastreamServer;
 
   @BeforeTest
   public void setUp() throws Exception {
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
-    DatastreamServer.INSTANCE.shutdown();
     setupServer();
   }
 
   @AfterTest
   public void tearDown() throws Exception {
-    DatastreamServer.INSTANCE.shutdown();
+    _datastreamServer.shutdown();
   }
 
   public static Datastream generateDatastream(int seed) {
@@ -77,8 +77,8 @@ public class TestDatastreamRestClient {
         DummyBootstrapConnectorFactory.class.getTypeName());
     properties.put(DUMMY_CONNECTOR + "." + DatastreamServer.CONFIG_CONNECTOR_BOOTSTRAP_TYPE, DUMMY_BOOTSTRAP_CONNECTOR);
     properties.put(DUMMY_CONNECTOR + ".dummyProperty", "dummyValue"); // DummyConnector will verify this value being correctly set
-    DatastreamServer.INSTANCE.init(properties);
-    DatastreamServer.INSTANCE.startup();
+    _datastreamServer = new DatastreamServer(properties);
+    _datastreamServer.startup();
   }
 
   @Test

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamNettyStandaloneLauncher.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamNettyStandaloneLauncher.java
@@ -1,0 +1,86 @@
+package com.linkedin.datastream.server;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.parseq.Engine;
+import com.linkedin.parseq.EngineBuilder;
+import com.linkedin.r2.filter.FilterChains;
+import com.linkedin.r2.transport.common.bridge.server.TransportDispatcher;
+import com.linkedin.r2.transport.http.server.HttpNettyServerFactory;
+import com.linkedin.r2.transport.http.server.HttpServer;
+import com.linkedin.restli.docgen.DefaultDocumentationRequestHandler;
+import com.linkedin.restli.server.DelegatingTransportDispatcher;
+import com.linkedin.restli.server.RestLiConfig;
+import com.linkedin.restli.server.RestLiServer;
+import com.linkedin.restli.server.resources.ResourceFactory;
+
+
+/**
+ * Datastream specific netty standalone launcher which uses the DatastreamResourceFactory for instantiating
+ * the datastream restli resources.
+ */
+public class DatastreamNettyStandaloneLauncher {
+  private static final Logger LOG = LoggerFactory.getLogger(DatastreamNettyStandaloneLauncher.class.getName());
+
+  private final int _port;
+  private final int _threadPoolSize;
+  private final int _parseqThreadPoolSize;
+  private final String[] _packages;
+  private final HttpServer _server;
+
+  public DatastreamNettyStandaloneLauncher(int httpPort, ResourceFactory resourceFactory, String... packages) {
+    this(httpPort, HttpNettyServerFactory.DEFAULT_THREAD_POOL_SIZE, Runtime.getRuntime().availableProcessors() + 1,
+        resourceFactory, packages);
+  }
+
+  public DatastreamNettyStandaloneLauncher(int port, int threadPoolSize, int parseqThreadPoolSize,
+      ResourceFactory resourceFactory, String... packages) {
+    _port = port;
+    _threadPoolSize = threadPoolSize;
+    _parseqThreadPoolSize = parseqThreadPoolSize;
+    _packages = packages;
+
+    final RestLiConfig config = new RestLiConfig();
+    config.setDocumentationRequestHandler(new DefaultDocumentationRequestHandler());
+    config.setServerNodeUri(URI.create("/"));
+    config.addResourcePackageNames(_packages);
+
+    LOG.info("Netty parseqThreadPoolSize: " + parseqThreadPoolSize);
+    final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(parseqThreadPoolSize);
+    final Engine engine = new EngineBuilder()
+        .setTaskExecutor(scheduler)
+        .setTimerScheduler(scheduler)
+        .build();
+
+    final RestLiServer restServer = new RestLiServer(config, resourceFactory, engine);
+    final TransportDispatcher dispatcher = new DelegatingTransportDispatcher(restServer);
+    LOG.info("Netty threadPoolSize: " + threadPoolSize);
+    _server = new HttpNettyServerFactory(FilterChains.empty()).createServer(_port, threadPoolSize, dispatcher);
+  }
+
+  /**
+   * Start the server
+   *
+   * @throws java.io.IOException server startup fails
+   */
+  public void start() throws IOException
+  {
+    _server.start();
+  }
+
+  /**
+   * Stop the server
+   *
+   * @throws IOException server shutdown fails
+   */
+  public void stop() throws IOException
+  {
+    _server.stop();
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
@@ -17,8 +17,15 @@ import com.linkedin.restli.server.annotations.RestLiActions;
 @RestLiActions(name = "bootstrap", namespace = "com.linkedin.datastream.server.dms")
 public class BootstrapActionResources {
 
-  private final DatastreamStore _store = DatastreamServer.INSTANCE.getDatastreamStore();
-  private final Coordinator _coordinator = DatastreamServer.INSTANCE.getCoordinator();
+  private final DatastreamStore _store;
+  private final Coordinator _coordinator;
+  private final DatastreamServer _datastreamServer;
+
+  public BootstrapActionResources(DatastreamServer datastreamServer) {
+    _datastreamServer = datastreamServer;
+    _store = datastreamServer.getDatastreamStore();
+    _coordinator = datastreamServer.getCoordinator();
+  }
 
   /**
    * Process the request of creating bootstrap datastream. The request provides the name of
@@ -34,9 +41,8 @@ public class BootstrapActionResources {
     }
     Datastream bootstrapDatastream = new Datastream();
     bootstrapDatastream.setName(baseDatastream.getName() + "-" + System.currentTimeMillis());
-    DatastreamServer datastreamServer = DatastreamServer.INSTANCE;
     try {
-      String bootstrapConnectorType = datastreamServer.getBootstrapConnector(baseDatastream.getConnectorType());
+      String bootstrapConnectorType = _datastreamServer.getBootstrapConnector(baseDatastream.getConnectorType());
       bootstrapDatastream.setConnectorType(bootstrapConnectorType);
     } catch (DatastreamException e) {
       throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, e);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResourceFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResourceFactory.java
@@ -1,0 +1,36 @@
+package com.linkedin.datastream.server.dms;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+
+import com.linkedin.datastream.common.ReflectionUtils;
+import com.linkedin.datastream.server.DatastreamServer;
+import com.linkedin.restli.internal.server.model.ResourceModel;
+import com.linkedin.restli.server.resources.ResourceFactory;
+
+
+/**
+ * Datastream Resource Factory that is used to create the datastream restli resources.
+ */
+public class DatastreamResourceFactory implements ResourceFactory {
+
+  private final DatastreamServer _datastreamServer;
+
+  public DatastreamResourceFactory(DatastreamServer datastreamServer) {
+    _datastreamServer = datastreamServer;
+  }
+
+  @Override
+  public void setRootResources(Map<String, ResourceModel> rootResources) {
+
+  }
+
+  @Override
+  public <R> R create(Class<R> resourceClass) {
+    try {
+      return ReflectionUtils.createInstance(resourceClass.getCanonicalName(), _datastreamServer);
+    } catch (ClassNotFoundException | NoSuchMethodException | InvocationTargetException | InstantiationException | IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -1,5 +1,8 @@
 package com.linkedin.datastream.server.dms;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.server.Coordinator;
 import com.linkedin.datastream.server.DatastreamServer;
@@ -19,9 +22,15 @@ import com.linkedin.restli.server.resources.CollectionResourceTemplate;
  */
 @RestLiCollection(name = "datastream", namespace = "com.linkedin.datastream.server.dms")
 public class DatastreamResources extends CollectionResourceTemplate<String, Datastream> {
+  private static final Logger LOG = LoggerFactory.getLogger(DatastreamResources.class.getName());
 
-  private final DatastreamStore _store = DatastreamServer.INSTANCE.getDatastreamStore();
-  private final Coordinator _coordinator = DatastreamServer.INSTANCE.getCoordinator();
+  private final DatastreamStore _store;
+  private final Coordinator _coordinator;
+
+  public DatastreamResources(DatastreamServer datastreamServer) {
+    _store = datastreamServer.getDatastreamStore();
+    _coordinator = datastreamServer.getCoordinator();
+  }
 
   @Override
   public UpdateResponse update(String key, Datastream datastream) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -49,6 +49,7 @@ public class EmbeddedDatastreamCluster {
   private EmbeddedKafkaCluster _embeddedKafkaCluster = null;
   private int _datastreamPort;
   private Properties _datastreamServerProperties;
+  private DatastreamServer _server;
 
   private EmbeddedDatastreamCluster(Map<String, Properties> connectorProperties, Properties override, int zkPort)
       throws IOException {
@@ -129,6 +130,10 @@ public class EmbeddedDatastreamCluster {
     return _datastreamPort;
   }
 
+  public DatastreamServer getDatastreamServer() {
+    return _server;
+  }
+
   public String getBrokerList() {
     if (_embeddedKafkaCluster == null) {
       LOG.error("kafka cluster not started correctly");
@@ -155,13 +160,12 @@ public class EmbeddedDatastreamCluster {
 
     _embeddedZookeeper.startup();
     _embeddedKafkaCluster.startup();
-
-    DatastreamServer.INSTANCE.init(_datastreamServerProperties);
-    DatastreamServer.INSTANCE.startup();
+    _server = new DatastreamServer(_datastreamServerProperties);
+    _server.startup();
   }
 
   public void shutdown() {
-    DatastreamServer.INSTANCE.shutdown();
+    _server.shutdown();
 
     if (_embeddedKafkaCluster != null) {
       _embeddedKafkaCluster.shutdown();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2,22 +2,17 @@ package com.linkedin.datastream.server;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 
-import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
-import com.linkedin.datastream.testutil.DatastreamTestUtils;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -31,11 +26,13 @@ import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.common.ReflectionUtils;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.connectors.DummyConnector;
+import com.linkedin.datastream.server.api.connector.Connector;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 import com.linkedin.datastream.server.assignment.BroadcastStrategy;
 import com.linkedin.datastream.server.assignment.SimpleStrategy;
-import com.linkedin.datastream.server.api.connector.Connector;
 import com.linkedin.datastream.server.dms.DatastreamResources;
 import com.linkedin.datastream.server.zk.KeyBuilder;
+import com.linkedin.datastream.testutil.DatastreamTestUtils;
 import com.linkedin.datastream.testutil.EmbeddedZookeeper;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.CreateResponse;
@@ -1038,7 +1035,7 @@ public class TestCoordinator {
     EmbeddedDatastreamCluster datastreamKafkaCluster = TestDatastreamServer.initializeTestDatastreamServer(null);
     datastreamKafkaCluster.startup();
     Properties properties = datastreamKafkaCluster.getDatastreamServerProperties();
-    DatastreamResources resource = new DatastreamResources();
+    DatastreamResources resource = new DatastreamResources(datastreamKafkaCluster.getDatastreamServer());
 
     Coordinator coordinator =
         createCoordinator(properties.getProperty(DatastreamServer.CONFIG_ZK_ADDRESS),
@@ -1069,7 +1066,7 @@ public class TestCoordinator {
     EmbeddedDatastreamCluster datastreamKafkaCluster = TestDatastreamServer.initializeTestDatastreamServer(null);
     datastreamKafkaCluster.startup();
     Properties properties = datastreamKafkaCluster.getDatastreamServerProperties();
-    DatastreamResources resource = new DatastreamResources();
+    DatastreamResources resource = new DatastreamResources(datastreamKafkaCluster.getDatastreamServer());
 
     Coordinator coordinator =
         createCoordinator(properties.getProperty(DatastreamServer.CONFIG_ZK_ADDRESS),

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -45,7 +45,6 @@ public class TestDatastreamServer {
   private EmbeddedDatastreamCluster _datastreamCluster;
 
   public static EmbeddedDatastreamCluster initializeTestDatastreamServerWithBootstrap() throws Exception {
-    DatastreamServer.INSTANCE.shutdown();
     Map<String, Properties> connectorProperties = new HashMap<>();
     connectorProperties.put(DUMMY_CONNECTOR, getDummyConnectorProperties(true));
     connectorProperties.put(DUMMY_BOOTSTRAP_CONNECTOR, getBootstrapConnectorProperties());
@@ -60,7 +59,6 @@ public class TestDatastreamServer {
   }
 
   public static EmbeddedDatastreamCluster initializeTestDatastreamServer(Properties override) throws Exception {
-    DatastreamServer.INSTANCE.shutdown();
     Map<String, Properties> connectorProperties = new HashMap<>();
     connectorProperties.put(DUMMY_CONNECTOR, getDummyConnectorProperties(false));
     EmbeddedDatastreamCluster datastreamKafkaCluster =
@@ -181,7 +179,6 @@ public class TestDatastreamServer {
 
   private EmbeddedDatastreamCluster initializeTestDatastreamServerWithFileConnector() throws IOException,
       DatastreamException {
-    DatastreamServer.INSTANCE.shutdown();
     Map<String, Properties> connectorProperties = new HashMap<>();
     connectorProperties.put(TEST_CONNECTOR, getTestConnectorProperties());
     EmbeddedDatastreamCluster datastreamKafkaCluster =

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestBootstrapActionResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestBootstrapActionResources.java
@@ -1,6 +1,7 @@
 package com.linkedin.datastream.server.dms;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.server.DatastreamServer;
 import com.linkedin.datastream.server.TestDatastreamServer;
 import com.linkedin.datastream.connectors.DummyBootstrapConnector;
 import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
@@ -32,8 +33,8 @@ public class TestBootstrapActionResources {
 
   @Test
   public void testCreateBootstrapDatastream() throws Exception {
-    DatastreamResources datastreamResources = new DatastreamResources();
-    BootstrapActionResources bootstrapActionResource = new BootstrapActionResources();
+    DatastreamResources datastreamResources = new DatastreamResources(_datastreamKafkaCluster.getDatastreamServer());
+    BootstrapActionResources bootstrapActionResource = new BootstrapActionResources(_datastreamKafkaCluster.getDatastreamServer());
 
     boolean exceptionCaught = false;
     try {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -12,6 +12,7 @@ import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.connectors.DummyConnector;
+import com.linkedin.datastream.server.DatastreamServer;
 import com.linkedin.datastream.server.TestDatastreamServer;
 import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
 import com.linkedin.restli.common.HttpStatus;
@@ -67,8 +68,8 @@ public class TestDatastreamResources {
 
   @Test
   public void testReadDatastream() {
-    DatastreamResources resource1 = new DatastreamResources();
-    DatastreamResources resource2 = new DatastreamResources();
+    DatastreamResources resource1 = new DatastreamResources(_datastreamKafkaCluster.getDatastreamServer());
+    DatastreamResources resource2 = new DatastreamResources(_datastreamKafkaCluster.getDatastreamServer());
 
     // read before creating
     Datastream ds = resource1.get("name_0");
@@ -85,7 +86,7 @@ public class TestDatastreamResources {
 
   @Test
   public void testCreateDatastream() {
-    DatastreamResources resource = new DatastreamResources();
+    DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getDatastreamServer());
     Set<String> missingFields = new HashSet<>();
 
     // happy path
@@ -131,7 +132,7 @@ public class TestDatastreamResources {
 
   @Test
   public void testCreateInvalidDatastream() {
-    DatastreamResources resource = new DatastreamResources();
+    DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getDatastreamServer());
     Datastream datastream1 = generateDatastream(6);
     datastream1.setConnectorType("InvalidConnectorName");
     CreateResponse response = resource.create(datastream1);

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
@@ -1,6 +1,7 @@
 package com.linkedin.datastream.common;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.util.stream.IntStream;
 import java.lang.reflect.Constructor;
 
@@ -23,7 +24,9 @@ public class ReflectionUtils {
    * @param <T> type fo the class
    * @return instance of the class, or null if anything went wrong
    */
-  public static <T> T createInstance(String clazz, Object... args) {
+  public static <T> T createInstance(String clazz, Object... args)
+      throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException,
+             IllegalAccessException {
     Validate.notNull(clazz, "null class name");
     try {
       Class classObj = Class.forName(clazz);
@@ -33,7 +36,7 @@ public class ReflectionUtils {
       return ctor.newInstance(args);
     } catch (Exception e) {
       LOG.warn("Failed to create instance for: " + clazz, e);
-      return null;
+      throw e;
     }
   }
 

--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/TestReflectionUtils.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/TestReflectionUtils.java
@@ -1,5 +1,7 @@
 package com.linkedin.datastream.common;
 
+import java.lang.reflect.InvocationTargetException;
+
 import junit.framework.Assert;
 import org.testng.annotations.Test;
 
@@ -21,7 +23,9 @@ public class TestReflectionUtils {
   }
 
   @Test
-  public void testCreateInstance() {
+  public void testCreateInstance()
+      throws ClassNotFoundException, NoSuchMethodException, InstantiationException, IllegalAccessException,
+             InvocationTargetException {
     TestReflectionUtils utils;
     utils = ReflectionUtils.createInstance(TestReflectionUtils.class.getCanonicalName());
     Assert.assertNotNull(utils);
@@ -32,14 +36,23 @@ public class TestReflectionUtils {
     utils = ReflectionUtils.createInstance(TestReflectionUtils.class.getCanonicalName(), STR_ARG1, INT_ARG2);
     Assert.assertNotNull(utils);
 
-    utils = ReflectionUtils.createInstance(TestReflectionUtils.class.getCanonicalName(), STR_ARG1, STR_ARG1);
-    Assert.assertNull(utils);
+    try {
+      utils = ReflectionUtils.createInstance(TestReflectionUtils.class.getCanonicalName(), STR_ARG1, STR_ARG1);
+      Assert.assertTrue(true);
+    } catch (NoSuchMethodException e) {
+    }
 
-    utils = ReflectionUtils.createInstance("Foobar");
-    Assert.assertNull(utils);
+    try {
+      utils = ReflectionUtils.createInstance("Foobar");
+      Assert.assertTrue(true);
+    } catch (ClassNotFoundException e) {
+    }
 
-    utils = ReflectionUtils.createInstance("Foobar", 200);
-    Assert.assertNull(utils);
+    try {
+      utils = ReflectionUtils.createInstance("Foobar", 200);
+      Assert.assertTrue(true);
+    } catch (ClassNotFoundException e) {
+    }
 
     boolean exception = false;
     try {


### PR DESCRIPTION
- Created a datastream resource factory that will inject the necessary dependency  (DatastreamServer) through the constructor for each of the datastream resources. 
- Created a new DatastreamNettyStandaloneLauncher that will use datastream specific resource factory for creating the datastream resources.
- Removed the singleton pattern of the DatastreamServer 
- Updated the testcases to not use DatastreamServer.INSTANCE.
