### PR TITLE
Show more useful error messages in DatastreamStore

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -74,7 +74,7 @@ subprojects {
 
     afterTest { descriptor, result ->
       if(result.getResultType() == TestResult.ResultType.FAILURE) {
-        logger.lifecycle("${descriptor.toString()} failed with output: ${results[descriptor.toString()].join('')}")
+        logger.lifecycle("${descriptor.toString()} failed with output:\n${results[descriptor.toString()].join('')}")
       }
       results[descriptor.toString()] = []
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -555,7 +555,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
         // Add the tasks for this connector type to the instance
         tasksByConnectorAndInstance.get(instance).forEach(task -> {
           // Each task must have a valid zkAdapter
-          ((DatastreamTaskImpl)task).setZkAdapter(_adapter);
+          ((DatastreamTaskImpl) task).setZkAdapter(_adapter);
           assigmentsByInstance.get(instance).add(task);
         });
       }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
@@ -1,6 +1,5 @@
 package com.linkedin.datastream.server;
 
-import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
 import com.linkedin.datastream.server.api.transport.TransportProvider;
 import com.linkedin.datastream.server.api.transport.TransportProviderFactory;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
@@ -6,10 +6,11 @@ import com.linkedin.datastream.server.Coordinator;
 import com.linkedin.datastream.server.DatastreamServer;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 import com.linkedin.restli.common.HttpStatus;
-import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.annotations.Action;
 import com.linkedin.restli.server.annotations.ActionParam;
 import com.linkedin.restli.server.annotations.RestLiActions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -17,15 +18,18 @@ import com.linkedin.restli.server.annotations.RestLiActions;
  */
 @RestLiActions(name = "bootstrap", namespace = "com.linkedin.datastream.server.dms")
 public class BootstrapActionResources {
+  private static final Logger LOG = LoggerFactory.getLogger(BootstrapActionResources.class);
 
   private final DatastreamStore _store;
   private final Coordinator _coordinator;
   private final DatastreamServer _datastreamServer;
+  private final ErrorLogger _errorLogger;
 
   public BootstrapActionResources(DatastreamServer datastreamServer) {
     _datastreamServer = datastreamServer;
     _store = datastreamServer.getDatastreamStore();
     _coordinator = datastreamServer.getCoordinator();
+    _errorLogger = new ErrorLogger(LOG);
   }
 
   /**
@@ -37,28 +41,32 @@ public class BootstrapActionResources {
   public Datastream create(@ActionParam("baseDatastream") String baseDatastreamName) {
     Datastream baseDatastream = _store.getDatastream(baseDatastreamName);
     if (baseDatastream == null) {
-      throw new RestLiServiceException(HttpStatus.S_404_NOT_FOUND,
-          "Can't create bootstrap datastream. Base datastream does not exists.");
+      _errorLogger.logAndThrow(HttpStatus.S_404_NOT_FOUND, "Base datastream does not exists.");
     }
     Datastream bootstrapDatastream = new Datastream();
-    bootstrapDatastream.setName(baseDatastream.getName() + "-" + System.currentTimeMillis());
+    bootstrapDatastream.setName(String.format("%s-Bootstrap-%d", baseDatastream.getName(),
+            System.currentTimeMillis()));
     try {
       String bootstrapConnectorType = _datastreamServer.getBootstrapConnector(baseDatastream.getConnectorType());
       bootstrapDatastream.setConnectorType(bootstrapConnectorType);
     } catch (DatastreamException e) {
-      throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, e);
+      _errorLogger.logAndThrow(HttpStatus.S_400_BAD_REQUEST,
+              "Missing bootstrap connector for " + baseDatastream.getConnectorType());
     }
     bootstrapDatastream.setSource(baseDatastream.getSource());
     try {
       _coordinator.initializeDatastream(bootstrapDatastream);
     } catch (DatastreamValidationException e) {
-      throw new RestLiServiceException(HttpStatus.S_400_BAD_REQUEST, e.getMessage());
+      _errorLogger.logAndThrow(HttpStatus.S_400_BAD_REQUEST, "Failed to initialize " + bootstrapDatastream, e);
     }
 
-    if (!_store.createDatastream(bootstrapDatastream.getName(), bootstrapDatastream)) {
-      throw new RestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
-          "Failed to create bootstrap datastream.");
+    try {
+      _store.createDatastream(bootstrapDatastream.getName(), bootstrapDatastream);
+    } catch (DatastreamException e) {
+      _errorLogger.logAndThrow(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
+              "Failed to initialize " + bootstrapDatastream, e);
     }
+
     return bootstrapDatastream;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -1,6 +1,7 @@
 package com.linkedin.datastream.server.dms;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamException;
 
 import java.util.stream.Stream;
 
@@ -28,22 +29,21 @@ public interface DatastreamStore {
    * Updates the datastream associated with the given key with the provided one.
    * @param key
    * @param datastream
-   * @return
+   * @throws DatastreamException
    */
-  boolean updateDatastream(String key, Datastream datastream);
+  void updateDatastream(String key, Datastream datastream) throws DatastreamException;
 
   /**
    * Creates a new datastream and associates it with the provided key.
    * @param key
    * @param datastream
-   * @return
+   * @throws DatastreamException
    */
-  boolean createDatastream(String key, Datastream datastream);
+  void createDatastream(String key, Datastream datastream) throws DatastreamException;
 
   /**
    * Deletes the datastream associated with the provided key.
    * @param key
-   * @return
    */
-  boolean deleteDatastream(String key);
+  void deleteDatastream(String key);
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ErrorLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ErrorLogger.java
@@ -1,0 +1,77 @@
+package com.linkedin.datastream.server.dms;
+
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.CreateResponse;
+import com.linkedin.restli.server.RestLiServiceException;
+
+import org.apache.commons.lang.Validate;
+import org.slf4j.Logger;
+
+import java.util.UUID;
+
+/**
+ * Simple utility class for logging and throwing/returning a restli exception.
+ * A random UUID is attached for each instance for more readable log output.
+ */
+final class ErrorLogger {
+  private String _id;
+  private Logger _logger;
+
+  public ErrorLogger(Logger logger) {
+    Validate.notNull(logger, "null logger");
+    _logger = logger;
+    _id = UUID.randomUUID().toString();
+  }
+
+  /**
+   * Log error and throw RestliServiceException
+   * @param status HTTP status
+   * @param msg error message
+   */
+  public void logAndThrow(HttpStatus status, String msg) {
+    logAndThrow(status, msg, null);
+  }
+
+  /**
+   * Log error and throw RestliServiceException with inner exception
+   * @param status HTTP status
+   * @param msg error message
+   * @param e inner exception
+   */
+  public void logAndThrow(HttpStatus status, String msg, Exception e) {
+    if (e != null) {
+      _logger.error(String.format("[%s] %s", _id, msg), e);
+      throw new RestLiServiceException(status, msg + " cause=" + e.getMessage());
+    } else {
+      _logger.error(String.format("[%s] %s", _id, msg));
+      throw new RestLiServiceException(status, msg);
+    }
+  }
+
+  /**
+   * Log error and return a CreateResponse
+   * @param status HTTP status
+   * @param msg error message
+   * @return CreateResponse object
+   */
+  public CreateResponse logAndGetResponse(HttpStatus status, String msg) {
+    return logAndGetResponse(status, msg, null);
+  }
+
+  /**
+   * Log error and return a CreateResponse with inner exception
+   * @param status HTTP status
+   * @param msg error message
+   * @param e inner exception
+   * @return CreateResponse object
+   */
+  public CreateResponse logAndGetResponse(HttpStatus status, String msg, Exception e) {
+    if (e != null) {
+      _logger.error(String.format("[%s] %s", _id, msg), e);
+      return new CreateResponse(new RestLiServiceException(status, msg + " cause=" + e.getMessage()));
+    } else {
+      _logger.error(String.format("[%s] %s", _id, msg));
+      return new CreateResponse(new RestLiServiceException(status, msg));
+    }
+  }
+}

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.datastream.testutil;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.server.dms.ZookeeperBackedDatastreamStore;
@@ -60,7 +61,7 @@ public class DatastreamTestUtils {
    * @param cluster name of the datastream cluster
    * @param datastreams list of datastreams
    */
-  public static void storeDatastreams(ZkClient zkClient, String cluster, Datastream... datastreams) {
+  public static void storeDatastreams(ZkClient zkClient, String cluster, Datastream... datastreams) throws DatastreamException {
     for (Datastream datastream : datastreams) {
       zkClient.ensurePath(KeyBuilder.datastreams(cluster));
       ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(zkClient, cluster);
@@ -78,7 +79,7 @@ public class DatastreamTestUtils {
    * @return
    */
   public static Datastream[] createAndStoreDatastreams(ZkClient zkClient, String cluster, String connectorType,
-      String... datastreamNames) {
+      String... datastreamNames) throws DatastreamException {
     Datastream[] datasteams = createDatastreams(connectorType, datastreamNames);
     storeDatastreams(zkClient, cluster, datasteams);
     return datasteams;

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
@@ -25,6 +25,7 @@ public class ReflectionUtils {
    * @param <T> type fo the class
    * @return instance of the class, or null if anything went wrong
    */
+  @SuppressWarnings("unchecked")
   public static <T> T createInstance(String clazz, Object... args)
       throws ClassNotFoundException, NoSuchMethodException, InvocationTargetException, InstantiationException,
              IllegalAccessException {
@@ -71,6 +72,7 @@ public class ReflectionUtils {
    * @param <T> type of the field
    * @return the value of the field or null if failed
    */
+  @SuppressWarnings("unchecked")
   public static <T> T getField(Object object, String field) throws Exception {
     Validate.notNull(object, "null target object");
     Validate.notNull(field, "null field name");
@@ -152,6 +154,7 @@ public class ReflectionUtils {
    * @param <T> return type
    * @return return value of the method, null for void methods
    */
+  @SuppressWarnings("unchecked")
   public static <T> T callMethod(Object object, String methodName, Object... args) throws Exception {
     Validate.notNull(object, "null class name");
     Method method = null;


### PR DESCRIPTION
ZookeeperBasedDatastreamStore returns false instead of throwing
exceptions for error conditions. This makes it hard to troubleshoot REST
failures.

This change replaces return false with throws which provides more
information on the specific errors.
