### PR TITLE
Print failed test output to console for debugging

### DIFF
--- a/HEADER
+++ b/HEADER
@@ -1,1 +1,0 @@
-Temporary file

--- a/build.gradle
+++ b/build.gradle
@@ -61,34 +61,22 @@ subprojects {
     }
   }
 
+  def results = [:].withDefault { [] }
   test {
-
     useTestNG()
-
-    testOutputs = [:]
-
-    beforeTest { test ->
-      testOutputs[test.name] = ""
-    }
-
-    afterTest { test, result ->
-      if (result.resultType == TestResult.ResultType.FAILURE) {
-        logger.error("Test output: " + test.name + "\n" + testOutputs[test.name])
-      }
-    }
-
-    //all standard error messages from tests will get routed to 'ERROR' level messages.
-    logging.captureStandardError(LogLevel.ERROR)
-    //all standard output messages from tests will get routed to 'INFO' level messages.
-    logging.captureStandardOutput(LogLevel.INFO)
-    
     testLogging {
       exceptionFormat = 'full'
       events "started", "passed", "skipped", "failed"
     }
+    onOutput { descriptor, event ->
+      results[descriptor.toString()] << event.message
+    }
 
-    onOutput { test, output ->
-      testOutputs[test.name] = testOutputs[test.name] + output.message
+    afterTest { descriptor, result ->
+      if(result.getResultType() == TestResult.ResultType.FAILURE) {
+        logger.lifecycle("${descriptor.toString()} failed with output: ${results[descriptor.toString()].join('')}")
+      }
+      results[descriptor.toString()] = []
     }
   }
 

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -2,12 +2,12 @@ repositories {
     repositories {
         // For license plugin.
         maven {
-            url 'http://dl.bintray.com/content/netflixoss/external-gradle-plugins/'
+            url "https://plugins.gradle.org/m2/"
         }
     }
 }
 
 dependencies {
-    classpath 'nl.javadude.gradle.plugins:license-gradle-plugin:0.6.1'
-    classpath 'com.linkedin.pegasus:gradle-plugins:1.15.4'
+    classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.12.1'
+    classpath 'com.linkedin.pegasus:gradle-plugins:3.1.2'
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.12-all.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.10-all.zip


### PR DESCRIPTION
This helps us print output to console from failing tests only such that
we can easily troubleshoot failures only occured on CI systems.
