### PR TITLE
Add trailing slash to dmsURI if missing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,6 +93,7 @@ subprojects {
     compile "log4j:log4j:$log4jVersion"
     compile "org.slf4j:slf4j-api:$slf4jVersion"
     compile "org.slf4j:slf4j-log4j12:$slf4jVersion"
+    compile "org.apache.commons:commons-lang3:$commonslang3Version"
     testCompile "org.testng:testng:$testngVersion"
   }
 

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
@@ -3,6 +3,8 @@ package com.linkedin.datastream;
 import java.util.Collections;
 import java.util.List;
 
+import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +45,8 @@ public class DatastreamRestClient {
   private final HttpClientFactory _httpClient;
 
   public DatastreamRestClient(String dsmUri) {
+    Validate.notEmpty(dsmUri, "invalid DSM URI");
+    dsmUri = StringUtils.appendIfMissing(dsmUri, "/");
     _builders = new DatastreamRequestBuilders();
     _bootstrapBuilders = new BootstrapRequestBuilders();
     _httpClient = new HttpClientFactory();

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -102,7 +102,7 @@ public class TestDatastreamRestClient {
   public void testCreateDatastream() throws DatastreamException, IOException, RemoteInvocationException {
     Datastream datastream = generateDatastream(1);
     LOG.info("Datastream : " + datastream);
-    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
+    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080");
     restClient.createDatastream(datastream);
     Datastream createdDatastream = restClient.getDatastream(datastream.getName());
     LOG.info("Created Datastream : " + createdDatastream);
@@ -118,7 +118,7 @@ public class TestDatastreamRestClient {
       throws DatastreamException, InterruptedException {
     Datastream datastream = generateDatastream(11);
     LOG.info("Datastream : " + datastream);
-    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
+    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080");
     restClient.createDatastream(datastream);
     Datastream initializedDatastream = restClient.waitTillDatastreamIsInitialized(datastream.getName(), 60000);
     LOG.info("Initialized Datastream : " + initializedDatastream);

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -10,4 +10,5 @@ ext {
     zookeeperVersion = "3.4.6"
     testngVersion = "6.4"
     intellijAnnotations = "12.0"
+    commonslang3Version = "3.4"
 }


### PR DESCRIPTION
Without the trailing "/", REST client fails to connect to DSM service.
