### PR TITLE
Generators now populate general IndexedRecords instead of GenericRecords.

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -108,7 +108,7 @@ class FileProcessor implements Runnable {
           builder.addEvent(event);
 
           // If the destination is user managed, we will use the key to decide the partition.
-          if(!_task.isUserManagedDestination()) {
+          if (!_task.isUserManagedDestination()) {
             builder.setPartition(0);
           }
 

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -3,7 +3,6 @@ package com.linkedin.datastream.server;
 import java.util.List;
 import java.util.Map;
 
-import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -375,8 +375,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
     _log.info(String.format("END: Coordinator::handleAssignmentChange, Duration: %d milliseconds", endAt - startAt));
   }
 
-  private DatastreamTask getDatastreamTask( String taskName) {
-    if(_assignedDatastreamTasks.containsKey(taskName)) {
+  private DatastreamTask getDatastreamTask(String taskName) {
+    if (_assignedDatastreamTasks.containsKey(taskName)) {
       return _assignedDatastreamTasks.get(taskName);
 
     } else {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -15,7 +15,6 @@ import org.apache.commons.lang.Validate;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderFactory.java
@@ -39,8 +39,10 @@ public class DummyTransportProviderFactory implements TransportProviderFactory {
       @Override
       public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete)
           throws TransportException {
-        if(_throwOnSend && onComplete != null) {
-          onComplete.onCompletion(new DatastreamRecordMetadata(record.getCheckpoint(), destination, record.getPartition().get()), new DatastreamRuntimeException());
+        if (_throwOnSend && onComplete != null) {
+          onComplete.onCompletion(
+              new DatastreamRecordMetadata(record.getCheckpoint(), destination, record.getPartition().get()),
+              new DatastreamRuntimeException());
         }
       }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -290,7 +290,7 @@ public class EventProducer {
     SendFailedException sendFailedException = null;
 
     // Shutdown the producer right away
-    if(exception != null) {
+    if (exception != null) {
       shutdown();
       sendFailedException = new SendFailedException(_safeCheckpoints);
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
@@ -7,7 +7,6 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.diagnostics.ConnectorHealth;
 import com.linkedin.datastream.diagnostics.ConnectorHealthArray;
 import com.linkedin.datastream.diagnostics.ServerHealth;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -125,7 +125,7 @@ public class TestCoordinator {
 
       _tasks = tasks;
       for (DatastreamTask task : tasks) {
-        if(task.getEventProducer() == null) {
+        if (task.getEventProducer() == null) {
           Assert.assertNotNull(task.getEventProducer());
         }
       }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -524,7 +524,7 @@ public class TestDatastreamServer {
     testFile.createNewFile();
     testFile.deleteOnExit();
     Datastream fileDatastream1;
-    if(destinationTopic != null) {
+    if (destinationTopic != null) {
       fileDatastream1 = DatastreamTestUtils.createDatastream(FileConnector.CONNECTOR_TYPE, "file_" + testFile.getName(),
           testFile.getAbsolutePath(), destinationTopic, destinationPartitions);
     } else {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
@@ -2,23 +2,18 @@ package com.linkedin.datastream.server;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.linkedin.datastream.common.DatastreamEvent;
-import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
-import com.linkedin.datastream.server.api.transport.SendCallback;
-import com.linkedin.datastream.server.providers.CheckpointProvider;
 import com.linkedin.datastream.server.api.schemaregistry.SchemaRegistryProvider;
+import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
 import com.linkedin.datastream.server.api.transport.TransportProviderFactory;
+import com.linkedin.datastream.server.providers.CheckpointProvider;
 
 import static org.mockito.Mockito.mock;
 
@@ -83,7 +78,7 @@ public class TestEventProducerPool {
     EventProducer oldEventProducer = oldDatastreamEventProducer.getEventProducer();
     task.getEventProducer().send(createEventRecord(0), (m, e) -> {
       metadata.add(m);
-      if(e != null) {
+      if (e != null) {
         exceptions.add(e);
       }
     });

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/ArraySchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/ArraySchemaField.java
@@ -3,7 +3,7 @@ package com.linkedin.datastream.testutil.event.generator;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class ArraySchemaField extends SchemaField {
@@ -15,8 +15,8 @@ public class ArraySchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) throws UnknownTypeException {
-    record.put(_field.name(), generateArray());
+  public void writeToRecord(IndexedRecord record) throws UnknownTypeException {
+    record.put(_field.pos(), generateArray());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/BooleanSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/BooleanSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class BooleanSchemaField extends SchemaField {
@@ -11,8 +11,8 @@ public class BooleanSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) throws UnknownTypeException {
-    record.put(_field.name(), generateBoolean());
+  public void writeToRecord(IndexedRecord record) throws UnknownTypeException {
+    record.put(_field.pos(), generateBoolean());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/BytesSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/BytesSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class BytesSchemaField extends SchemaField {
@@ -11,8 +11,8 @@ public class BytesSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord genericRecord) {
-    genericRecord.put(_field.name(), generateBytes());
+  public void writeToRecord(IndexedRecord record) {
+    record.put(_field.pos(), generateBytes());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/DoubleSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/DoubleSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class DoubleSchemaField extends SchemaField {
@@ -11,8 +11,8 @@ public class DoubleSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) {
-    record.put(_field.name(), generateDouble());
+  public void writeToRecord(IndexedRecord record) {
+    record.put(_field.pos(), generateDouble());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/EnumSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/EnumSchemaField.java
@@ -3,7 +3,7 @@ package com.linkedin.datastream.testutil.event.generator;
 import java.util.List;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class EnumSchemaField extends SchemaField {
@@ -16,8 +16,8 @@ public class EnumSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) throws UnknownTypeException {
-    record.put(_field.name(), generateEnum());
+  public void writeToRecord(IndexedRecord record) throws UnknownTypeException {
+    record.put(_field.pos(), generateEnum());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/FixedLengthSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/FixedLengthSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class FixedLengthSchemaField extends SchemaField {
@@ -14,8 +14,8 @@ public class FixedLengthSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) throws UnknownTypeException {
-    record.put(_field.name(), generateFixedLengthString());
+  public void writeToRecord(IndexedRecord record) throws UnknownTypeException {
+    record.put(_field.pos(), generateFixedLengthString());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/FloatSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/FloatSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class FloatSchemaField extends SchemaField {
@@ -11,8 +11,8 @@ public class FloatSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) {
-    record.put(_field.name(), generateFloat());
+  public void writeToRecord(IndexedRecord record) {
+    record.put(_field.pos(), generateFloat());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/IntegerSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/IntegerSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class IntegerSchemaField extends SchemaField {
@@ -11,8 +11,8 @@ public class IntegerSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord genericRecord) {
-    genericRecord.put(_field.name(), generateInteger());
+  public void writeToRecord(IndexedRecord record) {
+    record.put(_field.pos(), generateInteger());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/LongSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/LongSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class LongSchemaField extends SchemaField {
@@ -11,8 +11,8 @@ public class LongSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) {
-    record.put(_field.name(), generateLong());
+  public void writeToRecord(IndexedRecord record) {
+    record.put(_field.pos(), generateLong());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/MapSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/MapSchemaField.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.util.Utf8;
 
 
@@ -15,8 +15,8 @@ public class MapSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) throws UnknownTypeException {
-    record.put(_field.name(), generateMap());
+  public void writeToRecord(IndexedRecord record) throws UnknownTypeException {
+    record.put(_field.pos(), generateMap());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/NullSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/NullSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class NullSchemaField extends SchemaField {
@@ -11,8 +11,8 @@ public class NullSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) {
-    record.put(_field.name(), null);
+  public void writeToRecord(IndexedRecord record) {
+    record.put(_field.pos(), null);
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/RecordSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/RecordSchemaField.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.testutil.event.generator;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class RecordSchemaField extends SchemaField {
@@ -12,9 +13,9 @@ public class RecordSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) throws UnknownTypeException {
+  public void writeToRecord(IndexedRecord record) throws UnknownTypeException {
 
-    record.put(_field.name(), generateRecord());
+    record.put(_field.pos(), generateRecord());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/SchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/SchemaField.java
@@ -1,9 +1,9 @@
 package com.linkedin.datastream.testutil.event.generator;
 
+import com.linkedin.datastream.testutil.common.RandomValueGenerator;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
-import com.linkedin.datastream.testutil.common.RandomValueGenerator;
+import org.apache.avro.generic.IndexedRecord;
 
 
 /*
@@ -112,9 +112,9 @@ public abstract class SchemaField {
 
   /*
    * Override to write data
-   * @param  record  The GenericRecord to which the data is to be written.
+   * @param  record  The IndexedRecord to which the data is to be written.
    */
-  public abstract void writeToRecord(GenericRecord record) throws UnknownTypeException;
+  public abstract void writeToRecord(IndexedRecord record) throws UnknownTypeException;
 
   /*
    * return the random generated object. Use this to fetch the object instead of writing to an record.

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/StringSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/StringSchemaField.java
@@ -1,7 +1,7 @@
 package com.linkedin.datastream.testutil.event.generator;
 
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 
 
 public class StringSchemaField extends SchemaField {
@@ -12,8 +12,8 @@ public class StringSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord genericRecord) {
-    genericRecord.put(_field.name(), generateString());
+  public void writeToRecord(IndexedRecord record) {
+    record.put(_field.pos(), generateString());
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/UnionSchemaField.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/UnionSchemaField.java
@@ -1,9 +1,10 @@
 package com.linkedin.datastream.testutil.event.generator;
 
-import java.util.Optional;
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
+
+import java.util.Optional;
 
 
 public class UnionSchemaField extends SchemaField {
@@ -13,7 +14,7 @@ public class UnionSchemaField extends SchemaField {
   }
 
   @Override
-  public void writeToRecord(GenericRecord record) throws UnknownTypeException {
+  public void writeToRecord(IndexedRecord record) throws UnknownTypeException {
     getUnionFieldField().writeToRecord(record);
   }
 


### PR DESCRIPTION
When generating events from known sources we need to generate SpecificRecords. By making these classes work on IndexedRecords they should work for both Generic and Specific records.

Downstream tests for our internal usage passed without problem.

Sneaked in checkstyle fixes.
