### PR TITLE
Adding unchecked exception DatastreamRuntimeException

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamNotFoundException.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamNotFoundException.java
@@ -3,7 +3,7 @@ package com.linkedin.datastream.common;
 /**
  * Exception when the datastream is not found.
  */
-public class DatastreamNotFoundException extends DatastreamException {
+public class DatastreamNotFoundException extends DatastreamRuntimeException {
   public DatastreamNotFoundException(String datastreamName, Throwable e) {
     super(String.format("Datastream %s is not found", datastreamName), e);
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamRuntimeException.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamRuntimeException.java
@@ -1,0 +1,23 @@
+package com.linkedin.datastream.common;
+
+/**
+ * Common Datastream exception for all unchecked exceptions
+ */
+public class DatastreamRuntimeException extends RuntimeException {
+
+  public DatastreamRuntimeException() {
+    super();
+  }
+
+  public DatastreamRuntimeException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DatastreamRuntimeException(String message) {
+    super(message);
+  }
+
+  public DatastreamRuntimeException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -435,20 +435,12 @@ public class TestDatastreamServer {
   private Datastream getPopulatedDatastream(DatastreamRestClient restClient, Datastream fileDatastream1) {
     Boolean pollResult = PollUtils.poll(() -> {
       Datastream ds = null;
-      try {
-        ds = restClient.getDatastream(fileDatastream1.getName());
-      } catch (DatastreamException e) {
-        throw new RuntimeException("GetDatastream threw an exception", e);
-      }
+      ds = restClient.getDatastream(fileDatastream1.getName());
       return ds.hasDestination() && ds.getDestination().hasConnectionString() && !ds.getDestination().getConnectionString().isEmpty();
     }, 500, 60000);
 
     if (pollResult) {
-      try {
-        return restClient.getDatastream(fileDatastream1.getName());
-      } catch (DatastreamException e) {
-        throw new RuntimeException("GetDatastream threw an exception", e);
-      }
+      return restClient.getDatastream(fileDatastream1.getName());
     } else {
       throw new RuntimeException("Destination was not populated before the timeout");
     }


### PR DESCRIPTION
Adding an unchecked exception called DatastreamRuntimeException. And converting all the APIs to use the unchecked exceptions. If there was a way to act and recover from a checked exception we will do in the implementation of the API itself so that the consumer of the API doesn't need to bother. This method of exception handling also goes well with the use of lambdas which is just a side effect :).
