### PR TITLE
Shutdown all active producers in producer pool

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -235,6 +235,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
         LOG.warn("Exception caught while stopping coordinator", e);
       }
     }
+
+    _eventProducerPool.shutdown();
+
     _adapter.disconnect();
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -305,6 +305,10 @@ public class EventProducer {
    * It is the responsibility of the {@link EventProducerPool} to ensure this.
    */
   public void shutdown() {
+    if (_shutdownCompleted) {
+      return;
+    }
+
     LOG.info("Shutting down event producer for " + _tasks);
     try {
       _transportProvider.close();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
@@ -97,7 +97,7 @@ public class EventProducerPool {
         unusedProducerMap.remove(destination);
       } else {
         LOG.info(String.format("Creating new message producer for destination %s and task %s", destination, task));
-        ArrayList<DatastreamTask> tasksPerProducer = new ArrayList<DatastreamTask>();
+        ArrayList<DatastreamTask> tasksPerProducer = new ArrayList<>();
         tasksPerProducer.add(task);
         EventProducer
             eventProducer = new EventProducer(tasksPerProducer, _transportProvider,
@@ -121,5 +121,21 @@ public class EventProducerPool {
     unusedProducers.addAll(unusedProducerMap.values());
 
     return taskProducerMapping;
+  }
+
+  /**
+   * Shutdown all outstanding event producers. This should only be called by Coordinator.shutdown()
+   */
+  public synchronized void shutdown() {
+    if (_producers.size() == 0) {
+      return;
+    }
+
+    LOG.info("Shutting down all producers in event producer pool");
+    for (Map<String, EventProducer> producerMap : _producers.values()) {
+      producerMap.values().forEach(producer -> producer.shutdown());
+    }
+
+    _producers.clear();
   }
 }


### PR DESCRIPTION
This is necessary to release the transport providers during DMS shutdown.
Without this, transport provider leaks the transport resource.
