### PR TITLE
Support for connectors to specify the number of partitions in the destination

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream;
 import java.io.IOException;
 import java.util.Properties;
 
+import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.connectors.DummyBootstrapConnector;
 import com.linkedin.datastream.connectors.DummyBootstrapConnectorFactory;
@@ -89,6 +90,7 @@ public class TestDatastreamRestClient {
     restClient.createDatastream(datastream);
     Datastream createdDatastream = restClient.getDatastream(datastream.getName());
     LOG.info("Created Datastream : " + createdDatastream);
+    datastream.setDestination(new DatastreamDestination());
     Assert.assertEquals(createdDatastream, datastream);
   }
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamSource.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamSource.java
@@ -16,14 +16,15 @@ import com.linkedin.data.template.SetMode;
  * Datastream source that connector will use to consume events
  * 
  */
-@Generated(value = "com.linkedin.pegasus.generator.PegasusDataTemplateGenerator", comments = "LinkedIn Data Template. Generated from /Users/spunuru/datastream/ds/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc.", date = "Wed Dec 09 10:45:32 PST 2015")
+@Generated(value = "com.linkedin.pegasus.generator.PegasusDataTemplateGenerator", comments = "LinkedIn Data Template. Generated from /Users/spunuru/datastream/ds/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc.", date = "Fri Jan 15 13:18:15 PST 2016")
 public class DatastreamSource
     extends RecordTemplate
 {
 
     private final static DatastreamSource.Fields _fields = new DatastreamSource.Fields();
-    private final static RecordDataSchema SCHEMA = ((RecordDataSchema) DataTemplateUtil.parseSchema("{\"type\":\"record\",\"name\":\"DatastreamSource\",\"namespace\":\"com.linkedin.datastream.common\",\"doc\":\"Datastream source that connector will use to consume events\",\"fields\":[{\"name\":\"connectionString\",\"type\":\"string\",\"doc\":\"Source connection string to consume the data from.\"}]}"));
+    private final static RecordDataSchema SCHEMA = ((RecordDataSchema) DataTemplateUtil.parseSchema("{\"type\":\"record\",\"name\":\"DatastreamSource\",\"namespace\":\"com.linkedin.datastream.common\",\"doc\":\"Datastream source that connector will use to consume events\",\"fields\":[{\"name\":\"connectionString\",\"type\":\"string\",\"doc\":\"Source connection string to consume the data from.\"},{\"name\":\"partitions\",\"type\":\"int\",\"doc\":\"Number of partitions in the source.\"}]}"));
     private final static RecordDataSchema.Field FIELD_ConnectionString = SCHEMA.getField("connectionString");
+    private final static RecordDataSchema.Field FIELD_Partitions = SCHEMA.getField("partitions");
 
     public DatastreamSource() {
         super(new DataMap(), SCHEMA);
@@ -93,6 +94,72 @@ public class DatastreamSource
         return this;
     }
 
+    /**
+     * Existence checker for partitions
+     * 
+     * @see Fields#partitions
+     */
+    public boolean hasPartitions() {
+        return contains(FIELD_Partitions);
+    }
+
+    /**
+     * Remover for partitions
+     * 
+     * @see Fields#partitions
+     */
+    public void removePartitions() {
+        remove(FIELD_Partitions);
+    }
+
+    /**
+     * Getter for partitions
+     * 
+     * @see Fields#partitions
+     */
+    public Integer getPartitions(GetMode mode) {
+        return obtainDirect(FIELD_Partitions, Integer.class, mode);
+    }
+
+    /**
+     * Getter for partitions
+     * 
+     * @see Fields#partitions
+     */
+    public Integer getPartitions() {
+        return getPartitions(GetMode.STRICT);
+    }
+
+    /**
+     * Setter for partitions
+     * 
+     * @see Fields#partitions
+     */
+    public DatastreamSource setPartitions(Integer value, SetMode mode) {
+        putDirect(FIELD_Partitions, Integer.class, Integer.class, value, mode);
+        return this;
+    }
+
+    /**
+     * Setter for partitions
+     * 
+     * @see Fields#partitions
+     */
+//    public DatastreamSource setPartitions(Integer value) {
+//        putDirect(FIELD_Partitions, Integer.class, Integer.class, value, SetMode.DISALLOW_NULL);
+//        return this;
+//    }
+
+    /**
+     * Setter for partitions
+     * 
+     * @see Fields#partitions
+     */
+    public DatastreamSource setPartitions(int value) {
+        putDirect(FIELD_Partitions, Integer.class, Integer.class, value, SetMode.DISALLOW_NULL);
+        return this;
+    }
+
     @Override
     public DatastreamSource clone()
         throws CloneNotSupportedException
@@ -126,6 +193,14 @@ public class DatastreamSource
          */
         public PathSpec connectionString() {
             return new PathSpec(getPathComponents(), "connectionString");
+        }
+
+        /**
+         * Number of partitions in the source.
+         * 
+         */
+        public PathSpec partitions() {
+            return new PathSpec(getPathComponents(), "partitions");
         }
 
     }

