### PR TITLE
Minor fixes in Destination Manager to guard against metadata being not set

### DIFF
--- a/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc
+++ b/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc
@@ -45,7 +45,7 @@
         "fields": [
           {
             "name": "connectionString",
-            "doc": "Source connection string to consume the data from.",
+            "doc": "Destination connection string to write the data to.",
             "type": "string"
           },
           {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DestinationManager.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DestinationManager.java
@@ -58,9 +58,11 @@ public class DestinationManager {
         continue;
       }
 
-      boolean topicReuse =
-          Boolean.parseBoolean(datastream.getMetadata().getOrDefault(
-              CoordinatorConfig.CONFIG_REUSE_EXISTING_DESTINATION, String.valueOf(_reuseExistingTopic)));
+      boolean topicReuse = _reuseExistingTopic;
+      if(datastream.hasMetadata()) {
+        topicReuse = Boolean.parseBoolean(datastream.getMetadata().getOrDefault(
+            CoordinatorConfig.CONFIG_REUSE_EXISTING_DESTINATION, String.valueOf(_reuseExistingTopic)));
+      }
 
       // De-dup the datastreams, Set the destination for the duplicate datastreams same as the existing ones.
       if (topicReuse && sourceDestinationMapping.containsKey(datastream.getSource())) {
@@ -83,7 +85,9 @@ public class DestinationManager {
 
   private String createTopic(Datastream datastream) throws TransportException {
     Properties datastreamProperties = new Properties();
-    datastreamProperties.putAll(datastream.getMetadata());
+    if(datastream.hasMetadata()) {
+      datastreamProperties.putAll(datastream.getMetadata());
+    }
     Properties topicProperties = new VerifiableProperties(datastreamProperties).getDomainProperties("topic");
     int numberOfPartitions = DEFAULT_NUMBER_PARTITIONS;
 


### PR DESCRIPTION
- When you create datastream using curl request, metadata is not set. Adding guards in DestinationManager for them. 
- Changing the default frequency of sending events to 5 seconds in the hearbeat connector.
- Minor other fixes. 
