### PR TITLE
Refactoring the Embedded Datastream cluster so that we can use pluggable kafka for testing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -110,6 +110,7 @@ project(':datastream-utils') {
   dependencies {
     compile project(':datastream-common')
     compile "com.101tec:zkclient:$zkclientVersion"
+    testCompile project(':datastream-kafka')
     testCompile project(':datastream-testcommon')
   }
 }
@@ -169,6 +170,7 @@ project(':datastream-client') {
     compile project(':datastream-utils')
 
     testCompile project(':datastream-testcommon')
+    testCompile project(':datastream-kafka')
     testCompile project(':datastream-server')
   }
 }

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -10,7 +10,7 @@ import com.linkedin.datastream.connectors.DummyBootstrapConnectorFactory;
 import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.connectors.DummyConnectorFactory;
 import com.linkedin.datastream.server.DummyTransportProviderFactory;
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.kafka.EmbeddedZookeeper;
 import org.apache.log4j.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -97,7 +97,7 @@ public class TestDatastreamRestClient {
   @Test(expectedExceptions = DatastreamNotFoundException.class)
   public void testDeleteDatastream()
       throws DatastreamException {
-    Datastream datastream = generateDatastream(1);
+    Datastream datastream = generateDatastream(2);
     LOG.info("Datastream : " + datastream);
     DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
     restClient.createDatastream(datastream);

--- a/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaCluster.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaCluster.java
@@ -1,0 +1,32 @@
+package com.linkedin.datastream.kafka;
+
+/**
+ * Interface to control the kafka cluster that is setup during testing.
+ */
+public interface KafkaCluster {
+
+  /**
+   * @return the brokers that are part of the kafka cluster.
+   */
+  String getBrokers();
+
+  /**
+   * @return the zookeeper connection string used by the kafka cluster.
+   */
+  String getZkConnection();
+
+  /**
+   * @return whether the kafka cluster is started or not.
+   */
+  boolean isStarted();
+
+  /**
+   * Start the kafka cluster.
+   */
+  void startup();
+
+  /**
+   * Stop the kafka cluster.
+   */
+  void shutdown();
+}

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedKafkaCluster.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedKafkaCluster.java
@@ -1,4 +1,4 @@
-package com.linkedin.datastream.server;
+package com.linkedin.datastream.kafka;
 
 /*
  * Copyright 2015 LinkedIn Corp. All rights reserved
@@ -24,7 +24,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
 
-import com.linkedin.datastream.testutil.TestUtils;
+import com.linkedin.datastream.common.FileUtils;
+import com.linkedin.datastream.common.NetworkUtils;
 
 import kafka.server.KafkaConfig;
 import kafka.server.KafkaServer;
@@ -73,7 +74,7 @@ public class EmbeddedKafkaCluster {
 
   private int resolvePort(int port) {
     if (port == -1) {
-      return TestUtils.getAvailablePort();
+      return NetworkUtils.getAvailablePort();
     }
     return port;
   }
@@ -92,7 +93,7 @@ public class EmbeddedKafkaCluster {
   public void startup() {
     for (int i = 0; i < _ports.size(); i++) {
       Integer port = _ports.get(i);
-      File logDir = TestUtils.constructTempDir("kafka-local-" + port);
+      File logDir = FileUtils.constructRandomDirectoryInTempDir("kafka-local-" + port);
 
       Properties properties = new Properties();
       properties.putAll(_baseProperties);
@@ -164,7 +165,7 @@ public class EmbeddedKafkaCluster {
     }
     for (File logDir : _logDirs) {
       try {
-        TestUtils.deleteFile(logDir);
+        FileUtils.deleteFile(logDir);
       } catch (FileNotFoundException e) {
         e.printStackTrace();
       }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedZookeeper.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedZookeeper.java
@@ -1,4 +1,4 @@
-package com.linkedin.datastream.testutil;
+package com.linkedin.datastream.kafka;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -8,6 +8,9 @@ import java.net.InetSocketAddress;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
+
+import com.linkedin.datastream.common.FileUtils;
+import com.linkedin.datastream.common.NetworkUtils;
 
 
 public class EmbeddedZookeeper {
@@ -35,18 +38,18 @@ public class EmbeddedZookeeper {
 
   private int resolvePort(int port) {
     if (port == -1) {
-      return TestUtils.getAvailablePort();
+      return NetworkUtils.getAvailablePort();
     }
     return port;
   }
 
   public void startup() throws IOException {
     if (this.port == -1) {
-      this.port = TestUtils.getAvailablePort();
+      this.port = NetworkUtils.getAvailablePort();
     }
     this.factory = NIOServerCnxnFactory.createFactory(new InetSocketAddress("localhost", port), 1024);
-    this.snapshotDir = TestUtils.constructTempDir("embedded-zk/snapshot-" + this.port);
-    this.logDir = TestUtils.constructTempDir("embedded-zk/log-" + this.port);
+    this.snapshotDir = FileUtils.constructRandomDirectoryInTempDir("embedded-zk/snapshot-" + this.port);
+    this.logDir = FileUtils.constructRandomDirectoryInTempDir("embedded-zk/log-" + this.port);
 
     try {
       factory.startup(new ZooKeeperServer(snapshotDir, logDir, tickTime));
@@ -63,12 +66,12 @@ public class EmbeddedZookeeper {
 
     factory.shutdown();
     try {
-      TestUtils.deleteFile(snapshotDir);
+      FileUtils.deleteFile(snapshotDir);
     } catch (FileNotFoundException e) {
       // ignore
     }
     try {
-      TestUtils.deleteFile(logDir);
+      FileUtils.deleteFile(logDir);
     } catch (FileNotFoundException e) {
       // ignore
     }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedZookeeperKafkaCluster.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedZookeeperKafkaCluster.java
@@ -1,0 +1,56 @@
+package com.linkedin.datastream.kafka;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+
+public class EmbeddedZookeeperKafkaCluster implements KafkaCluster {
+  private EmbeddedZookeeper _embeddedZookeeper = null;
+  private EmbeddedKafkaCluster _embeddedKafkaCluster = null;
+  private boolean _isStarted;
+
+  public EmbeddedZookeeperKafkaCluster() {
+    _embeddedZookeeper = new EmbeddedZookeeper(-1);
+    List<Integer> kafkaPorts = new ArrayList<>();
+    // -1 for any available port
+    kafkaPorts.add(-1);
+    kafkaPorts.add(-1);
+    _embeddedKafkaCluster = new EmbeddedKafkaCluster(_embeddedZookeeper.getConnection(), new Properties(), kafkaPorts);
+    _isStarted = false;
+  }
+
+  @Override
+  public String getBrokers() {
+    return _embeddedKafkaCluster.getBrokers();
+  }
+
+  @Override
+  public String getZkConnection() {
+    return _embeddedKafkaCluster.getZkConnection();
+  }
+
+  @Override
+  public boolean isStarted() {
+    return _isStarted;
+  }
+
+  @Override
+  public void startup() {
+    try {
+      _embeddedZookeeper.startup();
+    } catch (IOException e) {
+      throw new RuntimeException("Starting zookeeper failed with exception", e);
+    }
+    _embeddedKafkaCluster.startup();
+    _isStarted = true;
+  }
+
+  @Override
+  public void shutdown() {
+    _embeddedKafkaCluster.shutdown();
+    _embeddedZookeeper.shutdown();
+    _isStarted = false;
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -32,7 +32,7 @@ import com.linkedin.datastream.server.assignment.BroadcastStrategy;
 import com.linkedin.datastream.server.assignment.LoadbalancingStrategy;
 import com.linkedin.datastream.server.dms.DatastreamResources;
 import com.linkedin.datastream.server.zk.KeyBuilder;
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.kafka.EmbeddedZookeeper;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.CreateResponse;
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -29,6 +29,7 @@ import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.connectors.DummyConnectorFactory;
 import com.linkedin.datastream.connectors.file.FileConnector;
 import com.linkedin.datastream.connectors.file.FileConnectorFactory;
+import com.linkedin.datastream.kafka.EmbeddedZookeeperKafkaCluster;
 import com.linkedin.datastream.kafka.KafkaDestination;
 import com.linkedin.datastream.server.assignment.BroadcastStrategy;
 import com.linkedin.datastream.server.assignment.LoadbalancingStrategy;
@@ -53,7 +54,8 @@ public class TestDatastreamServer {
     Map<String, Properties> connectorProperties = new HashMap<>();
     connectorProperties.put(DUMMY_CONNECTOR, getDummyConnectorProperties(true));
     connectorProperties.put(DUMMY_BOOTSTRAP_CONNECTOR, getBootstrapConnectorProperties());
-    return EmbeddedDatastreamCluster.newTestDatastreamKafkaCluster(connectorProperties, new Properties());
+    return EmbeddedDatastreamCluster.newTestDatastreamCluster(new EmbeddedZookeeperKafkaCluster(), connectorProperties,
+        new Properties());
   }
 
   private static Properties getBootstrapConnectorProperties() {
@@ -68,7 +70,8 @@ public class TestDatastreamServer {
     Map<String, Properties> connectorProperties = new HashMap<>();
     connectorProperties.put(DUMMY_CONNECTOR, getDummyConnectorProperties(false));
     EmbeddedDatastreamCluster datastreamKafkaCluster =
-        EmbeddedDatastreamCluster.newTestDatastreamKafkaCluster(connectorProperties, override);
+        EmbeddedDatastreamCluster.newTestDatastreamCluster(new EmbeddedZookeeperKafkaCluster(), connectorProperties,
+            override);
     return datastreamKafkaCluster;
   }
 
@@ -97,7 +100,8 @@ public class TestDatastreamServer {
     connectorProperties.put(FILE_CONNECTOR, getTestConnectorProperties(strategy));
     connectorProperties.get(FILE_CONNECTOR).put(FileConnector.CFG_NUM_PARTITIONS, String.valueOf(numDestinationPartitions));
     EmbeddedDatastreamCluster datastreamKafkaCluster =
-        EmbeddedDatastreamCluster.newTestDatastreamKafkaCluster(connectorProperties, new Properties(), -1, numServers);
+        EmbeddedDatastreamCluster.newTestDatastreamCluster(new EmbeddedZookeeperKafkaCluster(), connectorProperties,
+            new Properties(), numServers);
     return datastreamKafkaCluster;
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
@@ -13,6 +13,7 @@ import org.testng.annotations.Test;
 
 import com.linkedin.datastream.connectors.DummyConnectorFactory;
 import com.linkedin.datastream.diagnostics.ServerHealth;
+import com.linkedin.datastream.kafka.EmbeddedZookeeperKafkaCluster;
 import com.linkedin.datastream.server.diagnostics.HealthBuilders;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.r2.transport.common.Client;
@@ -42,7 +43,8 @@ public class TestServerHealth {
     Map<String, Properties> connectorProperties = new HashMap<>();
     connectorProperties.put(TestDatastreamServer.DUMMY_CONNECTOR, getDummyConnectorProperties(false));
     EmbeddedDatastreamCluster datastreamKafkaCluster =
-        EmbeddedDatastreamCluster.newTestDatastreamKafkaCluster(connectorProperties, override, -1, 1);
+        EmbeddedDatastreamCluster.newTestDatastreamCluster(new EmbeddedZookeeperKafkaCluster(), connectorProperties,
+            override, 1);
     return datastreamKafkaCluster;
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
@@ -4,7 +4,7 @@ import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.zk.ZkClient;
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.kafka.EmbeddedZookeeper;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
@@ -15,7 +15,7 @@ import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.server.TestDestinationManager;
 import com.linkedin.datastream.server.zk.ZkAdapter;
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.kafka.EmbeddedZookeeper;
 
 
 public class TestZookeeperCheckpointProvider {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -6,9 +6,8 @@ import java.util.Collections;
 import java.util.List;
 
 import com.linkedin.datastream.common.PollUtils;
-import com.linkedin.datastream.server.dms.ZookeeperBackedDatastreamStore;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
-import org.I0Itec.zkclient.exception.ZkNoNodeException;
+
 import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,11 +16,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.kafka.EmbeddedZookeeper;
 
 
 public class TestZkAdapter {

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -20,49 +20,39 @@ package com.linkedin.datastream.server;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.locks.Lock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.Validate;
-import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.log4j.Logger;
 
 import com.linkedin.datastream.common.DatastreamException;
-import com.linkedin.datastream.kafka.KafkaTransportProvider;
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
-import com.linkedin.datastream.testutil.TestUtils;
+import com.linkedin.datastream.common.NetworkUtils;
+import com.linkedin.datastream.kafka.KafkaCluster;
 
 
 public class EmbeddedDatastreamCluster {
   private static final Logger LOG = Logger.getLogger(EmbeddedDatastreamCluster.class);
-  private static final Lock MUTEX = new ReentrantLock(true);
   private static final String KAFKA_TRANSPORT_FACTORY = "com.linkedin.datastream.kafka.KafkaTransportProviderFactory";
+  public static final String CONFIG_ZK_CONNECT = "zookeeper.connect";
+
+  public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";
 
   // the zookeeper ports that are currently taken
-  private static Set<Integer> _zkPorts = new HashSet<>();
+  private final KafkaCluster _kafkaCluster;
 
-  private EmbeddedZookeeper _embeddedZookeeper = null;
-  private EmbeddedKafkaCluster _embeddedKafkaCluster = null;
   private int _datastreamPort;
   private Properties _datastreamServerProperties;
   private int _numServers;
   private List<DatastreamServer> _servers;
 
-  private EmbeddedDatastreamCluster(Map<String, Properties> connectorProperties, Properties override, int zkPort, int numServers)
+  private EmbeddedDatastreamCluster(Map<String, Properties> connectorProperties, Properties override,
+      KafkaCluster kafkaCluster, int numServers)
       throws IOException {
-    _embeddedZookeeper = new EmbeddedZookeeper(zkPort);
-    List<Integer> kafkaPorts = new ArrayList<>();
-    // -1 for any available port
-    kafkaPorts.add(-1);
-    kafkaPorts.add(-1);
-    _embeddedKafkaCluster = new EmbeddedKafkaCluster(_embeddedZookeeper.getConnection(), new Properties(), kafkaPorts);
-    setupDatastreamProperties(_embeddedZookeeper.getConnection(), connectorProperties, override);
+    _kafkaCluster = kafkaCluster;
+    setupDatastreamProperties(kafkaCluster.getZkConnection(), connectorProperties, override, kafkaCluster);
     _numServers = numServers;
     _servers = new ArrayList<>(numServers);
     for (int i = 0; i < numServers; i++) {
@@ -70,28 +60,29 @@ public class EmbeddedDatastreamCluster {
     }
   }
 
-  public static EmbeddedDatastreamCluster newTestDatastreamKafkaCluster(Map<String, Properties> connectorProperties,
-      Properties override) throws IllegalArgumentException, IOException, DatastreamException {
-    return newTestDatastreamKafkaCluster(connectorProperties, override, -1, 1);
+  public static EmbeddedDatastreamCluster newTestDatastreamCluster(KafkaCluster kafkaCluster,
+      Map<String, Properties> connectorProperties, Properties override)
+      throws IllegalArgumentException, IOException, DatastreamException {
+    return newTestDatastreamCluster(kafkaCluster, connectorProperties, override, 1);
   }
 
   private void setupDatastreamProperties(String zkConnectionString, Map<String, Properties> connectorProperties,
-      Properties override) {
+      Properties override, KafkaCluster kafkaCluster) {
     String connectorTypes = connectorProperties.keySet().stream().collect(Collectors.joining(","));
     Properties properties = new Properties();
     properties.put(DatastreamServer.CONFIG_CLUSTER_NAME, "DatastreamCluster");
     properties.put(DatastreamServer.CONFIG_ZK_ADDRESS, zkConnectionString);
-    _datastreamPort = TestUtils.getAvailablePort();
+    _datastreamPort = NetworkUtils.getAvailablePort();
     properties.put(DatastreamServer.CONFIG_HTTP_PORT, String.valueOf(_datastreamPort));
     properties.put(DatastreamServer.CONFIG_CONNECTOR_TYPES, connectorTypes);
     properties.put(DatastreamServer.CONFIG_TRANSPORT_PROVIDER_FACTORY, KAFKA_TRANSPORT_FACTORY);
     properties.put(
-        String.format("%s.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, ProducerConfig.BOOTSTRAP_SERVERS_CONFIG),
-        _embeddedKafkaCluster.getBrokers());
+        String.format("%s.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, BOOTSTRAP_SERVERS_CONFIG),
+        kafkaCluster.getBrokers());
 
     properties.put(
-        String.format("%s.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, KafkaTransportProvider.CONFIG_ZK_CONNECT),
-        _embeddedKafkaCluster.getZkConnection());
+        String.format("%s.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, CONFIG_ZK_CONNECT),
+        kafkaCluster.getZkConnection());
 
     properties.putAll(getDomainConnectorProperties(connectorProperties));
     if (override != null) {
@@ -113,21 +104,11 @@ public class EmbeddedDatastreamCluster {
     return domainConnectorProperties;
   }
 
-  public static EmbeddedDatastreamCluster newTestDatastreamKafkaCluster(Map<String, Properties> connectorProperties,
-      Properties override, int zkPort, int numServers) throws IllegalArgumentException, IOException, DatastreamException {
+  public static EmbeddedDatastreamCluster newTestDatastreamCluster(KafkaCluster kafkaCluster,
+      Map<String, Properties> connectorProperties, Properties override, int numServers)
+      throws IllegalArgumentException, IOException, DatastreamException {
 
-    MUTEX.lock();
-
-    Validate.isTrue(zkPort == -1 || !_zkPorts.contains(new Integer(zkPort)),
-            "This zookeeper port " + zkPort + " is taken. Choose another port");
-    Validate.isTrue(numServers > 0, "invalid number of servers: " + numServers);
-
-    _zkPorts.add(zkPort);
-
-    EmbeddedDatastreamCluster cluster = new EmbeddedDatastreamCluster(connectorProperties, override, zkPort, numServers);
-
-    MUTEX.unlock();
-
+    EmbeddedDatastreamCluster cluster = new EmbeddedDatastreamCluster(connectorProperties, override, kafkaCluster, numServers);
     return cluster;
   }
 
@@ -148,32 +129,31 @@ public class EmbeddedDatastreamCluster {
   }
 
   public String getBrokerList() {
-    if (_embeddedKafkaCluster == null) {
+    if (_kafkaCluster == null) {
       LOG.error("kafka cluster not started correctly");
       return null;
     }
 
-    return _embeddedKafkaCluster.getBrokers();
+    return _kafkaCluster.getBrokers();
   }
 
   public String getZkConnection() {
-    if (_embeddedZookeeper == null) {
+    if (_kafkaCluster == null) {
       LOG.error("failed to get zookeeper connection string. Zookeeper service not started correctly.");
       return null;
     }
 
-    return _embeddedZookeeper.getConnection();
+    return _kafkaCluster.getZkConnection();
   }
 
   private void prepareStartup() throws IOException {
-    if (_embeddedKafkaCluster == null || _embeddedZookeeper == null) {
-      LOG.error("failed to start up kafka cluster: either kafka or zookeeper service is not initialized correctly.");
+    if (_kafkaCluster == null) {
+      LOG.error("failed to start up kafka cluster: kafka cluster is not initialized correctly.");
       return;
     }
 
-    if (!_embeddedZookeeper.isStarted()) {
-      _embeddedZookeeper.startup();
-      _embeddedKafkaCluster.startup();
+    if (!_kafkaCluster.isStarted()) {
+      _kafkaCluster.startup();
     }
   }
 
@@ -222,17 +202,8 @@ public class EmbeddedDatastreamCluster {
 
     _servers.clear();
 
-    if (_embeddedKafkaCluster != null) {
-      _embeddedKafkaCluster.shutdown();
+    if (_kafkaCluster != null) {
+      _kafkaCluster.shutdown();
     }
-
-    if (_embeddedZookeeper != null) {
-      _embeddedZookeeper.shutdown();
-    }
-
-    // make this zookeeper port available
-    MUTEX.lock();
-    _zkPorts.remove(_embeddedZookeeper.getPort());
-    MUTEX.unlock();
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/TestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/TestUtils.java
@@ -17,44 +17,8 @@ import java.util.UUID;
  * Helper class for writing tests.
  */
 public final class TestUtils {
-  private static final Random RANDOM = new Random();
 
   private TestUtils() {
-  }
-
-  public static File constructTempDir(String dirPrefix) {
-    File file = new File(System.getProperty("java.io.tmpdir"), dirPrefix + RANDOM.nextInt(10000000));
-    if (!file.mkdirs()) {
-      throw new RuntimeException("could not create temp directory: " + file.getAbsolutePath());
-    }
-    file.deleteOnExit();
-    return file;
-  }
-
-  public synchronized static int getAvailablePort() {
-    try {
-      ServerSocket socket = new ServerSocket(0);
-      try {
-        return socket.getLocalPort();
-      } finally {
-        socket.close();
-      }
-    } catch (IOException e) {
-      throw new IllegalStateException("Cannot find available port: " + e.getMessage(), e);
-    }
-  }
-
-  public static boolean deleteFile(File path) throws FileNotFoundException {
-    if (!path.exists()) {
-      throw new FileNotFoundException(path.getAbsolutePath());
-    }
-    boolean ret = true;
-    if (path.isDirectory()) {
-      for (File f : path.listFiles()) {
-        ret = ret && deleteFile(f);
-      }
-    }
-    return ret && path.delete();
   }
 
   public static List<String> generateStrings(int count) {

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
@@ -1,0 +1,53 @@
+package com.linkedin.datastream.common;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.util.Random;
+
+
+/**
+ * Class that contains the helper utility methods for File system operations.
+ */
+public class FileUtils {
+
+  private static final Random RANDOM = new Random();
+
+  /**
+   * Constructs a random directory with the prefix in the temp folder
+   * This directory is a temporary directory and will get deleted when the process exits.
+   * @param dirPrefix
+   *   Prefix to be used for the directory that needs to be created.
+   * @return
+   *   Object referencing the directory that is created.
+   */
+  public static File constructRandomDirectoryInTempDir(String dirPrefix) {
+    File file = new File(System.getProperty("java.io.tmpdir"), dirPrefix + RANDOM.nextInt(10000000));
+    if (!file.mkdirs()) {
+      throw new RuntimeException("could not create temp directory: " + file.getAbsolutePath());
+    }
+    file.deleteOnExit();
+    return file;
+  }
+
+  /**
+   * Delete the folder and all its contents recursively.
+   * @param path
+   *  Path that needs to be deleted.
+   * @return
+   *  True if the file was deleted successfully,
+   *  False if not.
+   * @throws FileNotFoundException
+   */
+  public static boolean deleteFile(File path) throws FileNotFoundException {
+    if (!path.exists()) {
+      throw new FileNotFoundException(path.getAbsolutePath());
+    }
+    boolean ret = true;
+    if (path.isDirectory()) {
+      for (File f : path.listFiles()) {
+        ret = ret && deleteFile(f);
+      }
+    }
+    return ret && path.delete();
+  }
+}

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
@@ -1,0 +1,28 @@
+package com.linkedin.datastream.common;
+
+import java.io.IOException;
+import java.net.ServerSocket;
+
+
+/**
+ * Class that contains the helper utility methods for Network operations.
+ */
+public class NetworkUtils {
+
+  /**
+   * @return
+   *  The next available port that can be used for opening a socket connection.
+   */
+  public synchronized static int getAvailablePort() {
+    try {
+      ServerSocket socket = new ServerSocket(0);
+      try {
+        return socket.getLocalPort();
+      } finally {
+        socket.close();
+      }
+    } catch (IOException e) {
+      throw new IllegalStateException("Cannot find available port: " + e.getMessage(), e);
+    }
+  }
+}

--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
@@ -14,7 +14,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.kafka.EmbeddedZookeeper;
 import com.linkedin.datastream.common.PollUtils;
 
 


### PR DESCRIPTION
In open source we use the Kafka 0.9. But in LinkedIn we use LiKafka version 0.8.x.x. To support this we need to make EmbeddedDatastreamCluster to be able to take the pluggable KafkaCluster as parameter and not setup the KafkaCluster on it's own.

This change also refactors the EmbeddedDatastreamCluster out of test code so that it is usable in datastream-li for testing espresso and espresso bootstrap connectors.
