### PR TITLE
add preconfig dms port number support in embedded datastream test cluster

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -165,6 +165,7 @@ project(':datastream-testcommon') {
     compile project(':datastream-utils')
     compile project(':datastream-server')
     compile project(':datastream-client')
+    compile "com.intellij:annotations:$intellijAnnotations"
     compile "commons-cli:commons-cli:$commonsCliVersion"
     compile "org.apache.avro:avro:$avroVersion"
     compile "org.apache.zookeeper:zookeeper:$zookeeperVersion"

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -113,7 +113,7 @@ public class TestDatastreamServer {
     override.put(CoordinatorConfig.CONFIG_SCHEMA_REGISTRY_PROVIDER_FACTORY, MockSchemaRegistryProviderFactory.class.getTypeName());
     EmbeddedDatastreamCluster datastreamKafkaCluster =
         EmbeddedDatastreamCluster.newTestDatastreamCluster(new EmbeddedZookeeperKafkaCluster(), connectorProperties,
-            override, numServers);
+            override, numServers, null);
     return datastreamKafkaCluster;
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
@@ -43,7 +43,7 @@ public class TestServerHealth {
     connectorProperties.put(TestDatastreamServer.DUMMY_CONNECTOR, getDummyConnectorProperties(false));
     EmbeddedDatastreamCluster datastreamKafkaCluster =
         EmbeddedDatastreamCluster.newTestDatastreamCluster(new EmbeddedZookeeperKafkaCluster(), connectorProperties,
-            override, 1);
+            override);
     return datastreamKafkaCluster;
   }
 

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -9,4 +9,5 @@ ext {
     zkclientVersion = "0.5"
     zookeeperVersion = "3.4.6"
     testngVersion = "6.4"
+    intellijAnnotations = "12.0"
 }


### PR DESCRIPTION
add preconfig dms port number support in embedded datastream test cluster
