### PR TITLE
Removing the need for connector to pass DatastreamTask while creating the DatastreamEventRecord

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventRecord.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventRecord.java
@@ -14,22 +14,18 @@ import com.linkedin.datastream.common.DatastreamEvent;
  * Envelope of a Datastream event to be sent via Kafka.
  */
 public class DatastreamEventRecord {
-  private final DatastreamTask _task;
   private final int _partition;
   private final String _checkpoint;
   private final List<DatastreamEvent> _events;
 
-  public DatastreamEventRecord(DatastreamEvent event, int partition, String checkpoint, DatastreamTask task) {
-    this(Arrays.asList(new DatastreamEvent[] { event }), partition, checkpoint, task);
+  public DatastreamEventRecord(DatastreamEvent event, int partition, String checkpoint) {
+    this(Arrays.asList(new DatastreamEvent[] { event }), partition, checkpoint);
   }
 
-  public DatastreamEventRecord(List<DatastreamEvent> events, int partition, String checkpoint, DatastreamTask task) {
+  public DatastreamEventRecord(List<DatastreamEvent> events, int partition, String checkpoint) {
     Validate.notEmpty(checkpoint, "empty checkpoint");
     Validate.notNull(events, "null event");
-    Validate.notNull(task, "null task");
 
-    // TODO: partition can be negative magic number for special meaning, eg. re-partitioning.
-    // For now, we requires partition to be non-negative.
     Validate.isTrue(partition >= 0, "invalid partition number: " + String.valueOf(partition));
 
     events.forEach((e) -> Validate.notNull(e, "null event"));
@@ -37,7 +33,6 @@ public class DatastreamEventRecord {
     _events = events;
     _partition = partition;
     _checkpoint = checkpoint;
-    _task = task;
   }
 
   /**
@@ -54,23 +49,10 @@ public class DatastreamEventRecord {
     return _partition;
   }
 
-  /**
-   * @return destination name.
-   */
-  public String getDestination() {
-    return _task.getDatastreamDestination().getConnectionString();
-  }
-
-  /**
-   * @return DatastreamTask this event is being produced for.
-   */
-  public DatastreamTask getDatastreamTask() {
-    return _task;
-  }
 
   @Override
   public String toString() {
-    return String.format("%s @ task=%s, partition=%d", _events, _task, _partition);
+    return String.format("%s @ partition=%d", _events, _partition);
   }
 
   @Override
@@ -80,13 +62,13 @@ public class DatastreamEventRecord {
     if (o == null || getClass() != o.getClass())
       return false;
     DatastreamEventRecord record = (DatastreamEventRecord) o;
-    return Objects.equals(_task, record._task) && Objects.equals(_partition, record._partition)
+    return Objects.equals(_partition, record._partition)
         && Objects.equals(_events, record._events) && Objects.equals(_checkpoint, record._checkpoint);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_task, _partition, _events, _checkpoint);
+    return Objects.hash(_partition, _events, _checkpoint);
   }
 
   /**

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
@@ -33,7 +33,7 @@ public interface TransportProvider {
    * @param record DatastreamEvent that needs to be sent to the stream.
    * @throws TransportException if the send fails.
    */
-  void send(DatastreamEventRecord record) throws TransportException;
+  void send(String destination, DatastreamEventRecord record) throws TransportException;
 
   /**
    * Closes the transport provider and its corresponding producer.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -376,7 +376,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
     }
 
     if (needed) {
-      List<DatastreamEventProducer> unusedProducers = new ArrayList<>();
+      List<EventProducer> unusedProducers = new ArrayList<>();
 
       List<DatastreamTask> newAssignment = new ArrayList<>();
       // Populate the event producers before calling the connector with the list of tasks.
@@ -402,7 +402,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
 
           if (unusedProducers.size() > 0) {
             LOG.info("Shutting down all unused event producers: " + unusedProducers);
-            unusedProducers.forEach((producer) -> ((DatastreamEventProducerImpl) producer).shutdown());
+            unusedProducers.forEach((producer) -> producer.shutdown());
           }
         } catch(Exception ex) {
           _eventQueue.put(CoordinatorEvent.createHandleInstanceErrorEvent(ExceptionUtils.getRootCauseMessage(ex)));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
@@ -1,267 +1,39 @@
 package com.linkedin.datastream.server;
 
-import com.linkedin.datastream.common.DatastreamEvent;
-import com.linkedin.datastream.common.JsonUtils;
-import com.linkedin.datastream.common.PollUtils;
-import com.linkedin.datastream.common.VerifiableProperties;
-import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryException;
-import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
-import com.linkedin.datastream.server.api.transport.TransportException;
-import com.linkedin.datastream.server.api.transport.TransportProvider;
-import com.linkedin.datastream.server.providers.CheckpointProvider;
-
 import org.apache.avro.Schema;
-import org.apache.commons.lang.Validate;
-import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.nio.ByteBuffer;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ScheduledThreadPoolExecutor;
-import java.util.concurrent.TimeUnit;
-
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryException;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
 
 /**
- * DatastreamEventProducerImpl is the default implementation of {@link DatastreamEventProducer}.
- * It allows connectors to send events to the transport and handles save/restore checkpoints
- * automatically if {@link DatastreamEventProducerImpl.CheckpointPolicy#DATASTREAM} is specified.
- * Otherwise, it exposes the safe checkpoints which are guaranteed to have been flushed.
+ * Implementation of the DatastremaEventProducer that connector will use to produce events. There is an unique
+ * DatastreamEventProducerImpl object created per DatastreamTask that is assigned to the connector.
+ * DatastreamEventProducer will inturn use a shared EventProducer (shared across the tasks that use the same destinations)
+ * to produce the events.
  */
 public class DatastreamEventProducerImpl implements DatastreamEventProducer {
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamEventProducerImpl.class);
 
-  /**
-   * Policy for checkpoint handling
-   */
-  enum CheckpointPolicy {
-    DATASTREAM,
-    CUSTOM
-  }
-
-  public static final String INVALID_CHECKPOINT = "";
-  public static final String CHECKPOINT_PERIOD_MS = "checkpointPeriodMs";
-  public static final Integer DEFAULT_CHECKPOINT_PERIOD_MS = 1000;
-  public static final Integer SHUTDOWN_POLL_MS = 1000;
-  public static final Integer SHUTDOWN_POLL_PERIOD_MS = 50;
-
-  // List of tasks the producer is responsible for
-  private final List<DatastreamTask> _tasks;
-
-  private final TransportProvider _transportProvider;
   private final SchemaRegistryProvider _schemaRegistryProvider;
-  private final CheckpointProvider _checkpointProvider;
-  private final CheckpointPolicy _checkpointPolicy;
+  private final EventProducer _eventProducer;
+  private final DatastreamTask _task;
 
-  // This stores the latest "dirty" checkpoint that we received
-  // from send() call but haven't been flushed on the transport.
-  // One one checkpoint is needed since connector only need to
-  // fulfill all the tasks by only producing any one of them,
-  // hence producer just need to store one dirty checkpoint and
-  // update all tasks in _safeCheckpoints with this.
-  private Map<DatastreamTask, Map<Integer, String>> _latestCheckpoints;
-
-  // This stores the checkpoints that have been recently flushed such that
-  // are safe to be committed to the source consumption tracking system.
-  private Map<DatastreamTask, Map<Integer, String>> _safeCheckpoints;
-
-  private Map<DatastreamTask, String> _pendingCheckpoints;
-
-  // Helper for periodical flush/checkpoint operations
-  private final CheckpointHandler _checkpointHandler;
-
-  private volatile boolean _pendingCheckpoint = false;
-  private volatile boolean _shutdownCompleted = false;
-
-  /**
-   * Flush transport periodically and save checkpoints.
-   * Default period is 1 second.
-   */
-  class CheckpointHandler implements Runnable {
-    private final Long _periodMs;
-    private final ScheduledExecutorService _executor;
-
-    public CheckpointHandler(Properties config) {
-      VerifiableProperties props = new VerifiableProperties(config);
-      _periodMs = props.getLong(CHECKPOINT_PERIOD_MS, DEFAULT_CHECKPOINT_PERIOD_MS);
-      _executor = new ScheduledThreadPoolExecutor(1);
-      _executor.scheduleAtFixedRate(this, 0, _periodMs, TimeUnit.MILLISECONDS);
-    }
-
-    public void shutdown() {
-      LOG.info(String.format("Shutdown requested, tasks = [%s].", _tasks));
-
-      // Initial shutdown and interrupt the thread
-      _executor.shutdown();
-
-      // Poll for 1 second for the thread to actually exit
-      PollUtils.poll(() -> _executor.isTerminated(), SHUTDOWN_POLL_MS, SHUTDOWN_POLL_PERIOD_MS);
-
-      // Final flush
-      flushAndCheckpoint();
-
-      LOG.info(String.format("Shutdown finished, tasks = [%s].", _tasks));
-    }
-
-    private void flushAndCheckpoint() {
-      try {
-        flush();
-        LOG.debug(String.format("Checkpoint handler exited, tasks = [%s].", _tasks));
-      } catch (Throwable t) {
-        // Since have have handled all exceptions here, there would be no exceptions leaked
-        // to the executor, which will reschedules as usual so no explicit retry is needed.
-        LOG.error(String.format("Checkpoint failed, will retry after %d ms, reason = %s", _periodMs, t.getMessage()), t);
-      }
-    }
-
-    @Override
-    public void run() {
-      flushAndCheckpoint();
-    }
-  }
-
-  /**
-   * Construct a DatastreamEventProducerImpl instance.
-   * @param tasks list of tasks which have the same destination
-   * @param transportProvider event transport
-   * @param schemaRegistryProvider
-   * @param checkpointProvider checkpoint store
-   * @param config global config
-   * @param customCheckpointing decides whether Producer should use custom checkpointing or the datastream server
-   *                            provided checkpointing.
-   */
-  public DatastreamEventProducerImpl(List<DatastreamTask> tasks, TransportProvider transportProvider,
-      SchemaRegistryProvider schemaRegistryProvider, CheckpointProvider checkpointProvider, Properties config,
-      boolean customCheckpointing) {
-    Validate.notNull(tasks, "null tasks");
-    Validate.notNull(transportProvider, "null transport provider");
-    Validate.notNull(checkpointProvider, "null checkpoint provider");
-    Validate.notNull(config, "null config");
-    Validate.notEmpty(tasks, "empty task list");
-
-    DatastreamTask task0 = tasks.get(0);
-    Set<Integer> knownPartitions = new HashSet<>();
-    for (DatastreamTask task : tasks) {
-      // Ensure all tasks are for the same destination
-      task.getDatastreamDestination().equals(task0.getDatastreamDestination());
-
-      // DatastreamTask should include at least one partition.
-      // This should be ensured by DatastreamTaskImpl's ctor.
-      Validate.notEmpty(task.getPartitions(), "null or empty partitions in: " + task);
-
-      // Ensure no duplicate partitions exist
-      for (Integer partition : task.getPartitions()) {
-        Validate.isTrue(!knownPartitions.contains(partition), "duplicate partition: " + partition);
-        knownPartitions.add(partition);
-      }
-    }
-
-    _tasks = tasks;
-    _transportProvider = transportProvider;
+  public DatastreamEventProducerImpl(DatastreamTask task, SchemaRegistryProvider schemaRegistryProvider,
+      EventProducer eventProducer) {
     _schemaRegistryProvider = schemaRegistryProvider;
-    _checkpointProvider = checkpointProvider;
-
-    _checkpointPolicy = customCheckpointing ? CheckpointPolicy.CUSTOM : CheckpointPolicy.DATASTREAM;
-
-    _checkpointHandler = new CheckpointHandler(config);
-
-    // For DATASTREAM checkpoint policy, load initial checkpoints
-    if (_checkpointPolicy == CheckpointPolicy.DATASTREAM) {
-      loadCheckpoints();
-    }
-
-    _pendingCheckpoints = new HashMap<>();
-    _tasks.forEach(task -> _pendingCheckpoints.put(task, INVALID_CHECKPOINT));
-
-    // This can happen for first time run or custom checkpointing
-    if (_safeCheckpoints == null || _safeCheckpoints.size() == 0) {
-      _safeCheckpoints = new HashMap<>();
-      for (DatastreamTask task : tasks) {
-        Map<Integer, String> checkpoints = new HashMap<>();
-        _safeCheckpoints.put(task, checkpoints);
-        task.getPartitions().forEach(partition -> checkpoints.put(partition, INVALID_CHECKPOINT));
-      }
-    }
-
-    _latestCheckpoints = new HashMap<>(_safeCheckpoints);
-
-    LOG.info("Created event producer, tasks: " + _tasks + ", safe checkpoints: " + _safeCheckpoints);
+    _eventProducer = eventProducer;
+    _task = task;
   }
 
-  private void loadCheckpoints() {
-    _safeCheckpoints = new HashMap<>();
-
-    Map<DatastreamTask, String> checkpoints = _checkpointProvider.getCommitted(_tasks);
-
-    // Instruct jackson to convert string keys to integer
-    TypeReference typeRef = new TypeReference<HashMap<Integer, String>>() {
-    };
-
-    for (DatastreamTask task : checkpoints.keySet()) {
-      String cpString = checkpoints.get(task);
-      try {
-        _safeCheckpoints.put(task, JsonUtils.fromJson(cpString, typeRef));
-      } catch (Exception e) {
-        throw new IllegalArgumentException(String.format(
-            "Failed to load checkpoints, task = %s, checkpoint = %s, error = %s", task, cpString, e.getMessage()), e);
-      }
-    }
+  EventProducer getEventProducer() {
+    return _eventProducer;
   }
 
-  private void validateEventRecord(DatastreamEventRecord record) {
-    Validate.notNull(record, "null event record.");
-    Validate.notNull(record.getEvents(), "null event payload.");
-    DatastreamTask task = record.getDatastreamTask();
-    Validate.notNull(task, "null event task.");
-    Validate.notNull(record.getCheckpoint(), "null event checkpoint.");
-    Validate.notEmpty(record.getDestination(), "invalid event destination.");
-    Map<Integer, String> checkpoints = _latestCheckpoints.get(task);
-    Validate.notNull(checkpoints, "unknown task: " + task);
-  }
-
-  /**
-   * Send the event onto the underlying transport.
-   *
-   * @param record DatastreamEvent envelope
-   */
   @Override
-  public synchronized void send(DatastreamEventRecord record) {
-    // Prevent sending if we have been shutdown
-    if (_shutdownCompleted) {
-      throw new IllegalStateException("send() is not allowed on a shutdown producer");
-    }
-
-    validateEventRecord(record);
-
-    for (DatastreamEvent event : record.getEvents()) {
-      if (event.metadata == null) {
-        event.metadata = new HashMap<>();
-      }
-
-      event.key = event.key == null ? ByteBuffer.allocate(0) : event.key;
-      event.payload = event.payload == null ? ByteBuffer.allocate(0) : event.payload;
-      event.previous_payload = event.previous_payload == null ? ByteBuffer.allocate(0) : event.previous_payload;
-    }
-
-    try {
-      // Send the event to transport
-      _transportProvider.send(record);
-
-      // Update the checkpoint for the task/partition
-      _latestCheckpoints.get(record.getDatastreamTask()).put(record.getPartition(), record.getCheckpoint());
-
-      // Dirty the flag
-      _pendingCheckpoint = true;
-    } catch (TransportException e) {
-      LOG.info(String.format("Failed send the event %s exception %s", record, e));
-      throw new RuntimeException("Failed to send: " + record, e);
-    }
+  public void send(DatastreamEventRecord event) {
+    _eventProducer.send(_task, event);
   }
 
   /**
@@ -282,65 +54,7 @@ public class DatastreamEventProducerImpl implements DatastreamEventProducer {
   }
 
   @Override
-  public synchronized void flush() {
-    if (!_pendingCheckpoint) {
-      return;
-    }
-
-    try {
-      LOG.info(String.format("Staring transport flush, tasks = [%s].", _tasks));
-
-      _transportProvider.flush();
-
-      LOG.info("Transport has been successfully flushed.");
-    } catch (Throwable t) {
-      throw new RuntimeException(String.format("Flush failed, tasks = [%s].", _tasks), t);
-    }
-    if (_checkpointPolicy == CheckpointPolicy.DATASTREAM) {
-      try {
-        LOG.info(String.format("Start committing checkpoints, cpMap = %s, tasks = [%s].", _pendingCheckpoints, _tasks));
-
-        // Populate checkpoint map for checkpoint provider
-        _latestCheckpoints.keySet().forEach(
-            task -> _pendingCheckpoints.put(task, JsonUtils.toJson(_latestCheckpoints.get(task))));
-
-        _checkpointProvider.commit(_pendingCheckpoints);
-
-        // Update the safe checkpoints for the task
-        _latestCheckpoints.keySet().forEach(task -> _safeCheckpoints.put(task, _latestCheckpoints.get(task)));
-
-        LOG.info("Checkpoints have been successfully committed.");
-      } catch (Throwable t) {
-        throw new RuntimeException(String.format("Checkpoint commit failed, tasks = [%s].", _tasks), t);
-      }
-    }
-
-    _pendingCheckpoint = false;
-
-    LOG.info("Safe checkpoints: " + _safeCheckpoints);
-  }
-
-  /**
-   * @return a map of safe checkpoints per task, per partition.
-   * This is internally used by DatastreamTaskImpl. Connectors
-   * are expected to all {@link DatastreamTask#getCheckpoints()}.
-   */
-  public synchronized Map<DatastreamTask, Map<Integer, String>> getSafeCheckpoints() {
-    return _safeCheckpoints;
-  }
-
-  /**
-   * shutdown should only be called when all tasks associated with it are out of mission.
-   * It is the responsibility of the {@link EventProducerPool} to ensure this.
-   */
-  public void shutdown() {
-    LOG.info("Shutting down event producer for " + _tasks);
-    try {
-      _transportProvider.close();
-    } catch (TransportException e) {
-      LOG.warn("Closing the TransportProvider failed with exception", e);
-    }
-    _checkpointHandler.shutdown();
-    _shutdownCompleted = true;
+  public void flush() {
+    _eventProducer.flush();
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -162,10 +162,10 @@ public class DatastreamTaskImpl implements DatastreamTask {
   @Override
   public Map<Integer, String> getCheckpoints() {
     // There is only one implementation of EventProducer so it's safe to cast
-    DatastreamEventProducerImpl impl = (DatastreamEventProducerImpl) _eventProducer;
+    EventProducer impl = (EventProducer) _eventProducer;
     // Checkpoint map of the owning task must be present in the producer
     Validate.isTrue(impl.getSafeCheckpoints().containsKey(this), "null checkpoints for task: " + this);
-    return impl.getSafeCheckpoints().get(this);
+    return ((EventProducer) _eventProducer).getSafeCheckpoints().get(this);
   }
 
   @JsonIgnore

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderFactory.java
@@ -22,7 +22,7 @@ public class DummyTransportProviderFactory implements TransportProviderFactory {
       }
 
       @Override
-      public void send(DatastreamEventRecord record) {
+      public void send(String destination, DatastreamEventRecord record) {
 
       }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -1,0 +1,317 @@
+package com.linkedin.datastream.server;
+
+import com.linkedin.datastream.common.DatastreamEvent;
+import com.linkedin.datastream.common.JsonUtils;
+import com.linkedin.datastream.common.PollUtils;
+import com.linkedin.datastream.common.VerifiableProperties;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryException;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
+import com.linkedin.datastream.server.api.transport.TransportException;
+import com.linkedin.datastream.server.api.transport.TransportProvider;
+import com.linkedin.datastream.server.providers.CheckpointProvider;
+
+import org.apache.avro.Schema;
+import org.apache.commons.lang.Validate;
+import org.codehaus.jackson.type.TypeReference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+* EventProducer class uses the transport to send events and handles save/restore checkpoints
+* automatically if {@link EventProducer.CheckpointPolicy#DATASTREAM} is specified.
+* Otherwise, it exposes the safe checkpoints which are guaranteed to have been flushed.
+*/
+public class EventProducer {
+  private static final Logger LOG = LoggerFactory.getLogger(DatastreamEventProducerImpl.class);
+
+  /**
+   * Policy for checkpoint handling
+   */
+  enum CheckpointPolicy {
+    DATASTREAM,
+    CUSTOM
+  }
+
+  public static final String INVALID_CHECKPOINT = "";
+  public static final String CHECKPOINT_PERIOD_MS = "checkpointPeriodMs";
+  public static final Integer DEFAULT_CHECKPOINT_PERIOD_MS = 1000;
+  public static final Integer SHUTDOWN_POLL_MS = 1000;
+  public static final Integer SHUTDOWN_POLL_PERIOD_MS = 50;
+
+  // List of tasks the producer is responsible for
+  private final List<DatastreamTask> _tasks;
+
+  private final TransportProvider _transportProvider;
+  private final CheckpointProvider _checkpointProvider;
+  private final CheckpointPolicy _checkpointPolicy;
+
+  // This stores the latest "dirty" checkpoint that we received
+  // from send() call but haven't been flushed on the transport.
+  // One one checkpoint is needed since connector only need to
+  // fulfill all the tasks by only producing any one of them,
+  // hence producer just need to store one dirty checkpoint and
+  // update all tasks in _safeCheckpoints with this.
+  private Map<DatastreamTask, Map<Integer, String>> _latestCheckpoints;
+
+  // This stores the checkpoints that have been recently flushed such that
+  // are safe to be committed to the source consumption tracking system.
+  private Map<DatastreamTask, Map<Integer, String>> _safeCheckpoints;
+
+  private Map<DatastreamTask, String> _pendingCheckpoints;
+
+  // Helper for periodical flush/checkpoint operations
+  private final CheckpointHandler _checkpointHandler;
+
+  private volatile boolean _pendingCheckpoint = false;
+  private volatile boolean _shutdownCompleted = false;
+
+  /**
+   * Flush transport periodically and save checkpoints.
+   * Default period is 1 second.
+   */
+  class CheckpointHandler implements Runnable {
+    private final Long _periodMs;
+    private final ScheduledExecutorService _executor;
+
+    public CheckpointHandler(Properties config) {
+      VerifiableProperties props = new VerifiableProperties(config);
+      _periodMs = props.getLong(CHECKPOINT_PERIOD_MS, DEFAULT_CHECKPOINT_PERIOD_MS);
+      _executor = new ScheduledThreadPoolExecutor(1);
+      _executor.scheduleAtFixedRate(this, 0, _periodMs, TimeUnit.MILLISECONDS);
+    }
+
+    public void shutdown() {
+      LOG.info(String.format("Shutdown requested, tasks = [%s].", _tasks));
+
+      // Initial shutdown and interrupt the thread
+      _executor.shutdown();
+
+      // Poll for 1 second for the thread to actually exit
+      PollUtils.poll(() -> _executor.isTerminated(), SHUTDOWN_POLL_MS, SHUTDOWN_POLL_PERIOD_MS);
+
+      // Final flush
+      flushAndCheckpoint();
+
+      LOG.info(String.format("Shutdown finished, tasks = [%s].", _tasks));
+    }
+
+    private void flushAndCheckpoint() {
+      try {
+        flush();
+        LOG.debug(String.format("Checkpoint handler exited, tasks = [%s].", _tasks));
+      } catch (Throwable t) {
+        // Since have have handled all exceptions here, there would be no exceptions leaked
+        // to the executor, which will reschedules as usual so no explicit retry is needed.
+        LOG.error(String.format("Checkpoint failed, will retry after %d ms, reason = %s", _periodMs, t.getMessage()), t);
+      }
+    }
+
+    @Override
+    public void run() {
+      flushAndCheckpoint();
+    }
+  }
+
+  /**
+   * Construct a DatastreamEventProducerImpl instance.
+   * @param tasks list of tasks which have the same destination
+   * @param transportProvider event transport
+   * @param checkpointProvider checkpoint store
+   * @param config global config
+   * @param customCheckpointing decides whether Producer should use custom checkpointing or the datastream server
+   *                            provided checkpointing.
+   */
+  public EventProducer(List<DatastreamTask> tasks, TransportProvider transportProvider,
+      CheckpointProvider checkpointProvider, Properties config, boolean customCheckpointing) {
+    Validate.notNull(tasks, "null tasks");
+    Validate.notNull(transportProvider, "null transport provider");
+    Validate.notNull(checkpointProvider, "null checkpoint provider");
+    Validate.notNull(config, "null config");
+    Validate.notEmpty(tasks, "empty task list");
+
+    DatastreamTask task0 = tasks.get(0);
+    Set<Integer> knownPartitions = new HashSet<>();
+    for (DatastreamTask task : tasks) {
+      // Ensure all tasks are for the same destination
+      task.getDatastreamDestination().equals(task0.getDatastreamDestination());
+
+      // DatastreamTask should include at least one partition.
+      // This should be ensured by DatastreamTaskImpl's ctor.
+      Validate.notEmpty(task.getPartitions(), "null or empty partitions in: " + task);
+
+      // Ensure no duplicate partitions exist
+      for (Integer partition : task.getPartitions()) {
+        Validate.isTrue(!knownPartitions.contains(partition), "duplicate partition: " + partition);
+        knownPartitions.add(partition);
+      }
+    }
+
+    _tasks = tasks;
+    _transportProvider = transportProvider;
+    _checkpointProvider = checkpointProvider;
+
+    _checkpointPolicy = customCheckpointing ? CheckpointPolicy.CUSTOM : CheckpointPolicy.DATASTREAM;
+
+    _checkpointHandler = new CheckpointHandler(config);
+
+    // For DATASTREAM checkpoint policy, load initial checkpoints
+    if (_checkpointPolicy == CheckpointPolicy.DATASTREAM) {
+      loadCheckpoints();
+    }
+
+    _pendingCheckpoints = new HashMap<>();
+    _tasks.forEach(task -> _pendingCheckpoints.put(task, INVALID_CHECKPOINT));
+
+    // This can happen for first time run or custom checkpointing
+    if (_safeCheckpoints == null || _safeCheckpoints.size() == 0) {
+      _safeCheckpoints = new HashMap<>();
+      for (DatastreamTask task : tasks) {
+        Map<Integer, String> checkpoints = new HashMap<>();
+        _safeCheckpoints.put(task, checkpoints);
+        task.getPartitions().forEach(partition -> checkpoints.put(partition, INVALID_CHECKPOINT));
+      }
+    }
+
+    _latestCheckpoints = new HashMap<>(_safeCheckpoints);
+
+    LOG.info("Created event producer, tasks: " + _tasks + ", safe checkpoints: " + _safeCheckpoints);
+  }
+
+  private void loadCheckpoints() {
+    _safeCheckpoints = new HashMap<>();
+
+    Map<DatastreamTask, String> checkpoints = _checkpointProvider.getCommitted(_tasks);
+
+    // Instruct jackson to convert string keys to integer
+    TypeReference typeRef = new TypeReference<HashMap<Integer, String>>() {
+    };
+
+    for (DatastreamTask task : checkpoints.keySet()) {
+      String cpString = checkpoints.get(task);
+      try {
+        _safeCheckpoints.put(task, JsonUtils.fromJson(cpString, typeRef));
+      } catch (Exception e) {
+        throw new IllegalArgumentException(String.format(
+            "Failed to load checkpoints, task = %s, checkpoint = %s, error = %s", task, cpString, e.getMessage()), e);
+      }
+    }
+  }
+
+  private void validateEventRecord(DatastreamEventRecord record) {
+    Validate.notNull(record, "null event record.");
+    Validate.notNull(record.getEvents(), "null event payload.");
+    Validate.notNull(record.getCheckpoint(), "null event checkpoint.");
+  }
+
+  /**
+   * Send the event onto the underlying transport.
+   *
+   * @param record DatastreamEvent envelope
+   */
+  public synchronized void send(DatastreamTask task, DatastreamEventRecord record) {
+    // Prevent sending if we have been shutdown
+    if (_shutdownCompleted) {
+      throw new IllegalStateException("send() is not allowed on a shutdown producer");
+    }
+
+    validateEventRecord(record);
+
+    for (DatastreamEvent event : record.getEvents()) {
+      if (event.metadata == null) {
+        event.metadata = new HashMap<>();
+      }
+
+      event.key = event.key == null ? ByteBuffer.allocate(0) : event.key;
+      event.payload = event.payload == null ? ByteBuffer.allocate(0) : event.payload;
+      event.previous_payload = event.previous_payload == null ? ByteBuffer.allocate(0) : event.previous_payload;
+    }
+
+    try {
+      // Send the event to transport
+      _transportProvider.send(task.getDatastreamDestination().getConnectionString(), record);
+
+      // Update the checkpoint for the task/partition
+      _latestCheckpoints.get(task).put(record.getPartition(), record.getCheckpoint());
+
+      // Dirty the flag
+      _pendingCheckpoint = true;
+    } catch (TransportException e) {
+      LOG.info(String.format("Failed send the event %s exception %s", record, e));
+      throw new RuntimeException("Failed to send: " + record, e);
+    }
+  }
+
+  public synchronized void flush() {
+    if (!_pendingCheckpoint) {
+      return;
+    }
+
+    try {
+      LOG.info(String.format("Staring transport flush, tasks = [%s].", _tasks));
+
+      _transportProvider.flush();
+
+      LOG.info("Transport has been successfully flushed.");
+    } catch (Throwable t) {
+      throw new RuntimeException(String.format("Flush failed, tasks = [%s].", _tasks), t);
+    }
+    if (_checkpointPolicy == CheckpointPolicy.DATASTREAM) {
+      try {
+        LOG.info(String.format("Start committing checkpoints, cpMap = %s, tasks = [%s].", _pendingCheckpoints, _tasks));
+
+        // Populate checkpoint map for checkpoint provider
+        _latestCheckpoints.keySet().forEach(
+            task -> _pendingCheckpoints.put(task, JsonUtils.toJson(_latestCheckpoints.get(task))));
+
+        _checkpointProvider.commit(_pendingCheckpoints);
+
+        // Update the safe checkpoints for the task
+        _latestCheckpoints.keySet().forEach(task -> _safeCheckpoints.put(task, _latestCheckpoints.get(task)));
+
+        LOG.info("Checkpoints have been successfully committed.");
+      } catch (Throwable t) {
+        throw new RuntimeException(String.format("Checkpoint commit failed, tasks = [%s].", _tasks), t);
+      }
+    }
+
+    _pendingCheckpoint = false;
+
+    LOG.info("Safe checkpoints: " + _safeCheckpoints);
+  }
+
+  /**
+   * @return a map of safe checkpoints per task, per partition.
+   * This is internally used by DatastreamTaskImpl. Connectors
+   * are expected to all {@link DatastreamTask#getCheckpoints()}.
+   */
+  public synchronized Map<DatastreamTask, Map<Integer, String>> getSafeCheckpoints() {
+    return _safeCheckpoints;
+  }
+
+  /**
+   * shutdown should only be called when all tasks associated with it are out of mission.
+   * It is the responsibility of the {@link EventProducerPool} to ensure this.
+   */
+  public void shutdown() {
+    LOG.info("Shutting down event producer for " + _tasks);
+    try {
+      _transportProvider.close();
+    } catch (TransportException e) {
+      LOG.warn("Closing the TransportProvider failed with exception", e);
+    }
+    _checkpointHandler.shutdown();
+    _shutdownCompleted = true;
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
@@ -28,8 +28,10 @@ public class TestEventProducerPool {
     CheckpointProvider checkpointProvider = mock(CheckpointProvider.class);
     TransportProvider transportProvider = mock(TransportProvider.class);
     Properties config = new Properties();
-    config.put(DatastreamEventProducerImpl.CHECKPOINT_PERIOD_MS, "50");
-    _eventProducerPool = new EventProducerPool(checkpointProvider, transportProvider, null, config);
+    config.put(EventProducer.CHECKPOINT_PERIOD_MS, "50");
+    _eventProducerPool =
+        new EventProducerPool(checkpointProvider, transportProvider, null,
+            config);
   }
 
   @Test
@@ -133,7 +135,8 @@ public class TestEventProducerPool {
         _eventProducerPool.getEventProducers(tasks, connectorType, false, new ArrayList<>());
 
     // Check if producers are reused
-    Assert.assertTrue(taskProducerMap.get(tasks.get(0)) == taskProducerMap.get(tasks.get(2)));
+    Assert.assertTrue(((DatastreamEventProducerImpl) taskProducerMap.get(tasks.get(0))).getEventProducer()
+        == ((DatastreamEventProducerImpl) taskProducerMap.get(tasks.get(2))).getEventProducer());
   }
 
   @Test
@@ -147,7 +150,7 @@ public class TestEventProducerPool {
     tasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(2)));
     String connectorType = "connectorType";
 
-    List<DatastreamEventProducer> unusedProducers = new ArrayList<>();
+    List<EventProducer> unusedProducers = new ArrayList<>();
     Map<DatastreamTask, DatastreamEventProducer> taskProducerMap1 =
             _eventProducerPool.getEventProducers(tasks, connectorType, false, unusedProducers);
 


### PR DESCRIPTION
DatastreamEventRecord right now requires task to be instantiated. But the producer that the connector will use to send the eventrecord is associated with the task. There can be discrepencies between these two. To avoid this and also make the instantiation of the DatastreamEventRecord simpler, This change decouples the task from the DatastreamEventRecord.
