### PR TITLE
Hearbeat connector 

### DIFF
--- a/config/server.properties
+++ b/config/server.properties
@@ -4,7 +4,7 @@ datastream.server.coordinator.cluster=DATASTREAM_CLUSTER
 datastream.server.coordinator.zkAddress=localhost:2181
 datastream.server.httpPort=32311
 datastream.server.coordinator.transportProviderFactory=com.linkedin.datastream.kafka.KafkaTransportProviderFactory
-datastream.server.connectorTypes=file
+datastream.server.connectorTypes=file,heartbeatlb,heartbeatbc
 
 ########################### Transport provider configs ######################
 
@@ -16,3 +16,12 @@ datastream.server.transportProvider.kafka.zookeeper.connect=localhost:2181
 datastream.server.connector.file.factoryClassName=com.linkedin.datastream.connectors.file.FileConnectorFactory
 datastream.server.connector.file.assignmentStrategy=com.linkedin.datastream.server.assignment.BroadcastStrategy
 
+########################### Heartbeat load balanced connector Configs ######################
+
+datastream.server.connector.heartbeatlb.factoryClassName=com.linkedin.datastream.connectors.HeartbeatConnectorFactory
+datastream.server.connector.heartbeatlb.assignmentStrategy=com.linkedin.datastream.server.assignment.LoadbalancingStrategy
+
+########################### Heartbeat Broadcast connector Configs ######################
+
+datastream.server.connector.heartbeatbc.factoryClassName=com.linkedin.datastream.connectors.HeartbeatConnectorFactory
+datastream.server.connector.heartbeatbc.assignmentStrategy=com.linkedin.datastream.server.assignment.BroadcastStrategy

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -60,7 +60,7 @@ public class KafkaTransportProvider implements TransportProvider {
   private final ZkUtils _zkUtils;
 
   public KafkaTransportProvider(Properties props) {
-
+    LOG.info(String.format("Creating kafka transport provider with properties: %s", props));
     if (!props.containsKey(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)) {
       throw new RuntimeException("Bootstrap servers are not set");
     }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderFactory.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderFactory.java
@@ -20,7 +20,6 @@ public class KafkaTransportProviderFactory implements TransportProviderFactory {
   public TransportProvider createTransportProvider(Properties config) {
     Validate.notNull(config, "null config");
     VerifiableProperties kafkaProps = new VerifiableProperties(config);
-    kafkaProps.getDomainProperties(KAFKA_CONFIG_PREFIX);
-    return new KafkaTransportProvider(config);
+    return new KafkaTransportProvider(kafkaProps.getDomainProperties(KAFKA_CONFIG_PREFIX));
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -78,11 +78,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
   }
 
   public DatastreamTaskImpl(Datastream datastream) {
-    this(datastream, UUID.randomUUID().toString());
-  }
-
-  public DatastreamTaskImpl(Datastream datastream, String id) {
-    this(datastream, id, null);
+    this(datastream, UUID.randomUUID().toString(), new ArrayList<>());
   }
 
   public DatastreamTaskImpl(Datastream datastream, String id, List<Integer> partitions) {
@@ -94,12 +90,12 @@ public class DatastreamTaskImpl implements DatastreamTask {
     _id = id;
     _partitions = new ArrayList<>();
     if (partitions != null && partitions.size() > 0) {
-      _partitions.addAll(partitions);
+        _partitions.addAll(partitions);
     } else {
-      // Add [0, N) if destination has N partitions
+      // Add [0, N) if source has N partitions
       // Or add a default partition 0 otherwise
-      if (datastream.hasDestination() && datastream.getDestination().hasPartitions()) {
-        int numPartitions = datastream.getDestination().getPartitions();
+      if (datastream.hasSource() && datastream.getSource().hasPartitions()) {
+        int numPartitions = datastream.getSource().getPartitions();
         for (int i = 0; i < numPartitions; i++) {
           _partitions.add(i);
         }
@@ -107,6 +103,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
         _partitions.add(0);
       }
     }
+
     LOG.info("Created new DatastreamTask " + this);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -106,9 +106,24 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
     int tasksPerDatastream = maxTasksPerDatastream < numberOfDatastreamPartitions ? maxTasksPerDatastream : numberOfDatastreamPartitions;
     Set<DatastreamTask> tasks = new HashSet<>();
     for(int index = 0; index < tasksPerDatastream; index++) {
-      tasks.add(new DatastreamTaskImpl(datastream));
+      tasks.add(new DatastreamTaskImpl(datastream, Integer.toString(index),
+          assignPartitionsToTask(datastream, index, tasksPerDatastream)));
     }
 
     return tasks;
+  }
+
+  // Finds the list of partitions that the current datastream task should own.
+  // Based on the task index, total number of tasks in the datastream and the total partitions in the datastream source
+  private List<Integer> assignPartitionsToTask(Datastream datastream, int taskIndex, int totalTasks) {
+    List<Integer> partitions = new ArrayList<>();
+    if(datastream.hasSource() && datastream.getSource().hasPartitions()) {
+      int numPartitions = datastream.getSource().getPartitions();
+      for(int index = 0; index + taskIndex < numPartitions; index += totalTasks) {
+        partitions.add(index + taskIndex);
+      }
+    }
+
+    return partitions;
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnector.java
@@ -1,0 +1,111 @@
+package com.linkedin.datastream.connectors;
+
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamEvent;
+import com.linkedin.datastream.server.DatastreamEventRecord;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.api.connector.Connector;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+
+
+/**
+ * Hearbeat connector sends heartbeat events for each of the datastream tasks at a regular interval.
+ * This connector is mainly used for both automated and manual testing.
+ */
+public class HeartbeatConnector implements Connector {
+  private static final Logger LOG = LoggerFactory.getLogger(HeartbeatConnector.class);
+
+  /**
+   * Default timeperiod at which the heartbeat connector sends events.
+   */
+  private static final String DEFAULT_HEARTBEAT_PERIOD_MS = "60000";
+  private static final String CFG_HEARTBEAT_PERIOD = "heartbeatPeriodMs";
+
+  private static final String BROADCAST_CONNECTOR_TYPE = "hearbeatbc";
+  private static final String LOADBALANCING_CONNECTOR_TYPE = "hearbeatlb";
+
+  private final int _hearbeatPeriodMs;
+
+  private ScheduledThreadPoolExecutor _executor;
+  private List<DatastreamTask> _tasks;
+
+  private Map<DatastreamTask, Map<Integer, Integer>> _checkpoint = new HashMap<>();
+
+  public HeartbeatConnector(Properties config) {
+    LOG.info(String.format("Creating Heartbeat connector with config: %s", config));
+    _hearbeatPeriodMs = Integer.parseInt(config.getProperty(CFG_HEARTBEAT_PERIOD, DEFAULT_HEARTBEAT_PERIOD_MS));
+  }
+
+  @Override
+  public void start() {
+    _executor = new ScheduledThreadPoolExecutor(1);
+    _executor.scheduleAtFixedRate(this::sendHeartBeatEvents, 0, _hearbeatPeriodMs, TimeUnit.MILLISECONDS);
+  }
+
+  private void sendHeartBeatEvents() {
+    DatastreamTask[] tasks = new DatastreamTask[_tasks.size()];
+    _tasks.toArray(tasks);
+    LOG.info(String.format("Sending heartbeat event for tasks: %s", _tasks));
+    try {
+      for(DatastreamTask task : tasks) {
+        if(task.getConnectorType().equalsIgnoreCase(BROADCAST_CONNECTOR_TYPE)) {
+          Integer eventIndex = _checkpoint.get(task).get(0);
+          task.getEventProducer().send(createHeartbeatEvent(0, eventIndex));
+          _checkpoint.get(task).put(0, eventIndex + 1);
+        } else {
+          for(int partition : task.getPartitions()) {
+            Integer eventIndex = _checkpoint.get(task).get(partition);
+            task.getEventProducer().send(createHeartbeatEvent(partition, eventIndex));
+            _checkpoint.get(task).put(partition, eventIndex + 1);
+          }
+        }
+      }
+    } catch(Exception e) {
+      LOG.error("Exception while sending the event", e);
+    }
+  }
+
+  private DatastreamEventRecord createHeartbeatEvent(int partition, int eventIndex) {
+    DatastreamEvent event = new DatastreamEvent();
+    event.key = ByteBuffer.wrap(Integer.toString(eventIndex).getBytes());
+    event.payload = ByteBuffer.wrap("Heartbeat".getBytes());
+    return new DatastreamEventRecord(event, partition, Integer.toString(eventIndex));
+  }
+
+  @Override
+  public void stop() {
+    _executor.shutdown();
+  }
+
+  @Override
+  public void onAssignmentChange(List<DatastreamTask> tasks) {
+    _tasks = tasks;
+    for(DatastreamTask task : tasks) {
+      if(!_checkpoint.containsKey(task)) {
+        _checkpoint.put(task, new HashMap<>());
+        Map<Integer, String> taskCheckpoint = task.getCheckpoints();
+        LOG.info(String.format("Assigned a new Datastream task %s with checkpoint %s", task, taskCheckpoint));
+        for(Integer partition : taskCheckpoint.keySet()) {
+          _checkpoint.get(task).put(partition, Integer.parseInt(taskCheckpoint.get(partition)));
+        }
+      }
+    }
+  }
+
+  @Override
+  public void initializeDatastream(Datastream stream)
+      throws DatastreamValidationException {
+
+  }
+}

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnectorFactory.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnectorFactory.java
@@ -1,0 +1,14 @@
+package com.linkedin.datastream.connectors;
+
+import java.util.Properties;
+
+import com.linkedin.datastream.server.api.connector.Connector;
+import com.linkedin.datastream.server.api.connector.ConnectorFactory;
+
+
+public class HeartbeatConnectorFactory implements ConnectorFactory {
+  @Override
+  public Connector createConnector(Properties config) {
+    return new HeartbeatConnector(config);
+  }
+}


### PR DESCRIPTION
Simple heartbeat connector that sends heartbeat events every so often. This connector could be used for both Broadcast and loadbalancing strategy. Right now the configurable time period is at the connector level.
Events are generated with increasing order of eventIndex. eventIndex is maintained per partition and checkpointed per partition.

Some future improvements we could make
- we could have the hearbeat period configuration at the datastream level. 
- The message that gets written can be improved to identify the task, instance that is writing. etc.
