### PR TITLE
fix embedded datastream cluster to support multiple servers and retur…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -156,6 +156,7 @@ project(':datastream-testcommon') {
     compile project(':datastream-common')
     compile project(':datastream-utils')
     compile project(':datastream-server')
+    compile project(':datastream-client')
     compile "commons-cli:commons-cli:$commonsCliVersion"
     compile "org.apache.avro:avro:$avroVersion"
     compile "org.apache.zookeeper:zookeeper:$zookeeperVersion"

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -17,7 +17,6 @@ import com.linkedin.datastream.testutil.EmbeddedZookeeper;
 import com.linkedin.r2.RemoteInvocationException;
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1117,7 +1117,7 @@ public class TestCoordinator {
     EmbeddedDatastreamCluster datastreamKafkaCluster =
         TestDatastreamServer.initializeTestDatastreamServerWithDummyConnector(null);
     datastreamKafkaCluster.startup();
-    Properties properties = datastreamKafkaCluster.getDatastreamServerProperties();
+    Properties properties = datastreamKafkaCluster.getPrimaryDatastreamServerProperties();
     DatastreamResources resource = new DatastreamResources(datastreamKafkaCluster.getPrimaryDatastreamServer());
 
     Coordinator coordinator =

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -179,7 +179,7 @@ public class TestDatastreamServer {
     Assert.assertTrue(eventsReceived1.containsAll(eventsWritten1));
 
     // Ensure 1st instance was assigned the task
-    String cluster = _datastreamCluster.getDatastreamServerProperties().getProperty(
+    String cluster = _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(
             DatastreamServer.CONFIG_CLUSTER_NAME);
     ZkClient zkclient = new ZkClient(_datastreamCluster.getZkConnection());
     String instance = server1.getCoordinator().getInstanceName();
@@ -248,7 +248,7 @@ public class TestDatastreamServer {
     countMap.forEach((k, v) -> Assert.assertEquals(v, (Integer) 0, "incorrect number of " + k + " is read"));
 
     // Ensure both instances were assigned the task
-    String cluster = _datastreamCluster.getDatastreamServerProperties().getProperty(
+    String cluster = _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(
         DatastreamServer.CONFIG_CLUSTER_NAME);
     ZkClient zkclient = new ZkClient(_datastreamCluster.getZkConnection());
     String instance = server1.getCoordinator().getInstanceName();
@@ -332,7 +332,7 @@ public class TestDatastreamServer {
     Assert.assertTrue(eventsReceived2.containsAll(eventsWritten2));
 
     // Ensure 1st instance was assigned both tasks
-    String cluster = _datastreamCluster.getDatastreamServerProperties().getProperty(
+    String cluster = _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(
             DatastreamServer.CONFIG_CLUSTER_NAME);
     ZkClient zkclient = new ZkClient(_datastreamCluster.getZkConnection());
     String instance1 = server1.getCoordinator().getInstanceName();
@@ -396,9 +396,8 @@ public class TestDatastreamServer {
     testFile.deleteOnExit();
     Datastream fileDatastream1 =
         DatastreamTestUtils.createDatastream(FileConnector.CONNECTOR_TYPE, "file_" + testFile.getName(),
-                testFile.getAbsolutePath());
-    String restUrl = String.format("http://localhost:%d/", _datastreamCluster.getDatastreamPort());
-    DatastreamRestClient restClient = new DatastreamRestClient(restUrl);
+            testFile.getAbsolutePath());
+    DatastreamRestClient restClient = _datastreamCluster.createDatastreamRestClient();
     restClient.createDatastream(fileDatastream1);
     return getPopulatedDatastream(restClient, fileDatastream1);
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
@@ -67,14 +67,14 @@ public class TestServerHealth {
   public void testServerHealth_HasRightClusterNameAndInstanceName()
       throws RemoteInvocationException {
     ServerHealth serverHealth = fetchServerHealth();
-    Assert.assertEquals(serverHealth.getClusterName(), _datastreamCluster.getDatastreamServerProperties().getProperty(DatastreamServer.CONFIG_CLUSTER_NAME));
+    Assert.assertEquals(serverHealth.getClusterName(), _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(DatastreamServer.CONFIG_CLUSTER_NAME));
     Assert.assertEquals(serverHealth.getInstanceName(),
         _datastreamCluster.getPrimaryDatastreamServer().getCoordinator().getInstanceName());
   }
 
   public ServerHealth fetchServerHealth()
       throws RemoteInvocationException {
-    String healthUri = "http://localhost:" + _datastreamCluster.getDatastreamPort() + "/";
+    String healthUri = "http://localhost:" + _datastreamCluster.getPrimaryDatastreamPort() + "/";
     _builders = new HealthBuilders();
     final HttpClientFactory http = new HttpClientFactory();
     final Client r2Client = new TransportClientAdapter(http.getClient(Collections.<String, String> emptyMap()));

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -17,6 +17,10 @@ package com.linkedin.datastream.server;
  * under the License.
  */
 
+import com.linkedin.datastream.DatastreamRestClient;
+import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.NetworkUtils;
+import com.linkedin.datastream.kafka.KafkaCluster;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,13 +28,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.stream.Collectors;
-
 import org.apache.commons.lang.Validate;
 import org.apache.log4j.Logger;
-
-import com.linkedin.datastream.common.DatastreamException;
-import com.linkedin.datastream.common.NetworkUtils;
-import com.linkedin.datastream.kafka.KafkaCluster;
 
 
 public class EmbeddedDatastreamCluster {
@@ -43,20 +42,21 @@ public class EmbeddedDatastreamCluster {
   // the zookeeper ports that are currently taken
   private final KafkaCluster _kafkaCluster;
 
-  private int _datastreamPort;
-  private Properties _datastreamServerProperties;
   private int _numServers;
-  private List<DatastreamServer> _servers;
+  private List<Integer> _datastreamPorts = new ArrayList<>();
+  private List<Properties> _datastreamServerProperties = new ArrayList<>();
+  private List<DatastreamServer> _servers = new ArrayList<>();
 
   private EmbeddedDatastreamCluster(Map<String, Properties> connectorProperties, Properties override,
       KafkaCluster kafkaCluster, int numServers)
       throws IOException {
     _kafkaCluster = kafkaCluster;
-    setupDatastreamProperties(kafkaCluster.getZkConnection(), connectorProperties, override, kafkaCluster);
     _numServers = numServers;
-    _servers = new ArrayList<>(numServers);
     for (int i = 0; i < numServers; i++) {
       _servers.add(null);
+      _datastreamServerProperties.add(null);
+      _datastreamPorts.add(-1);
+      setupDatastreamProperties(i, _kafkaCluster.getZkConnection(), connectorProperties, override, kafkaCluster);
     }
   }
 
@@ -66,29 +66,27 @@ public class EmbeddedDatastreamCluster {
     return newTestDatastreamCluster(kafkaCluster, connectorProperties, override, 1);
   }
 
-  private void setupDatastreamProperties(String zkConnectionString, Map<String, Properties> connectorProperties,
+  private void setupDatastreamProperties(int index, String zkConnectionString, Map<String, Properties> connectorProperties,
       Properties override, KafkaCluster kafkaCluster) {
     String connectorTypes = connectorProperties.keySet().stream().collect(Collectors.joining(","));
     Properties properties = new Properties();
     properties.put(DatastreamServer.CONFIG_CLUSTER_NAME, "DatastreamCluster");
     properties.put(DatastreamServer.CONFIG_ZK_ADDRESS, zkConnectionString);
-    _datastreamPort = NetworkUtils.getAvailablePort();
-    properties.put(DatastreamServer.CONFIG_HTTP_PORT, String.valueOf(_datastreamPort));
+    _datastreamPorts.set(index, NetworkUtils.getAvailablePort());
+    properties.put(DatastreamServer.CONFIG_HTTP_PORT, String.valueOf(_datastreamPorts.get(index)));
     properties.put(DatastreamServer.CONFIG_CONNECTOR_TYPES, connectorTypes);
     properties.put(DatastreamServer.CONFIG_TRANSPORT_PROVIDER_FACTORY, KAFKA_TRANSPORT_FACTORY);
-    properties.put(
-        String.format("%s.kafka.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, BOOTSTRAP_SERVERS_CONFIG),
+    properties.put(String.format("%s.kafka.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, BOOTSTRAP_SERVERS_CONFIG),
         kafkaCluster.getBrokers());
 
-    properties.put(
-        String.format("%s.kafka.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, CONFIG_ZK_CONNECT),
+    properties.put(String.format("%s.kafka.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, CONFIG_ZK_CONNECT),
         kafkaCluster.getZkConnection());
 
     properties.putAll(getDomainConnectorProperties(connectorProperties));
     if (override != null) {
       properties.putAll(override);
     }
-    _datastreamServerProperties = properties;
+    _datastreamServerProperties.set(index, properties);
   }
 
   private Properties getDomainConnectorProperties(Map<String, Properties> connectorProperties) {
@@ -108,16 +106,39 @@ public class EmbeddedDatastreamCluster {
       Map<String, Properties> connectorProperties, Properties override, int numServers)
       throws IllegalArgumentException, IOException, DatastreamException {
 
-    EmbeddedDatastreamCluster cluster = new EmbeddedDatastreamCluster(connectorProperties, override, kafkaCluster, numServers);
+    EmbeddedDatastreamCluster cluster =
+        new EmbeddedDatastreamCluster(connectorProperties, override, kafkaCluster, numServers);
     return cluster;
   }
 
-  public Properties getDatastreamServerProperties() {
-    return _datastreamServerProperties;
+  /**
+   * Get the datastream server config for the primary datastream server
+   * Configs for different servers in the cluster only differ by http port
+   * number.
+   */
+  public Properties getPrimaryDatastreamServerProperties() {
+    return _datastreamServerProperties.get(0);
   }
 
-  public int getDatastreamPort() {
-    return _datastreamPort;
+  /**
+   * Get the http port for the primary datastream server
+   */
+  public int getPrimaryDatastreamPort() {
+    return _datastreamPorts.get(0);
+  }
+
+  /**
+   * Construct a datastream rest client for the primary datastream server
+   */
+  public DatastreamRestClient createDatastreamRestClient() {
+    return createDatastreamRestClient(0);
+  }
+
+  /**
+   * Construct a datastream rest client for the specific datastream server
+   */
+  public DatastreamRestClient createDatastreamRestClient(int index) {
+    return new DatastreamRestClient(String.format("http://localhost:%d/", _datastreamPorts.get(index)));
   }
 
   public DatastreamServer getPrimaryDatastreamServer() {
@@ -146,7 +167,8 @@ public class EmbeddedDatastreamCluster {
     return _kafkaCluster.getZkConnection();
   }
 
-  private void prepareStartup() throws IOException {
+  private void prepareStartup()
+      throws IOException {
     if (_kafkaCluster == null) {
       LOG.error("failed to start up kafka cluster: kafka cluster is not initialized correctly.");
       return;
@@ -157,7 +179,8 @@ public class EmbeddedDatastreamCluster {
     }
   }
 
-  public void startupServer(int index) throws IOException, DatastreamException {
+  public void startupServer(int index)
+      throws IOException, DatastreamException {
     Validate.isTrue(index >= 0, "Server index out of bound: " + index);
     if (index < _servers.size() && _servers.get(index) != null) {
       LOG.warn(String.format("Server[%d] already exists, skipping.", index));
@@ -166,14 +189,15 @@ public class EmbeddedDatastreamCluster {
 
     prepareStartup();
 
-    DatastreamServer server = new DatastreamServer(_datastreamServerProperties);
+    DatastreamServer server = new DatastreamServer(_datastreamServerProperties.get(index));
     _servers.set(index, server);
     server.startup();
 
     LOG.info(String.format("DatastreamServer[%d] started.", index));
   }
 
-  public void startup() throws IOException, DatastreamException {
+  public void startup()
+      throws IOException, DatastreamException {
     int numServers = _numServers;
     for (int i = 0; i < numServers; i++) {
       startupServer(i);


### PR DESCRIPTION
(1) Add API to directly return a datastream rest client for the datastream server
(2) Although we created multiple servers in the embedded cluster, the codes do not honor that different servers actually have different http port numbers
