### PR TITLE
Not throw expcetion when the folder already exists for zookeeper

### DIFF
--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
@@ -48,7 +48,7 @@ public class FileUtils {
     File file = new File(System.getProperty("java.io.tmpdir"), dirName);
     if (!file.mkdirs()) {
       String errorMessage = "could not create temp directory: " + file.getAbsolutePath();
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, null);
+      LOG.info(errorMessage);
     }
 
     return file;


### PR DESCRIPTION
When zookeeper is restarted, the data and log folder already created by the old instance and will be reused by the new one.
