### PR TITLE
Remove usage of synchronized and add updateTasks support

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
@@ -7,6 +7,8 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryException;
 import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
 
+import java.util.Objects;
+
 /**
  * Implementation of the DatastremaEventProducer that connector will use to produce events. There is an unique
  * DatastreamEventProducerImpl object created per DatastreamTask that is assigned to the connector.
@@ -56,5 +58,24 @@ public class DatastreamEventProducerImpl implements DatastreamEventProducer {
   @Override
   public void flush() {
     _eventProducer.flush();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    DatastreamEventProducerImpl producer = (DatastreamEventProducerImpl) o;
+    return Objects.equals(_schemaRegistryProvider, producer._schemaRegistryProvider) &&
+            Objects.equals(_eventProducer, producer._eventProducer) &&
+            Objects.equals(_task, producer._task);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_schemaRegistryProvider, _eventProducer, _task);
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -6,10 +6,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 
-import org.codehaus.jackson.type.TypeReference;
 import org.testng.Assert;
 import org.testng.annotations.Test;
+import org.codehaus.jackson.type.TypeReference;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
@@ -19,7 +21,6 @@ import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.JsonUtils;
 import com.linkedin.datastream.common.PollUtils;
-import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
 import com.linkedin.datastream.server.api.transport.TransportException;
 import com.linkedin.datastream.server.api.transport.TransportProvider;
 import com.linkedin.datastream.server.providers.CheckpointProvider;
@@ -27,20 +28,23 @@ import com.linkedin.datastream.testutil.InMemoryCheckpointProvider;
 
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.internal.verification.VerificationModeFactory.times;
 
 
-public class TestDatastreamEventProducer {
+public class TestEventProducer {
   private ArrayList<DatastreamTask> _tasks;
   private EventProducer _producer;
   private Datastream _datastream;
   private TransportProvider _transport;
   private CheckpointProvider _cpProvider;
-  private SchemaRegistryProvider _schemaRegistryProvider;
   private Properties _config;
+  private AtomicInteger _inSend = new AtomicInteger(0);
+  private AtomicBoolean _inFlush = new AtomicBoolean(false);
 
   private Datastream createDatastream() {
     Datastream datastream = new Datastream();
@@ -61,7 +65,7 @@ public class TestDatastreamEventProducer {
 
   private int _eventSeed;
 
-  private DatastreamEventRecord createEventRecord(Datastream datastream, DatastreamTask task, Integer partition) {
+  private DatastreamEventRecord createEventRecord(Integer partition) {
     DatastreamEvent event = new DatastreamEvent();
     event.key = null;
     event.payload = null;
@@ -71,6 +75,10 @@ public class TestDatastreamEventProducer {
   }
 
   private void setup(boolean customCheckpointing) {
+    setup(customCheckpointing, false);
+  }
+
+  private void setup(boolean customCheckpointing, boolean checkRace) {
     _datastream = createDatastream();
 
     DatastreamTaskImpl task1 = new DatastreamTaskImpl(_datastream);
@@ -91,9 +99,39 @@ public class TestDatastreamEventProducer {
     _tasks.add(task1);
     _tasks.add(task2);
 
-    //ValidatingTransport transport = new ValidatingTransport();
     _transport = mock(TransportProvider.class);
-    _schemaRegistryProvider = mock(SchemaRegistryProvider.class);
+
+    // Verify transport.send() and transport.flush() is never called simultaneously
+    if (checkRace) {
+      try {
+        doAnswer((invocation) -> {
+          Assert.assertFalse(_inFlush.get());
+          _inSend.incrementAndGet();
+          try {
+            Thread.sleep(1); // mimic send delay
+          } catch (InterruptedException e) {
+            Assert.fail();
+          }
+          _inSend.decrementAndGet();
+          return null;
+        }).when(_transport).send(anyString(), anyObject());
+
+        doAnswer((invocation) -> {
+          Assert.assertEquals(_inSend.get(), 0);
+          _inFlush.set(true);
+          try {
+            Thread.sleep(3); // mimic send delay
+          } catch (InterruptedException e) {
+            Assert.fail();
+          }
+          _inFlush.set(false);
+          return null;
+        }).when(_transport).flush();
+      } catch (TransportException e) {
+        Assert.fail(); // this is impossible
+      }
+    }
+
     if (!customCheckpointing) {
       _cpProvider = new InMemoryCheckpointProvider();
     } else {
@@ -104,9 +142,7 @@ public class TestDatastreamEventProducer {
     _config = new Properties();
     _config.put(EventProducer.CHECKPOINT_PERIOD_MS, "50");
 
-    _producer =
-        new EventProducer(_tasks, _transport, _cpProvider, _config,
-            customCheckpointing);
+    _producer = new EventProducer(_tasks, _transport, _cpProvider, _config, customCheckpointing);
   }
 
   @Test
@@ -119,7 +155,7 @@ public class TestDatastreamEventProducer {
     for (int i = 0; i < 500; i++) {
       task = i % 3 == 0 ? _tasks.get(0) : _tasks.get(1);
       partition = i % 3 == 0 ? 1 + rand.nextInt(2) : 3 + rand.nextInt(2);
-      record = createEventRecord(_datastream, task, partition);
+      record = createEventRecord(partition);
       _producer.send(task, record);
     }
     final boolean[] isCommitCalled = { false };
@@ -164,7 +200,7 @@ public class TestDatastreamEventProducer {
     for (int i = 0; i < 500; i++) {
       task = i % 3 == 0 ? _tasks.get(0) : _tasks.get(1);
       partition = i % 3 == 0 ? 1 + rand.nextInt(2) : 3 + rand.nextInt(2);
-      record = createEventRecord(_datastream, task, partition);
+      record = createEventRecord(partition);
       _producer.send(task, record);
 
       Map<Integer, String> cpMap = taskCpMap.getOrDefault(task, new HashMap<>());
@@ -189,5 +225,114 @@ public class TestDatastreamEventProducer {
     // Expect saved checkpoint to match that of the last event
     Map<DatastreamTask, Map<Integer, String>> checkpointsNew = _producer.getSafeCheckpoints();
     Assert.assertEquals(checkpointsNew, taskCpMap);
+  }
+
+  private void verifyCheckpoints() {
+    int size = _tasks.size();
+    Assert.assertEquals(_producer.getSafeCheckpoints().size(), size);
+    _tasks.forEach(t -> {
+      Assert.assertNotNull(_producer.getSafeCheckpoints().get(t), t.toString());
+      Assert.assertEquals(_producer.getSafeCheckpoints().get(t).keySet(), t.getPartitions(), t.toString());
+    });
+  }
+
+  /**
+   * Helper for tests exercising updateTasks
+   *
+   * 1. add a new task (task3)
+   * 2. remove a task (task3)
+   * 3. add task3 and remove task2
+   *
+   * Validate the checkpoint map after each step.
+   */
+  private void callUpdateTasksAndVerify(int partition) {
+    List<Integer> partitions = new ArrayList<>();
+    partitions.add(partition);
+    partitions.add(partition + 1);
+    DatastreamTaskImpl task3 = new DatastreamTaskImpl(_datastream);
+    task3.setPartitions(partitions);
+    _tasks.add(task3);
+    _producer.updateTasks(_tasks);
+    verifyCheckpoints();
+
+    // Remove a task
+    _tasks.remove(2);
+    _producer.updateTasks(_tasks);
+    verifyCheckpoints();
+
+    // Add and remove a task
+    _tasks.remove(1);
+    _tasks.add(task3);
+    _producer.updateTasks(_tasks);
+    verifyCheckpoints();
+  }
+
+  /**
+   * Basic test case of update tasks
+   */
+  @Test
+  public void testUpdateTasks() {
+    setup(false);
+
+    verifyCheckpoints();
+    callUpdateTasksAndVerify(5);
+  }
+
+  /**
+   * Using three threads doing repeated send/flush/updateTasks and check for race conditions.
+   */
+  @Test
+  public void testSendFlushUpdateTaskStress() {
+    setup(false, true);
+
+    // Mimic a connector constantly calls send/flush
+    final boolean stopHandler[] = { false };
+    Thread sender = new Thread(() -> {
+      DatastreamTask task = _tasks.get(0);
+      while (!stopHandler[0]) {
+        try {
+          Thread.sleep(5);
+        } catch (InterruptedException e) {
+          break;
+        }
+
+        _producer.send(task, createEventRecord(1));
+      }
+    });
+    sender.start();
+
+    Thread flusher = new Thread(() -> {
+      DatastreamTask task = _tasks.get(0);
+      while (!stopHandler[0]) {
+        try {
+          Thread.sleep(5);
+        } catch (InterruptedException e) {
+          break;
+        }
+
+        _producer.flush();
+      }
+    });
+    flusher.start();
+
+    // Repeatedly update the tasks and check for corruption
+    int iterations = 100;
+    for (int i = 0, step = 0; i < iterations; i++, step += 2) {
+      callUpdateTasksAndVerify(step + 100);
+      try {
+        Thread.sleep(2);
+      } catch (InterruptedException e) {
+        Assert.fail();
+      }
+    }
+
+    stopHandler[0] = true;
+    Assert.assertTrue(PollUtils.poll(() -> !flusher.isAlive(), 50, 2000));
+
+    // Remove all tasks
+    _tasks.clear();
+    _producer.updateTasks(_tasks);
+    verifyCheckpoints();
+
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
@@ -1,6 +1,7 @@
 package com.linkedin.datastream.server;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -8,7 +9,7 @@ import java.util.Properties;
 import java.util.Set;
 
 import org.testng.Assert;
-import org.testng.annotations.BeforeTest;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.linkedin.datastream.server.providers.CheckpointProvider;
@@ -23,7 +24,7 @@ public class TestEventProducerPool {
 
   private EventProducerPool _eventProducerPool;
 
-  @BeforeTest
+  @BeforeMethod
   public void setUp() throws Exception {
     CheckpointProvider checkpointProvider = mock(CheckpointProvider.class);
     TransportProvider transportProvider = mock(TransportProvider.class);
@@ -110,8 +111,8 @@ public class TestEventProducerPool {
         _eventProducerPool.getEventProducers(tasks, connectorType, false, new ArrayList<>());
 
     // Check if producers are reused
-    Assert.assertTrue(taskProducerMap1.get(tasks.get(0)) == taskProducerMap2.get(tasks.get(0)));
-    Assert.assertTrue(taskProducerMap1.get(tasks.get(1)) == taskProducerMap2.get(tasks.get(1)));
+    Assert.assertEquals(taskProducerMap1.get(tasks.get(0)), taskProducerMap2.get(tasks.get(0)));
+    Assert.assertEquals(taskProducerMap1.get(tasks.get(1)), taskProducerMap2.get(tasks.get(1)));
 
     // Check if new producers are generated for the new tasks.
     Set<DatastreamEventProducer> uniqueProducers = new HashSet<>();
@@ -125,18 +126,18 @@ public class TestEventProducerPool {
    */
   public void testProducerSharedForTasksWithSameDestination() {
 
-    List<DatastreamTask> tasks = new ArrayList<DatastreamTask>();
-    tasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(1)));
+    List<DatastreamTask> tasks = new ArrayList<>();
+    tasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(1), "1a", Collections.singletonList(1)));
     tasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(2)));
