### PR TITLE
Fix the locking in event producer

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -428,6 +428,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener {
       return _assignmentChangeThreadPool.submit((Callable<Void>) () -> {
         try {
           connector.onAssignmentChange(assignment);
+
+          // Unassign tasks with producers
+          _eventProducerPool.unassignEventProducers(removedTasks);
         } catch (Exception ex) {
           _log.warn(String.format("connector.onAssignmentChange for connector %s threw an exception, "
               + "Queuing up a new onAssignmentChange event for retry.", connectorType), ex);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamEventProducerImpl.java
@@ -67,7 +67,7 @@ public class DatastreamEventProducerImpl implements DatastreamEventProducer {
 
   @Override
   public void flush() {
-    _eventProducer.flush();
+    _eventProducer.flushAndCheckpoint();
   }
 
   @Override

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -173,7 +173,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
     Map<DatastreamTask, Map<Integer, String>> safeCheckpoints = impl.getEventProducer().getSafeCheckpoints();
     // Checkpoint map of the owning task must be present in the producer
     Validate.isTrue(safeCheckpoints.containsKey(this), "null checkpoints for task: " + this);
-    return safeCheckpoints.get(this);
+    return Collections.unmodifiableMap(safeCheckpoints.get(this));
   }
 
   @JsonIgnore

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/providers/CheckpointProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/providers/CheckpointProvider.java
@@ -15,7 +15,7 @@ public interface CheckpointProvider {
    * Commit the checkpoints to the checkpoint store.
    * @param checkpoints Map of the datastreamTask to the checkpoint associated with the datastreamTask
    */
-  public void commit(Map<DatastreamTask, String> checkpoints);
+  void commit(Map<DatastreamTask, String> checkpoints);
 
   /**
    * Read the commited checkpoints from the checkpoint store


### PR DESCRIPTION
- combine current/safeCheckpoints into one because any checkpoints,
  once acknowledged by transport, is safe already.
- reworked the locking in various methods in event producers
- rename sendFlushLock to checkpointRWLock to reflect its meaning
- added and fixed comments in event producer
- defer unassignTasks until after onAssignmentChange has returned
  This is because the conector might still be actively sending events
  during reassignment in Coordinator. If we unassign them prematurely,
  it will cause event acknowledgement loss.
- remove the send-flush race checking in the producer test
