### PR TITLE
Adding testcase for usermanaged Destination

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -96,7 +96,9 @@ class FileProcessor implements Runnable {
         if (text != null) {
           DatastreamEvent event = new DatastreamEvent();
           event.payload = ByteBuffer.wrap(text.getBytes());
-          event.key = ByteBuffer.allocate(0);
+
+          // Using the line# as the key
+          event.key = ByteBuffer.wrap(lineNo.toString().getBytes());
           event.metadata = new HashMap<>();
           //Registering a null schema just for testing using the MockSchemaRegistryProvider
           event.metadata.put("PayloadSchemaId", _producer.registerSchema(null, null));
@@ -104,7 +106,12 @@ class FileProcessor implements Runnable {
           LOG.info("sending event " + text);
           DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
           builder.addEvent(event);
-          builder.setPartition(0);
+
+          // If the destination is user managed, we will use the key to decide the partition.
+          if(!_task.isUserManagedDestination()) {
+            builder.setPartition(0);
+          }
+
           builder.setSourceCheckpoint(lineNo.toString());
           _producer.send(builder.build());
           LOG.info("Sending event succeeded");

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.server;
 import java.util.List;
 import java.util.Map;
 
+import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
@@ -58,6 +59,11 @@ public interface DatastreamTask {
   String getDatastreamTaskName();
 
   /**
+   * @return whether the destination is a user managed.
+   */
+  boolean isUserManagedDestination();
+
+  /**
    * @return the Datastream source.
    */
   DatastreamSource getDatastreamSource();
@@ -80,9 +86,9 @@ public interface DatastreamTask {
   Map<Integer, String> getCheckpoints();
 
   /**
-   * @return the list of datastream names for which this task is producing events for.
+   * @return the list of datastreams for which this task is producing events for.
    */
-  List<String> getDatastreams();
+  List<Datastream> getDatastreams();
 
   /**
    * A connector must acquire a task before starting processing it. This ensures no

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -182,26 +182,6 @@ public class DatastreamServer {
     _isStarted = false;
   }
 
-  /**
-   * Return the corresponding bootstrap connector type for a connector
-   * @param baseConnectorType the base (online) connector type
-   * @return bootstrap connector type for the base connector. If the base connector doesn't
-   * have a bootstrap connector, a DatastreamException will be thrown.
-   * @throws DatastreamException
-   */
-  public String getBootstrapConnector(String baseConnectorType) {
-    if (!_isInitialized) {
-      String errorMessage = "DatastreamServer is not initialized.";
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, null);
-    }
-    String ret = _bootstrapConnectors.get(baseConnectorType);
-    if (ret == null) {
-      String errorMessage = "No bootstrap connector specified for connector: " + baseConnectorType;
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, null);
-    }
-    return ret;
-  }
-
   public static void main(String[] args) throws Exception {
     Properties serverProperties = getServerProperties(args);
     DatastreamServer server = new DatastreamServer(serverProperties);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.server;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.JsonUtils;
 import com.linkedin.datastream.server.zk.ZkAdapter;
@@ -135,6 +136,12 @@ public class DatastreamTaskImpl implements DatastreamTask {
     return _id.equals("") ? _datastreamName : _datastreamName + "_" + _id;
   }
 
+  @Override
+  public boolean isUserManagedDestination() {
+    String userManaged = _datastream.getMetadata().getOrDefault(DatastreamMetadataConstants.IS_USER_MANAGED_DESTINATION_KEY, "false");
+    return Boolean.parseBoolean(userManaged);
+  }
+
   @JsonIgnore
   @Override
   public DatastreamSource getDatastreamSource() {
@@ -170,8 +177,8 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   @JsonIgnore
   @Override
-  public List<String> getDatastreams() {
-    return Arrays.asList(_datastreamName);
+  public List<Datastream> getDatastreams() {
+    return Arrays.asList(_datastream);
   }
 
   @Override

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -288,6 +288,8 @@ public class EventProducer {
       _transportProvider.send(task.getDatastreamDestination().getConnectionString(), record);
 
       // Update the checkpoint for the task/partition
+      // TODO DDSDBUS-7413 This assumption that record.getPartition() will always be present may not be valid.
+      // TODO Because connector may use transport provider's hashing method to write to a specific partition.
       _latestCheckpoints.get(task).put(record.getPartition().get(), record.getCheckpoint());
 
       // Dirty the flag
@@ -340,9 +342,9 @@ public class EventProducer {
 
       // Clear the dirty flag
       _pendingCheckpoint = false;
-    } catch (Throwable t) {
+    } catch (Exception e) {
       String errorMessage = String.format("Failed to flush transport, tasks = [%s].", _tasks);
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, t);
+      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, e);
     } finally {
       _sendFlushLock.writeLock().unlock();
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -23,6 +23,9 @@ public class BroadcastStrategy implements AssignmentStrategy {
   public Map<String, Set<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
       Map<String, Set<DatastreamTask>> currentAssignment) {
 
+    LOG.info(String.format("Trying to assign datastreams {%s} to instances {%s} and the current assignment is {%s}",
+        datastreams, instances, currentAssignment));
+
     Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
 
     for (String instance : instances) {
@@ -36,7 +39,7 @@ public class BroadcastStrategy implements AssignmentStrategy {
           currentAssignment.get(instance) :  new HashSet<>();
 
       for (DatastreamTask datastreamTask : currentAssignmentForInstance) {
-        datastreamTask.getDatastreams().stream().forEach(d -> datastreamToTaskMap.put(d, datastreamTask));
+        datastreamTask.getDatastreams().stream().forEach(d -> datastreamToTaskMap.put(d.getName(), datastreamTask));
       }
 
       for (Datastream datastream : datastreams) {
@@ -45,6 +48,8 @@ public class BroadcastStrategy implements AssignmentStrategy {
         newAssignmentForInstance.add(foundDatastreamTask);
       }
     }
+
+    LOG.info(String.format("New assignment is {%s}", assignment));
 
     return assignment;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
@@ -62,21 +62,11 @@ public class ServerHealthResources extends SimpleResourceTemplate<ServerHealth> 
 
     for (DatastreamTask task : _coordinator.getTasksByConnectorType().get(connectorType)) {
       TaskHealth taskHealth = new TaskHealth();
-      taskHealth.setDatastreams(String.join(",", task.getDatastreams()));
-
-      if (task.getDatastreamDestination() != null) {
-        taskHealth.setDestination(task.getDatastreamDestination().getConnectionString());
-      }
-
-      if (task.getDatastreamSource() != null) {
-        taskHealth.setSource(task.getDatastreamSource().getConnectionString());
-      }
-
-      if (task.getStatus() != null) {
-        taskHealth.setStatusCode(task.getStatus().getCode().toString());
-        taskHealth.setStatusMessage(task.getStatus().getMessage());
-      }
-
+      taskHealth.setDatastreams(task.getDatastreams().toString());
+      taskHealth.setDestination(task.getDatastreamDestination().getConnectionString());
+      taskHealth.setSource(task.getDatastreamSource().getConnectionString());
+      taskHealth.setStatusCode(task.getStatus().getCode().toString());
+      taskHealth.setStatusMessage(task.getStatus().getMessage());
       taskHealth.setName(task.getDatastreamTaskName());
       taskHealth.setPartitions(task.getPartitions().toString());
       taskHealth.setSourceCheckpoint(task.getCheckpoints().toString());

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -2,6 +2,7 @@ package com.linkedin.datastream.testutil;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.zk.ZkClient;
@@ -56,10 +57,35 @@ public class DatastreamTestUtils {
   }
 
   /**
+   * Creates a test datastream of specific connector type
+   * @param connectorType connector type of the datastream to be created.
+   * @param datastreamName Name of the datastream to be created.
+   * @param source source connection string to be used.
+   * @param destination the destination connection string to be used.
+   * @param destinationPartitions the destination partitions
+   * @return Datastream that is created.
+   */
+  public static Datastream createDatastream(String connectorType, String datastreamName, String source,
+      String destination, int destinationPartitions) {
+    Datastream ds = new Datastream();
+    ds.setName(datastreamName);
+    ds.setConnectorType(connectorType);
+    ds.setSource(new DatastreamSource());
+    ds.getSource().setConnectionString(source);
+    ds.setDestination(new DatastreamDestination());
+    ds.getDestination().setConnectionString(destination);
+    ds.getDestination().setPartitions(destinationPartitions);
+    StringMap metadata = new StringMap();
+    ds.setMetadata(metadata);
+    return ds;
+  }
+
+  /**
    * Store the datastreams into the appropriate locations in zookeeper.
    * @param zkClient zookeeper client
    * @param cluster name of the datastream cluster
    * @param datastreams list of datastreams
+   * @throws DatastreamException the datastream exception
    */
   public static void storeDatastreams(ZkClient zkClient, String cluster, Datastream... datastreams) throws DatastreamException {
     for (Datastream datastream : datastreams) {
@@ -76,7 +102,8 @@ public class DatastreamTestUtils {
    * @param cluster name of the datastream cluster
    * @param connectorType connector type string
    * @param datastreamNames list of datastream names
-   * @return
+   * @return datastream [ ]
+   * @throws DatastreamException the datastream exception
    */
   public static Datastream[] createAndStoreDatastreams(ZkClient zkClient, String cluster, String connectorType,
       String... datastreamNames) throws DatastreamException {


### PR DESCRIPTION
Enabled the file connector to support usermanaged destination datastreams
Added the test case using the file connector, The test case is disabled because the event producer depends on the partition number in the datastreamEventRecord but the datastreamEventRecord may not contain the partition number always. (This is true even for datastreams whose destinations are created by the framework i.e. isUserManaged = false)
