### PR TITLE
Changing the API of the schemaregistry to register schemas

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -99,7 +99,7 @@ class FileProcessor implements Runnable {
           event.key = ByteBuffer.allocate(0);
           event.metadata = new HashMap<>();
           //Registering a null schema just for testing using the MockSchemaRegistryProvider
-          event.metadata.put("PayloadSchemaId", _producer.registerSchema(null));
+          event.metadata.put("PayloadSchemaId", _producer.registerSchema(null, null));
           event.previous_payload = ByteBuffer.allocate(0);
           LOG.info("sending event " + text);
           _producer.send(new DatastreamEventRecord(event, 0, lineNo.toString()));

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
@@ -26,11 +26,12 @@ public interface DatastreamEventProducer {
   /**
    * Register the schema in schema registry. If the schema already exists in the registry
    * Just return the schema Id of the existing
+   * @param schemaName Name of the schema. Schema within the same name needs to be backward compatible.
    * @param schema Schema that needs to be registered.
    * @return
    *   SchemaId of the registered schema.
    */
-  String registerSchema(Schema schema) throws SchemaRegistryException;
+  String registerSchema(String schemaName, Schema schema) throws SchemaRegistryException;
 
   /**
    * Flush the transport for the pending events. This can be a slow and heavy operation.

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/schemaregistry/SchemaRegistryProvider.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/schemaregistry/SchemaRegistryProvider.java
@@ -11,10 +11,11 @@ public interface SchemaRegistryProvider {
   /**
    * Register the schema in schema registry. If the schema already exists in the registry
    * Just return the schema Id of the existing
+   * @param schemaName Name of the schema. Schema within the same name needs to be backward compatible.
    * @param schema Schema that needs to be registered.
    * @return
    *   SchemaId of the registered schema.
    * @throws SchemaRegistryException if the register schema fails.
    */
-  String registerSchema(Schema schema) throws SchemaRegistryException;
+  String registerSchema(String schemaName, Schema schema) throws SchemaRegistryException;
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
@@ -41,14 +41,15 @@ public class DatastreamEventProducerImpl implements DatastreamEventProducer {
   /**
    * Register the schema in schema registry. If the schema already exists in the registry
    * Just return the schema Id of the existing
+   * @param schemaName Name of the schema. Schema within the same name needs to be backward compatible.
    * @param schema Schema that needs to be registered.
    * @return
    *   SchemaId of the registered schema.
    */
   @Override
-  public String registerSchema(Schema schema) throws SchemaRegistryException {
+  public String registerSchema(String schemaName, Schema schema) throws SchemaRegistryException {
     if (_schemaRegistryProvider != null) {
-      return _schemaRegistryProvider.registerSchema(schema);
+      return _schemaRegistryProvider.registerSchema(schemaName, schema);
     } else {
       LOG.info("SchemaRegistryProvider is not configured, so registerSchema is not supported");
       throw new RuntimeException("SchemaRegistryProvider is not configured, So registerSchema is not supported");

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/MockSchemaRegistryProvider.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/MockSchemaRegistryProvider.java
@@ -11,7 +11,7 @@ public class MockSchemaRegistryProvider implements SchemaRegistryProvider {
   public static String MOCK_SCHEMA_ID = "mockSchemaId";
 
   @Override
-  public String registerSchema(Schema schema)
+  public String registerSchema(String schemaName, Schema schema)
       throws SchemaRegistryException {
     return MOCK_SCHEMA_ID;
   }


### PR DESCRIPTION
Right now schemaregistry uses the schema name as dimension around which the backward compatibility is enforced but the tableschema.Name for espresso is always "key_name" so we should provide capability for connector to specific a custom schemaName. 
