### PR TITLE
Adding unchecked exception DatastreamRuntimeException

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -1,5 +1,22 @@
 package com.linkedin.datastream;
 
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+
+import org.apache.log4j.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
@@ -16,21 +33,6 @@ import com.linkedin.datastream.server.DatastreamServer;
 import com.linkedin.datastream.server.DummyTransportProviderFactory;
 import com.linkedin.datastream.testutil.EmbeddedZookeeper;
 import com.linkedin.r2.RemoteInvocationException;
-import java.io.IOException;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Properties;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import org.apache.log4j.Level;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
-import org.testng.annotations.Test;
 
 
 @Test(singleThreaded = true)
@@ -140,14 +142,8 @@ public class TestDatastreamRestClient {
       restClient.createDatastream(datastream);
     }
 
-    Optional<List<Datastream>> result = PollUtils.poll(() -> {
-      try {
-        return restClient.getAllDatastreams();
-      } catch (DatastreamException e) {
-        e.printStackTrace();
-        return null;
-      }
-    }, streams -> streams.size() - initialSize == createdCount, 100, 1000);
+    Optional<List<Datastream>> result = PollUtils.poll(restClient::getAllDatastreams,
+        streams -> streams.size() - initialSize == createdCount, 100, 1000);
 
     Assert.assertTrue(result.isPresent());
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamNotFoundException.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamNotFoundException.java
@@ -3,7 +3,7 @@ package com.linkedin.datastream.common;
 /**
  * Exception when the datastream is not found.
  */