--- a/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc
+++ b/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc
@@ -26,6 +26,11 @@
             "name": "connectionString",
             "doc": "Source connection string to consume the data from.",
             "type": "string"
+          },
+          {
+            "name": "partitions",
+            "doc": "Number of partitions in the source.",
+            "type": "int"
           }
         ]
       }
@@ -45,7 +50,7 @@
           },
           {
             "name": "partitions",
-            "doc": "Number of partitions of the kafka topic.",
+            "doc": "Number of partitions in the destination.",
             "type": "int"
           }
         ]

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -6,6 +6,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.server.api.connector.Connector;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 
@@ -109,6 +110,9 @@ public class ConnectorWrapper {
     logApiStart("initializeDatastream");
 
     try {
+      if(!stream.hasDestination()) {
+        stream.setDestination(new DatastreamDestination());
+      }
       _connector.initializeDatastream(stream);
     } catch (Exception ex) {
       logErrorAndException("initializeDatastream", ex);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -100,8 +100,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
 
   private Set<DatastreamTask> createTasksForDatastream(Datastream datastream, int maxTasksPerDatastream) {
     int numberOfDatastreamPartitions = 1;
-    if(datastream.hasDestination() && datastream.getDestination().hasPartitions()) {
-      numberOfDatastreamPartitions = datastream.getDestination().getPartitions();
+    if(datastream.hasSource() && datastream.getSource().hasPartitions()) {
+      numberOfDatastreamPartitions = datastream.getSource().getPartitions();
     }
     int tasksPerDatastream = maxTasksPerDatastream < numberOfDatastreamPartitions ? maxTasksPerDatastream : numberOfDatastreamPartitions;
     Set<DatastreamTask> tasks = new HashSet<>();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -181,7 +181,6 @@ public class TestCoordinator {
 
       @Override
       public void initializeDatastream(Datastream stream) {
-
       }
     };
     coordinator.addConnector(testConectorType, testConnector, new BroadcastStrategy(), false);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
@@ -17,17 +17,13 @@ import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
 
-
 public class TestLoadbalancingStrategy {
 
   @Test
   public void testLoadbalancingStrategy_DistributesTasks_AcrossInstancesEqually() {
     String[] instances = new String[] { "instance1", "instance2", "instance3" };
     List<Datastream> datastreams =  Arrays.asList(DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1"));
-    datastreams.forEach(x -> {
-      x.setDestination(new DatastreamDestination());
-      x.getDestination().setPartitions(12);
-    });
+    datastreams.forEach(x -> x.getSource().setPartitions(12));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
         strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
@@ -41,10 +37,7 @@ public class TestLoadbalancingStrategy {
   public void testLoadbalancingStrategy_CreatesTasks_OnlyForPartitionsInDestination() {
     String[] instances = new String[] { "instance1", "instance2", "instance3" };
     List<Datastream> datastreams =  Arrays.asList(DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1"));
-    datastreams.forEach(x -> {
-      x.setDestination(new DatastreamDestination());
-      x.getDestination().setPartitions(2);
-    });
+    datastreams.forEach(x -> x.getSource().setPartitions(2));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
         strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
@@ -61,10 +54,7 @@ public class TestLoadbalancingStrategy {
   public void testLoadbalancingStrategy_RedistributesTasks_WhenNodeGoesDown() {
     String[] instances = new String[] { "instance1", "instance2", "instance3" };
     List<Datastream> datastreams =  Arrays.asList(DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1"));
-    datastreams.forEach(x -> {
-      x.setDestination(new DatastreamDestination());
-      x.getDestination().setPartitions(12);
-    });
+    datastreams.forEach(x -> x.getSource().setPartitions(12));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
         strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
@@ -85,10 +75,7 @@ public class TestLoadbalancingStrategy {
   public void testLoadbalancingStrategy_RedistributesTasks_WhenNodeIsAdded() {
     String[] instances = new String[] { "instance1", "instance2" };
     List<Datastream> datastreams =  Arrays.asList(DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1"));
-    datastreams.forEach(x -> {
-      x.setDestination(new DatastreamDestination());
-      x.getDestination().setPartitions(12);
-    });
+    datastreams.forEach(x -> x.getSource().setPartitions(12));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
         strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
@@ -110,10 +97,7 @@ public class TestLoadbalancingStrategy {
   public void testLoadbalancingStrategy_CreatesNewDatastreamTasks_WhenNewDatastreamIsAdded() {
     String[] instances = new String[] { "instance1", "instance2", "instance3" };
     List<Datastream> datastreams =  Arrays.asList(DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1"));
-    datastreams.forEach(x -> {
-      x.setDestination(new DatastreamDestination());
-      x.getDestination().setPartitions(12);
-    });
+    datastreams.forEach(x -> x.getSource().setPartitions(12));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
         strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
@@ -125,8 +109,7 @@ public class TestLoadbalancingStrategy {
     datastreams = new ArrayList<>(datastreams);
     datastreams.add(DatastreamTestUtils.createDatastream(DummyConnector.CONNECTOR_TYPE, "ds2", "source"));
     datastreams.forEach(x -> {
-      x.setDestination(new DatastreamDestination());
-      x.getDestination().setPartitions(12);
+      x.getSource().setPartitions(12);
     });
 
     Map<String, Set<DatastreamTask>> newAssignment =
@@ -141,10 +124,7 @@ public class TestLoadbalancingStrategy {
   public void testLoadbalancingStrategy_RemovesTasks_WhenDatastreamIsDeleted() {
     String[] instances = new String[] { "instance1", "instance2", "instance3" };
     List<Datastream> datastreams =  Arrays.asList(DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1", "ds2"));
-    datastreams.forEach(x -> {
-      x.setDestination(new DatastreamDestination());
-      x.getDestination().setPartitions(12);
-    });
+    datastreams.forEach(x -> x.getSource().setPartitions(12));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
         strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -10,6 +10,7 @@ import org.testng.annotations.Test;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.server.TestDatastreamServer;
@@ -74,13 +75,15 @@ public class TestDatastreamResources {
     Datastream ds = resource1.get("name_0");
     Assert.assertNull(ds);
 
-    CreateResponse response = resource1.create(generateDatastream(0));
+    Datastream datastreamToCreate = generateDatastream(0);
+    CreateResponse response = resource1.create(datastreamToCreate);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
 
     ds = resource2.get("name_0");
     Assert.assertNotNull(ds);
-    Assert.assertTrue(ds.equals(generateDatastream(0)));
+    datastreamToCreate.setDestination(new DatastreamDestination());
+    Assert.assertEquals(ds, datastreamToCreate);
   }
 
   @Test


### PR DESCRIPTION
Connectors should be able to specifiy the number of partitions in the source. But right now we are not honoring that field when we create the topic. Fix is to use the number of partitions that connector specify when we create the topic only if the destination doesn't already have the partitions set.  

Updated the DatastreamServer integration test to validate whether the topic is created with the appropriate number of partitions.
