### PR TITLE
Using newest Gradle 1.x and Checkstyle possible.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ allprojects {
   checkstyle {
     configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
     ignoreFailures = true
+    toolVersion = "6.7"
   }
 
   idea {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.10-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip


### PR DESCRIPTION
Checkstyle was not working for Java 8 code. With this change it reports errors correctly.
- Updated Gradle to the newest version < 2.0.
- Forced Checkstyle version to newest possible that works with this Gradle version
