### PR TITLE
Fixes in the SchemaRegistry provider hookup

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -98,6 +98,8 @@ class FileProcessor implements Runnable {
           event.payload = ByteBuffer.wrap(text.getBytes());
           event.key = ByteBuffer.allocate(0);
           event.metadata = new HashMap<>();
+          //Registering a null schema just for testing using the MockSchemaRegistryProvider
+          event.metadata.put("PayloadSchemaId", _producer.registerSchema(null));
           event.previous_payload = ByteBuffer.allocate(0);
           LOG.info("sending event " + text);
           _producer.send(new DatastreamEventRecord(event, 0, lineNo.toString()));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -178,10 +178,10 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
           InvocationTargetException e) {
         LOG.error(
             "Creating Schema registry provider factory failed with exception " + ExceptionUtils.getFullStackTrace(e));
-        throw new DatastreamException("Invalid Schema registry provider factory: " + transportFactory, e);
+        throw new DatastreamException("Invalid Schema registry provider factory: " + schemaRegistryFactoryType, e);
       }
 
-      schemaRegistryFactory
+      schemaRegistry = schemaRegistryFactory
           .createSchemaRegistryProvider(coordinatorProperties.getDomainProperties(SCHEMA_REGISTRY_CONFIG_DOMAIN));
     } else {
       LOG.info("Schema registry factory is not set, So schema registry provider won't be available for connectors");

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/MockSchemaRegistryProvider.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/MockSchemaRegistryProvider.java
@@ -1,0 +1,18 @@
+package com.linkedin.datastream.server;
+
+import org.apache.avro.Schema;
+
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryException;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
+
+
+public class MockSchemaRegistryProvider implements SchemaRegistryProvider {
+
+  public static String MOCK_SCHEMA_ID = "mockSchemaId";
+
+  @Override
+  public String registerSchema(Schema schema)
+      throws SchemaRegistryException {
+    return MOCK_SCHEMA_ID;
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/MockSchemaRegistryProviderFactory.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/MockSchemaRegistryProviderFactory.java
@@ -1,0 +1,17 @@
+package com.linkedin.datastream.server;
+
+import java.util.Properties;
+
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProviderFactory;
+
+
+public class MockSchemaRegistryProviderFactory implements SchemaRegistryProviderFactory {
+
+  @Override
+  public SchemaRegistryProvider createSchemaRegistryProvider(Properties properties) {
+    return new MockSchemaRegistryProvider();
+  }
+}
+
+

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.UUID;
 
+import org.apache.avro.Schema;
+import org.apache.avro.util.Utf8;
 import org.apache.commons.io.FileUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,6 +23,7 @@ import com.linkedin.datastream.common.AvroUtils;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamEvent;
 import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.connectors.DummyBootstrapConnector;
@@ -31,6 +34,9 @@ import com.linkedin.datastream.connectors.file.FileConnector;
 import com.linkedin.datastream.connectors.file.FileConnectorFactory;
 import com.linkedin.datastream.kafka.EmbeddedZookeeperKafkaCluster;
 import com.linkedin.datastream.kafka.KafkaDestination;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryException;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
+import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProviderFactory;
 import com.linkedin.datastream.server.assignment.BroadcastStrategy;
 import com.linkedin.datastream.server.assignment.LoadbalancingStrategy;
 import com.linkedin.datastream.server.zk.KeyBuilder;
@@ -47,6 +53,7 @@ public class TestDatastreamServer {
   public static final String DUMMY_CONNECTOR = DummyConnector.CONNECTOR_TYPE;
   public static final String DUMMY_BOOTSTRAP_CONNECTOR = DummyBootstrapConnector.CONNECTOR_TYPE;
   public static final String FILE_CONNECTOR = FileConnector.CONNECTOR_TYPE;
+
 
   private EmbeddedDatastreamCluster _datastreamCluster;
 
@@ -99,9 +106,11 @@ public class TestDatastreamServer {
     Map<String, Properties> connectorProperties = new HashMap<>();
     connectorProperties.put(FILE_CONNECTOR, getTestConnectorProperties(strategy));
     connectorProperties.get(FILE_CONNECTOR).put(FileConnector.CFG_NUM_PARTITIONS, String.valueOf(numDestinationPartitions));
+    Properties override = new Properties();
+    override.put(CoordinatorConfig.CONFIG_SCHEMA_REGISTRY_PROVIDER_FACTORY, MockSchemaRegistryProviderFactory.class.getTypeName());
     EmbeddedDatastreamCluster datastreamKafkaCluster =
         EmbeddedDatastreamCluster.newTestDatastreamCluster(new EmbeddedZookeeperKafkaCluster(), connectorProperties,
-            new Properties(), numServers);
+            override, numServers);
     return datastreamKafkaCluster;
   }
 
@@ -126,7 +135,7 @@ public class TestDatastreamServer {
     FileUtils.writeLines(new File(fileName1), eventsWritten1);
 
 
-    Collection<String> eventsReceived1 = readEvents(fileDatastream1, totalEvents);
+    Collection<String> eventsReceived1 = readFileDatastreamEvents(fileDatastream1, totalEvents);
 
     LOG.info("Events Received " + eventsReceived1);
     LOG.info("Events Written to file " + eventsWritten1);
@@ -141,7 +150,7 @@ public class TestDatastreamServer {
     Collection<String> eventsWritten2 = TestUtils.generateStrings(totalEvents);
     FileUtils.writeLines(new File(fileName2), eventsWritten2);
 
-    Collection<String> eventsReceived2 = readEvents(fileDatastream2, totalEvents);
+    Collection<String> eventsReceived2 = readFileDatastreamEvents(fileDatastream2, totalEvents);
 
     LOG.info("Events Received " + eventsReceived2);
     LOG.info("Events Written to file " + eventsWritten2);
@@ -171,7 +180,7 @@ public class TestDatastreamServer {
     // Write some events and make sure DMS properly produces them
     FileUtils.writeLines(new File(fileName1), eventsWritten1);
 
-    List<String> eventsReceived1 = readEvents(fileDatastream1, totalEvents);
+    List<String> eventsReceived1 = readFileDatastreamEvents(fileDatastream1, totalEvents);
 
     LOG.info("Events Received " + eventsReceived1);
     LOG.info("Events Written to file " + eventsWritten1);
@@ -206,7 +215,7 @@ public class TestDatastreamServer {
 
     // Read twice as many events (eventsWritten1 + eventsWritten2) because
     // KafkaTestUtils.readTopic always seeks to the beginning of the topic.
-    List<String> eventsReceived2 = readEvents(fileDatastream1, totalEvents * 2);
+    List<String> eventsReceived2 = readFileDatastreamEvents(fileDatastream1, totalEvents * 2);
 
     LOG.info("Events Received " + eventsReceived2);
     LOG.info("Events Written to file " + eventsWritten2);
@@ -236,7 +245,7 @@ public class TestDatastreamServer {
     // Start with a few events and make sure DMS properly produces them
     FileUtils.writeLines(new File(fileName1), eventsWritten1);
 
-    List<String> eventsReceived1 = readEvents(fileDatastream1, totalEvents * 2);
+    List<String> eventsReceived1 = readFileDatastreamEvents(fileDatastream1, totalEvents * 2);
 
     LOG.info("Events Received " + eventsReceived1);
     LOG.info("Events Written to file " + eventsWritten1);
@@ -281,7 +290,7 @@ public class TestDatastreamServer {
 
     // Read three times as many events (eventsWritten1 * 2 + eventsWritten2) because
     // KafkaTestUtils.readTopic always seeks to the beginning of the topic.
-    List<String> eventsReceived2 = readEvents(fileDatastream1, totalEvents * 3);
+    List<String> eventsReceived2 = readFileDatastreamEvents(fileDatastream1, totalEvents * 3);
 
     LOG.info("Events Received " + eventsReceived2);
     LOG.info("Events Written to file " + eventsWritten2);
@@ -320,8 +329,8 @@ public class TestDatastreamServer {
     FileUtils.writeLines(new File(fileName1), eventsWritten1);
     FileUtils.writeLines(new File(fileName2), eventsWritten2);
 
-    List<String> eventsReceived1 = readEvents(fileDatastream1, totalEvents);
-    List<String> eventsReceived2 = readEvents(fileDatastream2, totalEvents);
+    List<String> eventsReceived1 = readFileDatastreamEvents(fileDatastream1, totalEvents);
+    List<String> eventsReceived2 = readFileDatastreamEvents(fileDatastream2, totalEvents);
 
     LOG.info("(1) Events Received " + eventsReceived1);
     LOG.info("(1) Events Written to file " + eventsWritten1);
@@ -362,8 +371,8 @@ public class TestDatastreamServer {
 
     // Read twice as many events because KafkaTestUtils.readTopic always seeks
     // to the beginning of the topic such that previous events are included
-    eventsReceived1 = readEvents(fileDatastream1, totalEvents * 2);
-    eventsReceived2 = readEvents(fileDatastream2, totalEvents * 2);
+    eventsReceived1 = readFileDatastreamEvents(fileDatastream1, totalEvents * 2);
+    eventsReceived2 = readFileDatastreamEvents(fileDatastream2, totalEvents * 2);
 
     LOG.info("(1-NEW) Events Received " + eventsReceived1);
     LOG.info("(1-NEW) Events Written to file " + eventsWritten1);
@@ -374,7 +383,7 @@ public class TestDatastreamServer {
     Assert.assertTrue(eventsReceived2.containsAll(eventsWritten2));
   }
 
-  private List<String> readEvents(Datastream fileDatastream1, int totalEvents) throws Exception {
+  private List<String> readFileDatastreamEvents(Datastream fileDatastream1, int totalEvents) throws Exception {
     KafkaDestination kafkaDestination =
         KafkaDestination.parseKafkaDestinationUri(fileDatastream1.getDestination().getConnectionString());
     final int[] numberOfMessages = { 0 };
@@ -382,6 +391,10 @@ public class TestDatastreamServer {
     KafkaTestUtils.readTopic(kafkaDestination.topicName(), 0, _datastreamCluster.getBrokerList(), (key, value) -> {
       DatastreamEvent datastreamEvent = AvroUtils.decodeAvroSpecificRecord(DatastreamEvent.class, value);
       String eventValue = new String(datastreamEvent.payload.array());
+      DatastreamUtils.processEventMetadata(datastreamEvent);
+      String schemaId = datastreamEvent.metadata.get("PayloadSchemaId").toString();
+      LOG.info("Schema Id: " + schemaId);
+      Assert.assertEquals(schemaId, MockSchemaRegistryProvider.MOCK_SCHEMA_ID);
       eventsReceived.add(eventValue);
       numberOfMessages[0]++;
       return numberOfMessages[0] < totalEvents;


### PR DESCRIPTION
- Fixes in the schmearegistryprovider hookup in the datastream server
- Changes to the file connector to register the schema
- Adding the validations to check whether the schemaId is being set appropriately.
