### PR TITLE
Running tests ten times in travis to catch any issues with tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: java
 
 script:
-  - "./gradlew test --continue"
+  - "seq 10 | xargs -Iz ./gradlew clean test --continue"
 before_cache:
   - rm -f $HOME/.gradle/caches/modules-2/modules-2.lock
 cache:


### PR DESCRIPTION
Right now we see some strange flakiness in tests when we run on non dev machines. This change makes the tests run ten times on travis machines. 

This is a temporary change, we will revert it when we get enough confidence.
