### PR TITLE
Make ReflectionUtils.callMethod() a litter smarter

### DIFF
--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/TestReflectionUtils.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/TestReflectionUtils.java
@@ -2,6 +2,8 @@ package com.linkedin.datastream.common;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.HashSet;
+import java.util.Set;
 
 import junit.framework.Assert;
 import org.testng.annotations.Test;
@@ -79,7 +81,7 @@ public class TestReflectionUtils {
     Assert.assertEquals("hello", ReflectionUtils.getField(data, "_publicField"));
   }
 
-  private void privateVoidMethod(Integer foo, String bar) {
+  private void privateVoidMethod(float foo, String bar) {
     System.out.println("privateVoidMethod: " + String.valueOf(foo) + " " + bar);
   }
 
@@ -93,10 +95,27 @@ public class TestReflectionUtils {
     return 10;
   }
 
+  private int privateSetArgMethod(Set<Integer> mySet) {
+    System.out.println("privateSetArgMethod");
+    return 10;
+  }
+
+  class A {
+  }
+
+  class B extends A {
+  }
+
+  private void privateSubtype_Unhappy(B b) {
+  }
+
+  private void privateSubtype_happy(A a) {
+  }
+
   @Test
   public void testCallMethod() throws Exception {
     TestReflectionUtils tester = new TestReflectionUtils();
-    ReflectionUtils.callMethod(tester, "privateVoidMethod", 10, "Hello");
+    ReflectionUtils.callMethod(tester, "privateVoidMethod", 10.5f, "Hello");
     int retVal = ReflectionUtils.callMethod(tester, "privateIntMethod", 10);
     Assert.assertEquals(retVal, 15);
 
@@ -106,5 +125,17 @@ public class TestReflectionUtils {
 
     retVal = ReflectionUtils.callMethod(tester, "publicNoArgsMethod");
     Assert.assertEquals(retVal, 10);
+
+    Set<Integer> dummySet = new HashSet<>();
+    retVal = ReflectionUtils.callMethod(tester, "privateSetArgMethod", dummySet);
+    Assert.assertEquals(retVal, 10);
+
+    try {
+      ReflectionUtils.callMethod(tester, "privateSubtype_Unhappy", new A());
+      Assert.fail();
+    } catch(NoSuchMethodException e) {
+    }
+
+    ReflectionUtils.callMethod(tester, "privateSubtype_happy", new B());
   }
 }


### PR DESCRIPTION
```
Make ReflectionUtils.callMethod() a litter smarter

Before this fix, if the paramter type is a supertype of the argument
type, eg. Set vs HashSet, callMethod would fail to find the method. This
change makes it a little bit more intelligent such that it recognizes
such subtype/supertype relation between the argument/parameter.

In addition, callMethod can also support the case where either argument
or parameter is primitive and the other is the boxed type.
```
