### PR TITLE
Adding capability for connectors to dedup datastreams

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
@@ -130,7 +130,8 @@ public class FileConnector implements Connector {
   }
 
   @Override
-  public void initializeDatastream(Datastream stream) throws DatastreamValidationException {
+  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
     LOG.info("validating datastream " + stream.toString());
     File streamFile = new File(stream.getSource().getConnectionString());
     if (!streamFile.exists() || !streamFile.isFile()) {
@@ -140,5 +141,7 @@ public class FileConnector implements Connector {
     if (_numPartitions != 1) {
       stream.getSource().setPartitions(_numPartitions);
     }
+
+    return stream;
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -34,9 +34,15 @@ public interface Connector {
   void onAssignmentChange(List<DatastreamTask> tasks);
 
   /**
-   * Validate the datastream. Datastream management service call this before writing the
+   * Initialize the datastream. Datastream management service call this before writing the
    * Datastream into zookeeper. DMS ensures that stream.source has sufficient details.
    * @param stream: Datastream model
+   * @param allDatastreams : all existing datastreams in the system of connector type of the datastream that is being
+   *                       initialized.
+   * @return
+   *   Initialized datastream, Returning an existing datastream will de-dup the new datastream being initialized
+   *   with the datastream that is being returned.
+   * @throws DatastreamValidationException when the datastream that is being created fails any validation.
    */
-  void initializeDatastream(Datastream stream) throws DatastreamValidationException;
+  Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams) throws DatastreamValidationException;
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -105,20 +105,24 @@ public class ConnectorWrapper {
     logApiEnd("onAssignmentChange");
   }
 
-  public synchronized void initializeDatastream(Datastream stream)
+  public synchronized Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     logApiStart("initializeDatastream");
+
+    Datastream initializedDatastream;
 
     try {
       if (!stream.hasDestination()) {
         stream.setDestination(new DatastreamDestination());
       }
-      _connector.initializeDatastream(stream);
+      initializedDatastream = _connector.initializeDatastream(stream, allDatastreams);
     } catch (Exception ex) {
       logErrorAndException("initializeDatastream", ex);
       throw ex;
     }
 
     logApiEnd("initializeDatastream");
+
+    return initializedDatastream;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -622,18 +622,24 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
    * @param datastream datastream for validation
    * @return result of the validation
    */
-  public void initializeDatastream(Datastream datastream)
+  public Datastream initializeDatastream(Datastream datastream)
       throws DatastreamValidationException {
     String connectorType = datastream.getConnectorType();
+    List<Datastream> allDatastreams = _adapter.getAllDatastreams().stream()
+        .filter(d -> d.getConnectorType().equals(connectorType))
+        .collect(Collectors.toList());
+
     ConnectorWrapper connector = _connectors.get(connectorType);
     if (connector == null) {
       throw new DatastreamValidationException("Invalid connector type: " + connectorType);
     }
 
-    connector.initializeDatastream(datastream);
+    Datastream initializedDatastream = connector.initializeDatastream(datastream, allDatastreams);
     if (connector.hasError()) {
       _eventQueue.put(CoordinatorEvent.createHandleInstanceErrorEvent(connector.getLastError()));
     }
+
+    return initializedDatastream;
   }
 
   /**

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -123,7 +123,8 @@ public class TestCoordinator {
     }
 
     @Override
-    public void initializeDatastream(Datastream stream) {
+    public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams) {
+      return stream;
     }
 
     @Override
@@ -180,7 +181,8 @@ public class TestCoordinator {
       }
 
       @Override
-      public void initializeDatastream(Datastream stream) {
+      public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams) {
+        return stream;
       }
     };
     coordinator.addConnector(testConectorType, testConnector, new BroadcastStrategy(), false);
@@ -1048,8 +1050,9 @@ public class TestCoordinator {
     }
 
     @Override
-    public void initializeDatastream(Datastream stream) throws DatastreamValidationException {
-
+    public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+        throws DatastreamValidationException {
+      return stream;
     }
   }
 

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
@@ -36,9 +36,12 @@ public class DummyBootstrapConnector implements Connector {
   }
 
   @Override
-  public void initializeDatastream(Datastream stream) throws DatastreamValidationException {
+  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
     if (stream == null || stream.getSource() == null) {
       throw new DatastreamValidationException("Failed to get source from datastream.");
     }
+
+    return stream;
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
@@ -41,12 +41,15 @@ public class DummyConnector implements Connector {
   }
 
   @Override
-  public void initializeDatastream(Datastream stream) throws DatastreamValidationException {
+  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
     if (stream == null || stream.getSource() == null) {
       throw new DatastreamValidationException("Failed to get source from datastream.");
     }
     if (!stream.getSource().getConnectionString().equals(VALID_DUMMY_SOURCE)) {
       throw new DatastreamValidationException("Invalid source (" + stream.getSource() + ") in datastream.");
     }
+
+    return stream;
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnector.java
@@ -111,8 +111,8 @@ public class HeartbeatConnector implements Connector {
   }
 
   @Override
-  public void initializeDatastream(Datastream stream)
+  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
-
+    return stream;
   }
 }


### PR DESCRIPTION
Adding capability in the connector API to de-dup the datastreams. Initialize now passes the list of all available datastreams to the connector. Connector can then look at the existing datastreams and de-dup the newly created datastream to one of the existing datastream. 

Coordinator looks at the returned initializedDatastream and if it is not the same as the datastream that is being created. It just returns the datastream as the response to the create rest api

Todo:
I am trying to enable all the coordinator tests so that a new test can be added to test this scenario
