### PR TITLE
Fix for race between the assignment node getting created and actual assignment

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -17,7 +17,7 @@ import com.linkedin.datastream.server.api.connector.DatastreamValidationExceptio
  * some bookkeeping features like logging and try-catch error handling.
  */
 public class ConnectorWrapper {
-  private static final Logger LOG = LoggerFactory.getLogger(ConnectorWrapper.class.getName());
+  private final Logger _log;
   private final String _connectorType;
 
   private String _instanceName;
@@ -28,6 +28,7 @@ public class ConnectorWrapper {
   private long _endTime;
 
   public ConnectorWrapper(String connectorType, Connector connector) {
+    _log = LoggerFactory.getLogger(String.format("%s:%s", ConnectorWrapper.class.getName(), connectorType));
     _connectorType = connectorType;
     _connector = connector;
   }
@@ -46,19 +47,19 @@ public class ConnectorWrapper {
 
   private void logErrorAndException(String method, Exception ex) {
     String msg = "Failed to call connector API: Connector::" + method;
-    LOG.error(msg, ex);
+    _log.error(msg, ex);
     _lastError = msg + "\n" + ex.getMessage() + "\n" + ex.getStackTrace().toString();
   }
 
   private void logApiStart(String method) {
-    LOG.info(String.format("START: Connector::%s. Connector: %s, Instance: %s", method, _connectorType, _instanceName));
+    _log.info(String.format("START: Connector::%s. Connector: %s, Instance: %s", method, _connectorType, _instanceName));
     _startTime = System.currentTimeMillis();
     _lastError = null;
   }
 
   private void logApiEnd(String method) {
     _endTime = System.currentTimeMillis();
-    LOG.info(String.format("END: Connector::%s. Connector: %s, Instance: %s, Duration: %d milliseconds", method,
+    _log.info(String.format("END: Connector::%s. Connector: %s, Instance: %s, Duration: %d milliseconds", method,
         _connectorType, _instanceName, _endTime - _startTime));
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -737,6 +737,10 @@ public class TestCoordinator {
     // Make sure strategy reused all tasks as opposed to creating new ones
     List<DatastreamTask> tasks2 = new ArrayList<>(connector1.getTasks());
     Collections.sort(tasks2, (o1, o2) -> o1.getDatastreamTaskName().compareTo(o2.getDatastreamTaskName()));
+
+    LOG.info("Tasks1: " + tasks1.toString());
+    LOG.info("Tasks2: " + tasks2.toString());
+
     Assert.assertEquals(tasks1, tasks2);
 
     // Verify dead instance assignments have been removed
@@ -813,10 +817,11 @@ public class TestCoordinator {
     //
     assertConnectorAssignment(connector1, WAIT_TIMEOUT_MS, "datastream0", "datastream1");
 
-    // Make sure Coordinator has remove deprecated connector tasks of instance2
+    // Make sure Coordinator has removed deprecated connector tasks of instance2
     for (DatastreamTask task : tasks2) {
       String path = KeyBuilder.connectorTask(testCluster, task.getConnectorType(), task.getDatastreamTaskName());
-      Assert.assertFalse(zkClient.exists(path));
+      LOG.info("Checking whether the path doesn't exist anymore: " + path);
+      Assert.assertTrue(PollUtils.poll(() -> !zkClient.exists(path), 200, WAIT_TIMEOUT_MS));
     }
 
     //
@@ -915,6 +920,10 @@ public class TestCoordinator {
     // Make sure strategy reused all tasks as opposed to creating new ones
     List<DatastreamTask> tasks2 = new ArrayList<>(connector3.getTasks());
     Collections.sort(tasks2, (o1, o2) -> o1.getDatastreamTaskName().compareTo(o2.getDatastreamTaskName()));
+
+    LOG.info("Tasks1: " + tasks1.toString());
+    LOG.info("Tasks2: " + tasks2.toString());
+
     Assert.assertEquals(tasks1, tasks2);
 
     // Verify dead instance assignments have been removed


### PR DESCRIPTION
Right now we create the assignment node after creating the ephemeral node in the live instance. Creation of this ephemeral liveinstance node triggers a reassignment and if the reassignment happens before the assignment node is created. The assignment to the instance fails. 
This is one of the causes of the flakiness that we keep seeing. 
Fix is to ensure that the instance and assignment node is zk is present before the task is being written.
