### PR TITLE
Adding waitTillDatastreamIsInitialized method to DatastreamRestClient

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -94,6 +94,19 @@ public class TestDatastreamRestClient {
     Assert.assertEquals(createdDatastream, datastream);
   }
 
+  @Test
+  public void testWaitTillDatastreamIsInitialized_returnsInitializedDatastream()
+      throws DatastreamException, InterruptedException {
+    Datastream datastream = generateDatastream(1);
+    LOG.info("Datastream : " + datastream);
+    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
+    restClient.createDatastream(datastream);
+    Datastream initializedDatastream = restClient.waitTillDatastreamIsInitialized(datastream.getName(), 60000);
+    LOG.info("Initialized Datastream : " + initializedDatastream);
+    Assert.assertNotEquals(initializedDatastream.getDestination().getConnectionString(), "");
+    Assert.assertEquals(initializedDatastream.getDestination().getPartitions().intValue(), 1);
+  }
+
   @Test(expectedExceptions = DatastreamNotFoundException.class)
   public void testDeleteDatastream()
       throws DatastreamException {


### PR DESCRIPTION
After creating the datastream, initialization of the datastream is an async process.Initialization typically involves 
- creating the destination topic, 
- creating the datastream tasks
- assigning them to the datastream instances for producing.

Typically when a client creates a datastream, It needs to wait till it is initialized so that it can read the destination and start reading the events from the destination. Right now each client has to implement a poller to wait till the destination is initialized. This change adds  a helper method that will make client's life easier.
