### PR TITLE
Tell embedded zookeeper to pick available port

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -37,6 +37,7 @@ public class TestDatastreamRestClient {
   private static final String DUMMY_CONNECTOR = DummyConnector.CONNECTOR_TYPE;
   private static final String DUMMY_BOOTSTRAP_CONNECTOR = DummyBootstrapConnector.CONNECTOR_TYPE;
   private DatastreamServer _datastreamServer;
+  private EmbeddedZookeeper _embeddedZookeeper;
 
   @BeforeTest
   public void setUp() throws Exception {
@@ -47,6 +48,7 @@ public class TestDatastreamRestClient {
   @AfterTest
   public void tearDown() throws Exception {
     _datastreamServer.shutdown();
+    _embeddedZookeeper.shutdown();
   }
 
   public static Datastream generateDatastream(int seed) {
@@ -62,9 +64,9 @@ public class TestDatastreamRestClient {
   }
 
   private void setupServer() throws Exception {
-    EmbeddedZookeeper embeddedZookeeper = new EmbeddedZookeeper();
-    String zkConnectionString = embeddedZookeeper.getConnection();
-    embeddedZookeeper.startup();
+    _embeddedZookeeper = new EmbeddedZookeeper();
+    String zkConnectionString = _embeddedZookeeper.getConnection();
+    _embeddedZookeeper.startup();
 
     Properties properties = new Properties();
     properties.put(DatastreamServer.CONFIG_CLUSTER_NAME, "testCluster");
@@ -73,9 +75,9 @@ public class TestDatastreamRestClient {
     properties.put(DatastreamServer.CONFIG_CONNECTOR_TYPES, DUMMY_CONNECTOR + "," + DUMMY_BOOTSTRAP_CONNECTOR);
     properties.put(DatastreamServer.CONFIG_TRANSPORT_PROVIDER_FACTORY, TRANSPORT_FACTORY_CLASS);
     properties.put(DatastreamServer.CONFIG_CONNECTOR_PREFIX + DUMMY_CONNECTOR + "." + DatastreamServer.CONFIG_CONNECTOR_FACTORY_CLASS_NAME,
-        DummyConnectorFactory.class.getTypeName());
+            DummyConnectorFactory.class.getTypeName());
     properties.put(DatastreamServer.CONFIG_CONNECTOR_PREFIX + DUMMY_BOOTSTRAP_CONNECTOR + "." + DatastreamServer.CONFIG_CONNECTOR_FACTORY_CLASS_NAME,
-        DummyBootstrapConnectorFactory.class.getTypeName());
+            DummyBootstrapConnectorFactory.class.getTypeName());
     properties.put(DatastreamServer.CONFIG_CONNECTOR_PREFIX + DUMMY_CONNECTOR + "." + DatastreamServer.CONFIG_CONNECTOR_BOOTSTRAP_TYPE, DUMMY_BOOTSTRAP_CONNECTOR);
     properties.put(DatastreamServer.CONFIG_CONNECTOR_PREFIX + DUMMY_CONNECTOR + ".dummyProperty", "dummyValue"); // DummyConnector will verify this value being correctly set
     _datastreamServer = new DatastreamServer(properties);
@@ -97,7 +99,7 @@ public class TestDatastreamRestClient {
   @Test
   public void testWaitTillDatastreamIsInitialized_returnsInitializedDatastream()
       throws DatastreamException, InterruptedException {
-    Datastream datastream = generateDatastream(1);
+    Datastream datastream = generateDatastream(2);
     LOG.info("Datastream : " + datastream);
     DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
     restClient.createDatastream(datastream);

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedZookeeperKafkaCluster.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedZookeeperKafkaCluster.java
@@ -13,8 +13,8 @@ public class EmbeddedZookeeperKafkaCluster implements KafkaCluster {
   private EmbeddedKafkaCluster _embeddedKafkaCluster = null;
   private boolean _isStarted;
 
-  public EmbeddedZookeeperKafkaCluster() {
-    _embeddedZookeeper = new EmbeddedZookeeper(-1);
+  public EmbeddedZookeeperKafkaCluster() throws IOException {
+    _embeddedZookeeper = new EmbeddedZookeeper();
     List<Integer> kafkaPorts = new ArrayList<>();
     // -1 for any available port
     kafkaPorts.add(-1);
@@ -51,8 +51,12 @@ public class EmbeddedZookeeperKafkaCluster implements KafkaCluster {
 
   @Override
   public void shutdown() {
-    _embeddedKafkaCluster.shutdown();
-    _embeddedZookeeper.shutdown();
+    if (_embeddedKafkaCluster != null) {
+      _embeddedKafkaCluster.shutdown();
+    }
+    if (_embeddedZookeeper != null) {
+      _embeddedZookeeper.shutdown();
+    }
     _isStarted = false;
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/EmbeddedZookeeper.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/EmbeddedZookeeper.java
@@ -5,6 +5,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 
+import org.apache.commons.lang.Validate;
 import org.apache.zookeeper.server.NIOServerCnxnFactory;
 import org.apache.zookeeper.server.ServerCnxnFactory;
 import org.apache.zookeeper.server.ZooKeeperServer;
@@ -23,31 +24,22 @@ public class EmbeddedZookeeper {
 
   private boolean _started;
 
-  public EmbeddedZookeeper() {
-    this(-1);
+  public EmbeddedZookeeper() throws IOException {
+    this(0);
   }
 
-  public EmbeddedZookeeper(int port) {
+  public EmbeddedZookeeper(int port) throws IOException {
     this(port, 500);
   }
 
-  public EmbeddedZookeeper(int port, int tickTime) {
-    this.port = resolvePort(port);
+  public EmbeddedZookeeper(int port, int tickTime) throws IOException {
+    this.factory = NIOServerCnxnFactory.createFactory(port, 1024);
+    this.port = factory.getLocalPort();
     this.tickTime = tickTime;
   }
 
-  private int resolvePort(int port) {
-    if (port == -1) {
-      return NetworkUtils.getAvailablePort();
-    }
-    return port;
-  }
-
   public void startup() throws IOException {
-    if (this.port == -1) {
-      this.port = NetworkUtils.getAvailablePort();
-    }
-    this.factory = NIOServerCnxnFactory.createFactory(new InetSocketAddress("localhost", port), 1024);
+    Validate.isTrue(this.port > 0, "Failed to reserve port for zookeeper server.");
     this.snapshotDir = FileUtils.constructRandomDirectoryInTempDir("embedded-zk/snapshot-" + this.port);
     this.logDir = FileUtils.constructRandomDirectoryInTempDir("embedded-zk/log-" + this.port);
 

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
@@ -17,6 +17,7 @@ public class NetworkUtils {
     try {
       ServerSocket socket = new ServerSocket(0);
       try {
+        socket.setReuseAddress(true);
         return socket.getLocalPort();
       } finally {
         socket.close();


### PR DESCRIPTION
Currently, we are using NetworkUtils.getAvailablePort() to find a port for
embedded zookeeper. However, getAvailablePorts() is unreliable because
it closes the socket as soon as it gets the port number. After this
point, it is possible for OS to give the same port to the next socket.

Zookeeper server actually supports passing in 0 as the port and it knows
to pick an available port. As such, we should do this to avoid using
NetworkUtils.

We are already doing the same for embedded kafka. But we can't do the
same to DatastreamServer which depends on HttpNettyServer which does not
remember the port even though it can auto resolve if we pass 0 as the
port.
