### PR TITLE
Adding config prefix for connectors and kafka Transport provider

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -4,16 +4,15 @@ datastream.server.coordinator.cluster=DATASTREAM_CLUSTER
 datastream.server.coordinator.zkAddress=localhost:2181
 datastream.server.httpPort=32311
 datastream.server.coordinator.transportProviderFactory=com.linkedin.datastream.kafka.KafkaTransportProviderFactory
-datastream.server.connectorTypes=File
+datastream.server.connectorTypes=file
 
 ########################### Transport provider configs ######################
 
-datastream.server.transportProvider.bootstrap.servers=localhost:9092
-datastream.server.transportProvider.client.id=DevKafkaClientId
-datastream.server.transportProvider.zookeeper.connect=localhost:2181
+datastream.server.transportProvider.kafka.bootstrap.servers=localhost:9092
+datastream.server.transportProvider.kafka.zookeeper.connect=localhost:2181
 
 ########################### File connector Configs ######################
 
-File.factoryClassName=com.linkedin.datastream.connectors.file.FileConnectorFactory
-File.assignmentStrategy=com.linkedin.datastream.server.assignment.BroadcastStrategy
+datastream.server.connector.file.factoryClassName=com.linkedin.datastream.connectors.file.FileConnectorFactory
+datastream.server.connector.file.assignmentStrategy=com.linkedin.datastream.server.assignment.BroadcastStrategy
 

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderFactory.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderFactory.java
@@ -14,9 +14,13 @@ import com.linkedin.datastream.server.api.transport.TransportProviderFactory;
  */
 public class KafkaTransportProviderFactory implements TransportProviderFactory {
 
+  public static final String KAFKA_CONFIG_PREFIX = "kafka";
+
   @Override
   public TransportProvider createTransportProvider(Properties config) {
     Validate.notNull(config, "null config");
+    VerifiableProperties kafkaProps = new VerifiableProperties(config);
+    kafkaProps.getDomainProperties(KAFKA_CONFIG_PREFIX);
     return new KafkaTransportProvider(config);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -40,6 +40,7 @@ public class DatastreamServer {
   public static final String CONFIG_CONNECTOR_CUSTOM_CHECKPOINTING = "customCheckpointing";
 
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamServer.class.getName());
+  private static final String CONNECTOR_CONFIG_PREFIX = "datastream.server.connector.";
 
   private Coordinator _coordinator;
   private DatastreamStore _datastreamStore;
@@ -128,7 +129,7 @@ public class DatastreamServer {
     LOG.info("Loading connectors.");
     _bootstrapConnectors = new HashMap<>();
     for (String connectorStr : connectorTypes) {
-      initializeConnector(connectorStr, verifiableProperties.getDomainProperties(connectorStr));
+      initializeConnector(connectorStr, verifiableProperties.getDomainProperties(CONNECTOR_CONFIG_PREFIX + connectorStr));
     }
 
     LOG.info("Setting up DMS endpoint server.");


### PR DESCRIPTION
- Adding the config prefix "datastream.server.connector." to the connector properties
- Adding the config prefix for the kafka transport provider
- Removing the unused config.