-    tasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(1)));
+    tasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(1), "1b", Collections.singletonList(2)));
     String connectorType = "connectorType";
 
     Map<DatastreamTask, DatastreamEventProducer> taskProducerMap =
         _eventProducerPool.getEventProducers(tasks, connectorType, false, new ArrayList<>());
 
     // Check if producers are reused
-    Assert.assertTrue(((DatastreamEventProducerImpl) taskProducerMap.get(tasks.get(0))).getEventProducer()
-        == ((DatastreamEventProducerImpl) taskProducerMap.get(tasks.get(2))).getEventProducer());
+    Assert.assertEquals(((DatastreamEventProducerImpl) taskProducerMap.get(tasks.get(0))).getEventProducer(),
+            ((DatastreamEventProducerImpl) taskProducerMap.get(tasks.get(2))).getEventProducer());
   }
 
   @Test
@@ -163,7 +164,7 @@ public class TestEventProducerPool {
             _eventProducerPool.getEventProducers(tasks, connectorType, false, unusedProducers);
 
     // Check if producer for tasks[0] is reused
-    Assert.assertTrue(taskProducerMap1.get(tasks.get(0)) == taskProducerMap2.get(tasks.get(0)));
+    Assert.assertEquals(taskProducerMap1.get(tasks.get(0)), taskProducerMap2.get(tasks.get(0)));
 
     // Make sure there is exactly one unused producer
     Assert.assertEquals(unusedProducers.size(), 1);


### PR DESCRIPTION
TransportProvider (KafkaProducer) send() is thread-safe and we are
sharing the same EventProducer/Transport among all workers of the same
destination (for different partitions). Making send() synchronized
unnecessarily limits the throughput of connector workers. send() only
needs to be synchronized with flush so this is the classic read-write
lock scenario.

Given such observation, this change replaces all synchronized usages
with finer grained read-write lock. To protect against concurrent send
from different threads on the same partition, a per-partition lock is
added to form a critical section. In reality, this lock should rarely be
contended.

Also, added updateTask capability to EventProducer to allow dynamically
update the task set the producer needs to serve. This is because event
producer need to survive and be reused across mutliple task assignments.
Such that we event producer pool would call updateTasks to let producer
know about the new assignment and make adjustments to internal structures.

Lastly, revised the way how EventProducerPool creates and reuses event
producers for new tasks so that it can call updateTasks on existing event
producers.
