### PR TITLE
DatastreamAlreadyExists exception when you create duplicate bootstrap datastream

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
@@ -201,8 +201,15 @@ public class DatastreamRestClient {
     try {
       return datastreamResponseFuture.getResponse().getEntity();
     } catch (RemoteInvocationException e) {
-      String errorMessage = String.format("Create Bootstrap Datastream {%s} failed with error.", bootstrapDatastream);
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, e);
+      if (e instanceof RestLiResponseException && ((RestLiResponseException) e).getStatus() == HttpStatus.S_409_CONFLICT
+          .getCode()) {
+        String msg = String.format("Datastream %s already exists", bootstrapDatastream.getName());
+        LOG.warn(msg, e);
+        throw new DatastreamAlreadyExistsException(msg);
+      } else {
+        String errorMessage = String.format("Create Bootstrap Datastream {%s} failed with error.", bootstrapDatastream);
+        ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, e);
+      }
     }
 
     return null;

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -227,6 +227,17 @@ public class TestDatastreamRestClient {
     Assert.assertEquals(bootstrapDatastream.getConnectorType(), createdDatastream.getConnectorType());
   }
 
+  @Test(expectedExceptions = DatastreamAlreadyExistsException.class)
+  public void testCreateBootstrapDatastreamThatAlreadyExists() {
+
+    Datastream bootstrapDatastream = generateDatastream(4);
+    LOG.info("Bootstrap datastream : " + bootstrapDatastream);
+    DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
+    restClient.createBootstrapDatastream(bootstrapDatastream);
+    restClient.createBootstrapDatastream(bootstrapDatastream);
+  }
+
+
   @Test(expectedExceptions = DatastreamNotFoundException.class)
   public void testGetDatastreamThrowsDatastreamNotFoundExceptionWhenDatastreamIsNotfound()
       throws IOException, DatastreamException, RemoteInvocationException {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.server.Coordinator;
 import com.linkedin.datastream.server.DatastreamServer;
 import com.linkedin.restli.common.HttpStatus;
@@ -49,13 +50,15 @@ public class BootstrapActionResources {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Must specify connectorType!");
     }
     if (!bootstrapDatastream.hasSource()) {
-      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST,
-          "Must specify source of Datastream!");
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Must specify source of Datastream!");
     }
 
     try {
       _coordinator.initializeDatastream(bootstrapDatastream);
       _store.createDatastream(bootstrapDatastream.getName(), bootstrapDatastream);
+    } catch (DatastreamAlreadyExistsException e) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_409_CONFLICT,
+          "Failed to create bootstrap datastream: " + bootstrapDatastream, e);
     } catch (Exception e) {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
           String.format("Failed to initialize bootstrap Datastream %s", bootstrapDatastream), e);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
-import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.RestliUtils;
 import com.linkedin.datastream.server.Coordinator;
@@ -105,9 +105,13 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
     try {
       _store.createDatastream(datastream.getName(), datastream);
-      return new CreateResponse(datastream.getName(), HttpStatus.S_201_CREATED);
-    } catch (DatastreamException e) {
+    } catch (DatastreamAlreadyExistsException e) {
       return _errorLogger.logAndGetResponse(HttpStatus.S_409_CONFLICT, "Failed to create datastream: " + datastream, e);
+    } catch (Exception e) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
+          String.format("Failed to create Datastream %s", datastream), e);
     }
+
+    return new CreateResponse(datastream.getName(), HttpStatus.S_201_CREATED);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -39,7 +39,7 @@ public interface DatastreamStore {
    * @param datastream
    * @throws DatastreamException
    */
-  void createDatastream(String key, Datastream datastream) throws DatastreamException;
+  void createDatastream(String key, Datastream datastream);
 
   /**
    * Deletes the datastream associated with the provided key.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
@@ -1,6 +1,7 @@
 package com.linkedin.datastream.server.dms;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.zk.ZkClient;
@@ -78,7 +79,7 @@ public class ZookeeperBackedDatastreamStore implements DatastreamStore {
   }
 
   @Override
-  public void createDatastream(String key, Datastream datastream) throws DatastreamException {
+  public void createDatastream(String key, Datastream datastream) {
     Validate.notNull(datastream, "null datastream");
     Validate.notNull(key, "null key for datastream" + datastream);
 
@@ -87,7 +88,7 @@ public class ZookeeperBackedDatastreamStore implements DatastreamStore {
       String content = _zkClient.ensureReadData(path);
       String errorMessage = String.format("Datastream already exists: path=%s, content=%s", key, content);
       LOG.warn(errorMessage);
-      throw new DatastreamException(errorMessage);
+      throw new DatastreamAlreadyExistsException(errorMessage);
     }
     _zkClient.ensurePath(path);
     String json = DatastreamUtils.toJSON(datastream);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
@@ -1,18 +1,18 @@
 package com.linkedin.datastream.server.dms;
 
-import com.linkedin.data.template.StringMap;
-import com.linkedin.datastream.common.Datastream;
-import com.linkedin.datastream.common.DatastreamException;
-import com.linkedin.datastream.common.DatastreamSource;
-import com.linkedin.datastream.common.zk.ZkClient;
-import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import java.io.IOException;
 
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
-import org.testng.Assert;
 
-import java.io.IOException;
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
+import com.linkedin.datastream.common.DatastreamSource;
+import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.testutil.EmbeddedZookeeper;
 
 
 public class TestZookeeperBackedDatastreamStore {
@@ -70,7 +70,7 @@ public class TestZookeeperBackedDatastreamStore {
     try {
       _store.createDatastream(ds.getName(), ds);
       Assert.fail();
-    } catch (DatastreamException e) {
+    } catch (DatastreamAlreadyExistsException e) {
     }
 
     // deleting the Datastream
@@ -83,13 +83,13 @@ public class TestZookeeperBackedDatastreamStore {
   /**
    * Test invalid parameters or data on DatastreamStore
    */
-  @Test(expectedExceptions = DatastreamException.class)
-  public void testCreateDuplicateDatastreams() throws DatastreamException {
+  @Test(expectedExceptions = DatastreamAlreadyExistsException.class)
+  public void testCreateDuplicateDatastreams() {
     try {
       // This must work
       Datastream ds = generateDatastream(0);
       _store.createDatastream(ds.getName(), ds);
-    } catch (DatastreamException e) {
+    } catch (DatastreamAlreadyExistsException e) {
       Assert.fail();
     }
 


### PR DESCRIPTION
My last commit hooked up DatastreamAlreadyExists exception only for createDatastream not for the createBootstrapDatastream which is what i needed in the first place. This PR hooks up the DatastreamAlreadyExistsException when clients try to create duplicate datastreams.
