### PR TITLE
Removing the Datastream return value from the initializeDatastream call

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
@@ -130,7 +130,7 @@ public class FileConnector implements Connector {
   }
 
   @Override
-  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     LOG.info("validating datastream " + stream.toString());
     File streamFile = new File(stream.getSource().getConnectionString());
@@ -141,7 +141,5 @@ public class FileConnector implements Connector {
     if (_numPartitions != 1) {
       stream.getSource().setPartitions(_numPartitions);
     }
-
-    return stream;
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -37,12 +37,9 @@ public interface Connector {
    * Initialize the datastream. Datastream management service call this before writing the
    * Datastream into zookeeper. DMS ensures that stream.source has sufficient details.
    * @param stream: Datastream model
-   * @param allDatastreams : all existing datastreams in the system of connector type of the datastream that is being
+   * @param allDatastreams: all existing datastreams in the system of connector type of the datastream that is being
    *                       initialized.
-   * @return
-   *   Initialized datastream, Returning an existing datastream will de-dup the new datastream being initialized
-   *   with the datastream that is being returned.
    * @throws DatastreamValidationException when the datastream that is being created fails any validation.
    */
-  Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams) throws DatastreamValidationException;
+  void initializeDatastream(Datastream stream, List<Datastream> allDatastreams) throws DatastreamValidationException;
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -105,24 +105,20 @@ public class ConnectorWrapper {
     logApiEnd("onAssignmentChange");
   }
 
-  public synchronized Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+  public synchronized void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     logApiStart("initializeDatastream");
-
-    Datastream initializedDatastream;
 
     try {
       if (!stream.hasDestination()) {
         stream.setDestination(new DatastreamDestination());
       }
-      initializedDatastream = _connector.initializeDatastream(stream, allDatastreams);
+      _connector.initializeDatastream(stream, allDatastreams);
     } catch (Exception ex) {
       logErrorAndException("initializeDatastream", ex);
       throw ex;
     }
 
     logApiEnd("initializeDatastream");
-
-    return initializedDatastream;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -620,7 +620,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
    * @param datastream datastream for validation
    * @return result of the validation
    */
-  public Datastream initializeDatastream(Datastream datastream)
+  public void initializeDatastream(Datastream datastream)
       throws DatastreamValidationException {
     String connectorType = datastream.getConnectorType();
     List<Datastream> allDatastreams = _adapter.getAllDatastreams()
@@ -635,12 +635,10 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
       throw new DatastreamValidationException(errorMessage);
     }
 
-    Datastream initializedDatastream = connector.initializeDatastream(datastream, allDatastreams);
+    connector.initializeDatastream(datastream, allDatastreams);
     if (connector.hasError()) {
       _eventQueue.put(CoordinatorEvent.createHandleInstanceErrorEvent(connector.getLastError()));
     }
-
-    return initializedDatastream;
   }
 
   /**

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
@@ -52,19 +52,10 @@ public class BootstrapActionResources {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Must specify source of Datastream!");
     }
 
-    Datastream initializedDatastream = null;
     try {
-      initializedDatastream = _coordinator.initializeDatastream(bootstrapDatastream);
+      _coordinator.initializeDatastream(bootstrapDatastream);
     } catch (DatastreamValidationException e) {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Failed to initialize " + bootstrapDatastream, e);
-    }
-
-    if (initializedDatastream == null) {
-       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Failed to initialize Datastream, initializeDatastream returned null");
-    }
-
-    if (!initializedDatastream.getName().equals(bootstrapDatastream.getName())) {
-      return initializedDatastream;
     }
 
     try {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -71,6 +71,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
   @Override
   public CreateResponse create(Datastream datastream) {
+
     // rest.li has done this mandatory field check in the latest version.
     // Just in case we roll back to an earlier version, let's do the validation here anyway
     if (!datastream.hasName()) {
@@ -91,23 +92,12 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       datastream.getMetadata().put(DatastreamMetadataConstants.IS_USER_MANAGED_DESTINATION_KEY, "true");
     }
 
-    Datastream initializedDatastream;
-
     try {
-      initializedDatastream = _coordinator.initializeDatastream(datastream);
+      _coordinator.initializeDatastream(datastream);
     } catch (DatastreamValidationException e) {
       return _errorLogger.logAndGetResponse(HttpStatus.S_400_BAD_REQUEST, "Failed to initialize Datastream: ", e);
     }
-
-    if (initializedDatastream == null) {
-      return _errorLogger.logAndGetResponse(HttpStatus.S_400_BAD_REQUEST,
-          "Failed to initialize Datastream, initializeDatastream returned null");
-    }
-
-    if (!initializedDatastream.getName().equals(datastream.getName())) {
-      return new CreateResponse(initializedDatastream.getName());
-    }
-
+    
     try {
       _store.createDatastream(datastream.getName(), datastream);
       return new CreateResponse(datastream.getName(), HttpStatus.S_201_CREATED);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -128,8 +128,7 @@ public class TestCoordinator {
     }
 
     @Override
-    public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams) {
-      return stream;
+    public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams) {
     }
 
     @Override
@@ -186,8 +185,7 @@ public class TestCoordinator {
       }
 
       @Override
-      public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams) {
-        return stream;
+      public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams) {
       }
     };
 
@@ -1158,9 +1156,8 @@ public class TestCoordinator {
     }
 
     @Override
-    public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+    public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
         throws DatastreamValidationException {
-      return stream;
     }
   }
 

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
@@ -36,12 +36,10 @@ public class DummyBootstrapConnector implements Connector {
   }
 
   @Override
-  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     if (stream == null || stream.getSource() == null) {
       throw new DatastreamValidationException("Failed to get source from datastream.");
     }
-
-    return stream;
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
@@ -41,7 +41,7 @@ public class DummyConnector implements Connector {
   }
 
   @Override
-  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     if (stream == null || stream.getSource() == null) {
       throw new DatastreamValidationException("Failed to get source from datastream.");
@@ -49,7 +49,5 @@ public class DummyConnector implements Connector {
     if (!stream.getSource().getConnectionString().equals(VALID_DUMMY_SOURCE)) {
       throw new DatastreamValidationException("Invalid source (" + stream.getSource() + ") in datastream.");
     }
-
-    return stream;
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/HeartbeatConnector.java
@@ -116,8 +116,7 @@ public class HeartbeatConnector implements Connector {
   }
 
   @Override
-  public Datastream initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
-    return stream;
   }
 }


### PR DESCRIPTION
Previous implementation of the connector interface expected connectors to return the de-duped datastreams so that the datastream that is de-duped won't be created. But this is kind of different from existing de-duping methodology we use in the datastream server where we have different datastreams but share the same topic. To keep things consistent, we will use the same de-duping logic in initializeDatastream too. 
