### PR TITLE
Add helper methods to create task status

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTaskStatus.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTaskStatus.java
@@ -24,6 +24,32 @@ public class DatastreamTaskStatus {
   }
 
   /**
+   * Helper method to create an OK status.
+   * @return OK task status
+   */
+  public static DatastreamTaskStatus OK() {
+    return new DatastreamTaskStatus(Code.OK, "OK");
+  }
+
+  /**
+   * Helper method to create an OK status.
+   * @param message message to return
+   * @return OK task status
+   */
+  public static DatastreamTaskStatus OK(String message) {
+    return new DatastreamTaskStatus(Code.OK, message);
+  }
+
+  /**
+   * Helper method to create an ERROR status
+   * @param message
+   * @return ERROR task status
+   */
+  public static DatastreamTaskStatus ERROR(String message) {
+    return new DatastreamTaskStatus(Code.ERROR, message);
+  }
+
+  /**
    * @return kind of the status
    */
   public Code getCode() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -399,7 +399,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
           taskImpl.setEventProducer(producerMap.get(task));
           newAssignment.add(task);
         } else {
-          taskImpl.setStatus(new DatastreamTaskStatus(DatastreamTaskStatus.Code.ERROR, "Producer is missing"));
+          taskImpl.setStatus(DatastreamTaskStatus.ERROR("Producer is missing"));
           LOG.error("Event producer not created for datastream task: " + task);
         }
       }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -188,7 +188,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
       _zkAdapter.acquireTask(this, timeout);
     } catch (DatastreamException e) {
       LOG.error("Failed to acquire task: " + this, e);
-      setStatus(new DatastreamTaskStatus(DatastreamTaskStatus.Code.ERROR, "Acquire failed, exception: " + e));
+      setStatus(DatastreamTaskStatus.ERROR("Acquire failed, exception: " + e));
       throw e;
     }
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -26,7 +26,7 @@ public class TestDatastreamTask {
 
   @Test
   public void testTaskStatus_JsonIO() {
-    String json = JsonUtils.toJson(new DatastreamTaskStatus(DatastreamTaskStatus.Code.ERROR, "test msg"));
+    String json = JsonUtils.toJson(DatastreamTaskStatus.ERROR("test msg"));
     JsonUtils.fromJson(json, DatastreamTaskStatus.class);
   }
 }


### PR DESCRIPTION
Trivial change: adding two helper methods for creating the OK/ERROR status which is a little unwieldy to create. 
