### PR TITLE
Adding the test results folder to be archived

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 apply from: file('gradle/license.gradle')
 apply from: file('gradle/environment.gradle')
 apply from: file("gradle/dependency-versions.gradle")
-
+  
 buildscript {
   repositories {
     mavenCentral()
@@ -26,6 +26,8 @@ allprojects {
 subprojects {
   apply plugin: 'java'
   apply plugin: 'pegasus'
+
+  testReportDirName = "${project.rootDir}/out/${project.name}/"
 
   // Avoid failure in internal LinkedIn build validation
   if (!ext.has('spec')) {

--- a/circle.yml
+++ b/circle.yml
@@ -3,3 +3,8 @@ dependencies:
     - sudo update-alternatives --set java /usr/lib/jvm/jdk1.8.0/bin/java
     - sudo update-alternatives --set javac /usr/lib/jvm/java-8-openjdk-amd64/bin/javac
     - echo 'export JAVA_HOME=/usr/lib/jvm/jdk1.8.0/' >> ~/.circlerc
+
+test:
+  post:
+    - mkdir -p $CIRCLE_ARTIFACTS/testresults
+    - if [ -e out ]; then cp -R out/ $CIRCLE_ARTIFACTS/testresults;fi


### PR DESCRIPTION
Changes in the build.gradle to write all the test report files to the "out" directory.
Changes in the circle.yml file to copy those test report files to the folder that circle ci picks up the artifact files.
