### PR TITLE
Adding DatastreamAlreadyExists exception 

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -20,6 +20,7 @@ import org.testng.annotations.Test;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
@@ -115,6 +116,16 @@ public class TestDatastreamRestClient {
     clearDatastreamDestination(Collections.singletonList(createdDatastream));
     clearDynamicMetadata(Collections.singletonList(createdDatastream));
     Assert.assertEquals(createdDatastream, datastream);
+  }
+
+  @Test(expectedExceptions = DatastreamAlreadyExistsException.class)
+  public void testCreateDatastreamThatAlreadyExists()
+      throws DatastreamException, IOException, RemoteInvocationException, InterruptedException {
+    Datastream datastream = generateDatastream(1);
+    LOG.info("Datastream : " + datastream);
+    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080");
+    restClient.createDatastream(datastream);
+    restClient.createDatastream(datastream);
   }
 
   @Test

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamAlreadyExistsException.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamAlreadyExistsException.java
@@ -1,0 +1,21 @@
+package com.linkedin.datastream.common;
+
+public class DatastreamAlreadyExistsException extends DatastreamRuntimeException {
+  private static final long serialVersionUID = 1;
+
+  public DatastreamAlreadyExistsException() {
+    super();
+  }
+
+  public DatastreamAlreadyExistsException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DatastreamAlreadyExistsException(String message) {
+    super(message);
+  }
+
+  public DatastreamAlreadyExistsException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
Adding DatastreamAlreadyExists exception that is thrown when client tries to create datastream that already exists.
