### PR TITLE
Enabling usermanaged Destination testcase

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -33,6 +33,8 @@ import com.linkedin.datastream.common.DatastreamEvent;
 import com.linkedin.datastream.server.DatastreamEventProducer;
 import com.linkedin.datastream.server.DatastreamProducerRecordBuilder;
 import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
+import com.linkedin.datastream.server.api.transport.SendCallback;
 
 
 class FileProcessor implements Runnable {
@@ -113,8 +115,14 @@ class FileProcessor implements Runnable {
           }
 
           builder.setSourceCheckpoint(lineNo.toString());
-          _producer.send(builder.build(), null);
-          LOG.info("Sending event succeeded");
+          _producer.send(builder.build(),
+              (metadata, exception) -> {
+                if(exception == null) {
+                  LOG.info(String.format("Sending event:{%s} succeeded, metadata:{%s}", text, metadata));
+                } else {
+                  LOG.error(String.format("Sending event:{%s} failed, metadata:{%s}", text, metadata), exception);
+                }
+              });
           ++lineNo;
         } else {
           try {

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
@@ -35,4 +35,8 @@ public class DatastreamRecordMetadata {
   public String getTopic() {
     return _topic;
   }
+
+  public String toString() {
+    return String.format("Checkpoint: %s, Topic: %s, Partition: %d", _checkpoint, _topic, _partition);
+  }
 }


### PR DESCRIPTION
Enabling the test case for userManaged destination (aka BYOT) to test the scenario where the destination is already created and datastream uses the key to identify the partition to which the event should be sent.
