### PR TITLE
Add destination retention support

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -19,4 +19,14 @@ public class DatastreamMetadataConstants {
    * Represents datastream owner
    */
   public static final String OWNER_KEY = "owner";
+
+  /**
+   * Timestamp in Epoch-milis when destination was created
+   */
+  public static final String DESTINATION_CREATION_MS = "destination.creation.ms";
+
+  /**
+   * Duration in Epoch-milis before destination starts to delete messages
+   */
+  public static final String DESTINATION_RETENION_MS = "destination.retention.ms";
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.server.api.transport;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import com.linkedin.datastream.server.DatastreamProducerRecord;
@@ -46,4 +47,11 @@ public interface TransportProvider {
    * @throws TransportException if the flush fails.
    */
   void flush() throws TransportException;
+
+  /**
+   * Query the retention duration of a specific destination.
+   * @param destination Destination uri.
+   * @return retention duration
+   */
+  Duration getRetention(String destination);
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderFactory.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.server;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import com.linkedin.datastream.server.api.transport.TransportException;
@@ -33,6 +34,11 @@ public class DummyTransportProviderFactory implements TransportProviderFactory {
       @Override
       public void flush() {
 
+      }
+
+      @Override
+      public Duration getRetention(String destination) {
+        return Duration.ofDays(3);
       }
     };
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -17,7 +17,6 @@ import java.util.Set;
 import org.I0Itec.zkclient.IZkChildListener;
 import org.I0Itec.zkclient.IZkDataListener;
 import org.I0Itec.zkclient.exception.ZkException;
-import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
@@ -14,7 +14,6 @@ import org.testng.annotations.Test;
 import com.linkedin.datastream.connectors.DummyConnectorFactory;
 import com.linkedin.datastream.diagnostics.ServerHealth;
 import com.linkedin.datastream.kafka.EmbeddedZookeeperKafkaCluster;
-import com.linkedin.datastream.server.diagnostics.HealthBuilders;
 import com.linkedin.datastream.server.diagnostics.HealthRequestBuilders;
 import com.linkedin.r2.RemoteInvocationException;
 import com.linkedin.r2.transport.common.Client;


### PR DESCRIPTION
Destination retention is the vital information for connectors to explore
opportunities to reuse a destination for new requests. This change adds
such interface to the transport provider, who has the precise retention
of each destination. As such, destination manager can query it for each
new destination and store the expiry timestamp of it in the datastream.