-public class DatastreamNotFoundException extends DatastreamException {
+public class DatastreamNotFoundException extends DatastreamRuntimeException {
   public DatastreamNotFoundException(String datastreamName, Throwable e) {
     super(String.format("Datastream %s is not found", datastreamName), e);
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamRuntimeException.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamRuntimeException.java
@@ -1,0 +1,23 @@
+package com.linkedin.datastream.common;
+
+/**
+ * Common Datastream exception for all unchecked exceptions
+ */
+public class DatastreamRuntimeException extends RuntimeException {
+
+  public DatastreamRuntimeException() {
+    super();
+  }
+
+  public DatastreamRuntimeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DatastreamRuntimeException(String message) {
+    super(message);
+  }
+
+  public DatastreamRuntimeException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -140,7 +140,7 @@ public class TestCoordinator {
    */
   // This test is disabled because there are still some issues around saving the state. This should be fixed as part of
   // Scenario #3.
-  @Test(enabled = false)
+  @Test
   public void testConnectorStateSetAndGet() throws Exception {
     String testCluster = "testConnectorStateSetAndGet";
     String testConectorType = "testConnectorType";
@@ -263,7 +263,7 @@ public class TestCoordinator {
    * @throws Exception
    */
   // Flaky test!!! Need to deflake it before enabling.
-  @Test(enabled = false)
+  @Test
   public void testCoordinationWithBroadcastStrategy() throws Exception {
     String testCluster = "testCoordinationSmoke";
     String testConectorType = "testConnectorType";
@@ -415,7 +415,7 @@ public class TestCoordinator {
     }
   }
 
-  @Test(enabled = false)
+  @Test
   public void testCoordinationMultipleConnectorTypesForBroadcastStrategy() throws Exception {
     String testCluster = "testCoordinationMultipleConnectors";
 
@@ -480,7 +480,7 @@ public class TestCoordinator {
   // stress test, start multiple coordinator instances at the same time, and make sure that all of them
   // will get a unique instance name
   //
-  @Test(enabled = false)
+  @Test
   public void testStressLargeNumberOfLiveInstances() throws Exception {
     int concurrencyLevel = 100;
     String testCluster = "testStressUniqueInstanceNames";
@@ -523,7 +523,7 @@ public class TestCoordinator {
   }
 
   // this is a potentially flaky test
-  @Test(enabled = false)
+  @Test
   public void testStressLargeNumberOfDatastreams() throws Exception {
 
     int concurrencyLevel = 10;
@@ -569,7 +569,7 @@ public class TestCoordinator {
   // Test SimpleAssignmentStrategy: if new live instances come online, some tasks
   // will be moved from existing live instance to the new live instance
   //
-  @Test(enabled = false)
+  @Test
   public void testSimpleAssignmentReassignWithNewInstances() throws Exception {
     String testCluster = "testSimpleAssignmentReassignWithNewInstances";
     String testConnectoryType = "testConnectoryType";
@@ -634,7 +634,7 @@ public class TestCoordinator {
   // Test for SimpleAssignmentStrategy
   // Verify that when instance dies, the assigned tasks will be re-assigned to remaining live instances
   //
-  @Test(enabled = false)
+  @Test
   public void testSimpleAssignmentReassignAfterDeath() throws Exception {
     String testCluster = "testSimpleAssignmentReassignAfterDeath";
     String testConnectoryType = "testConnectoryType";
@@ -698,7 +698,7 @@ public class TestCoordinator {
     zkClient.close();
   }
 
-  @Test(enabled = false)
+  @Test
   public void testBroadcastAssignmentReassignAfterDeath() throws Exception {
     String testCluster = "testBroadcastAssignmentReassignAfterDeath";
     String testConnectoryType = "testConnectoryType";
@@ -766,7 +766,7 @@ public class TestCoordinator {
   // this case tests the scenario when the leader of the cluster dies, and make sure
   // the assignment will be taken over by the new leader.
   //
-  @Test(enabled = false)
+  @Test
   public void testSimpleAssignmentReassignAfterLeaderDeath() throws Exception {
     String testCluster = "testSimpleAssignmentReassignAfterLeaderDeath";
     String testConnectoryType = "testConnectoryType";
@@ -852,7 +852,7 @@ public class TestCoordinator {
   //
   // this test covers the scenario when multiple instances die at the same time
   //
-  @Test(enabled = false)
+  @Test
   public void testMultipleInstanceDeath() throws Exception {
     String testCluster = "testMultipleInstanceDeath";
     String testConnectoryType = "testConnectoryType";
@@ -915,7 +915,7 @@ public class TestCoordinator {
   // has a smaller lexicographical order, it will be assigned to an instance with smaller lexicographical order.
   // Put it in another word, this is how Kafka consumer rebalancing works.
   //
-  @Test(enabled = false)
+  @Test
   public void testSimpleAssignmentRebalancing() throws Exception {
     String testCluster = "testSimpleAssignmentRebalancing";
     String testConnectoryType = "testConnectoryType";
@@ -969,7 +969,7 @@ public class TestCoordinator {
   // we have two connectors for each instance, and they are using different assignment
   // strategies, BroadcastStrategy and SimpleStrategy respectively.
   //
-  @Test(enabled = false)
+  @Test
   public void testSimpleAssignmentStrategyIndependent() throws Exception {
     String testCluster = "testSimpleAssignmentStrategy";
     String connectoryType1 = "ConnectoryType1";
@@ -1051,7 +1051,7 @@ public class TestCoordinator {
     }
   }
 
-  @Test(enabled = false)
+  @Test
   public void testCoordinatorErrorHandling() throws Exception {
     String testCluster = "testCoordinatorErrorHandling";
     String connectoryType1 = "ConnectoryType1";
@@ -1147,7 +1147,7 @@ public class TestCoordinator {
    *
    * @throws Exception
    */
-  @Test(enabled = false)
+  @Test
   public void testCreateDatastreamHappyPath() throws Exception {
     TestSetup setup = createTestCoordinator();
 
@@ -1166,7 +1166,7 @@ public class TestCoordinator {
     setup._datastreamKafkaCluster.shutdown();
   }
 
-  @Test(enabled = false)
+  @Test
   public void testEndToEndHappyPath() throws Exception {
     TestSetup setup = createTestCoordinator();
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -435,20 +435,12 @@ public class TestDatastreamServer {
   private Datastream getPopulatedDatastream(DatastreamRestClient restClient, Datastream fileDatastream1) {
     Boolean pollResult = PollUtils.poll(() -> {
       Datastream ds = null;
-      try {
-        ds = restClient.getDatastream(fileDatastream1.getName());
-      } catch (DatastreamException e) {
-        throw new RuntimeException("GetDatastream threw an exception", e);
-      }
+      ds = restClient.getDatastream(fileDatastream1.getName());
       return ds.hasDestination() && ds.getDestination().hasConnectionString() && !ds.getDestination().getConnectionString().isEmpty();
     }, 500, 60000);
 
     if (pollResult) {
-      try {
-        return restClient.getDatastream(fileDatastream1.getName());
-      } catch (DatastreamException e) {
-        throw new RuntimeException("GetDatastream threw an exception", e);
-      }
+      return restClient.getDatastream(fileDatastream1.getName());
     } else {
       throw new RuntimeException("Destination was not populated before the timeout");
     }


### PR DESCRIPTION
Adding an unchecked exception called DatastreamRuntimeException. And converting all the APIs to use the unchecked exceptions. If there was a way to act and recover from a checked exception we will do in the implementation of the API itself so that the consumer of the API doesn't need to bother. This method of exception handling also goes well with the use of lambdas which is just a side effect :).
