### PR TITLE
Ability to register dynamic metrics

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DynamicMetricsManager.java
@@ -1,0 +1,104 @@
+package com.linkedin.datastream.common;
+
+import org.apache.commons.lang.Validate;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+
+/**
+ * Manages dynamic metrics and supports creating/updating metrics on the fly.
+ */
+public class DynamicMetricsManager {
+
+  private static DynamicMetricsManager _instance = null;
+  private final MetricRegistry _metricRegistry;
+
+  private DynamicMetricsManager(MetricRegistry metricRegistry) {
+    _metricRegistry = metricRegistry;
+  }
+
+  public static DynamicMetricsManager createInstance(MetricRegistry metricRegistry) {
+    if (_instance != null) {
+      throw new IllegalStateException("DynamicMetricsManager already instantiated.");
+    }
+    _instance = new DynamicMetricsManager(metricRegistry);
+    return _instance;
+  }
+
+  public static DynamicMetricsManager getInstance() {
+    if (_instance == null) {
+      throw new IllegalStateException("DynamicMetricsManager has not yet been instantiated.");
+    }
+    return _instance;
+  }
+
+  /**
+   * Update the counter (or creates it if it does not exist) for the specified key/metricName pair by the given value.
+   * To decrement the counter, pass in a negative value.
+   * @param clazz the class containing the metric
+   * @param key the key (i.e. topic or partition) for the metric
+   * @param metricName the metric name
+   * @param value amount to increment the counter by (use negative value to decrement)
+   */
+  public synchronized void createOrUpdateCounter(Class<?> clazz, String key, String metricName, long value) {
+    validateArguments(clazz, key, metricName);
+
+    String fullMetricName = MetricRegistry.name(clazz, key, metricName);
+
+    // create and register the metric if it does not exist
+    Counter counter = _metricRegistry.getCounters().get(fullMetricName);
+    if (counter == null) {
+      counter = _metricRegistry.counter(fullMetricName);
+    }
+    counter.inc(value);
+  }
+
+  /**
+   * Update the meter (or creates it if it does not exist) for the specified key/metricName pair by the given value.
+   * @param clazz the class containing the metric
+   * @param key the key (i.e. topic or partition) for the metric
+   * @param metricName the metric name
+   * @param value the value to mark on the meter
+   */
+  public synchronized void createOrUpdateMeter(Class<?> clazz, String key, String metricName, long value) {
+    validateArguments(clazz, key, metricName);
+
+    String fullMetricName = MetricRegistry.name(clazz, key, metricName);
+
+    // create and register the metric if it does not exist
+    Meter meter = _metricRegistry.getMeters().get(fullMetricName);
+    if (meter == null) {
+      meter = _metricRegistry.meter(fullMetricName);
+    }
+    meter.mark(value);
+  }
+
+  /**
+   * Update the histogram (or creates it if it does not exist) for the specified key/metricName pair by the given value.
+   * @param clazz the class containing the metric
+   * @param key the key (i.e. topic or partition) for the metric
+   * @param metricName the metric name
+   * @param value the value to update on the histogram
+   */
+  public synchronized void createOrUpdateHistogram(Class<?> clazz, String key, String metricName, long value) {
+    validateArguments(clazz, key, metricName);
+    String fullMetricName = MetricRegistry.name(clazz, key, metricName);
+
+    // create and register the metric if it does not exist
+    Histogram histogram = _metricRegistry.getHistograms().get(fullMetricName);
+    if (histogram == null) {
+      histogram = _metricRegistry.histogram(fullMetricName);
+    }
+    histogram.update(value);
+  }
+
+  private void validateArguments(Class<?> clazz, String key, String metricName) {
+    Validate.notNull(clazz, "clazz argument is null.");
+    Validate.notNull(key, "key argument is null.");
+    Validate.notNull(metricName, "metricName argument is null.");
+  }
+
+}

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/MetricsAware.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/MetricsAware.java
@@ -13,12 +13,34 @@ public interface MetricsAware {
 
   /**
    * Retrieve metrics
+   *
+   * For dynamic metrics to be captured by regular expression, since we do not have a reference to the actual Metric object,
+   * simply put null value into the map.
+   *
    * @return a mapping of metric name to metric
    */
   Map<String, Metric> getMetrics();
 
+  /**
+   * @return the metric name prepended with the caller's class name
+   */
   default String buildMetricName(String metricName) {
     return MetricRegistry.name(this.getClass(), metricName);
   }
 
+  /**
+   * Get a regular expression for all dynaminc metrics created within the class.
+   *
+   * For example, this regular expression should capture all topic-specific metrics emitted by KafkaTransportProvider
+   * with the given format: com.linkedin.datastream.kafka.KafkaTransportProvider.DYNAMIC_TOPIC_NAME.numDataEvents
+   *
+   * This regular expression purposely does not capture non topic-specific metrics. For example, non topic-specific
+   * metric emitted by KafkaTransportProvider with the format com.linkedin.datastream.kafka.KafkaTransportProvider.numDataEvents
+   * will not be captured.
+   *
+   * @return the regular expression to capture all dynamic metrics that will be created within the class
+   */
+  default String getDynamicMetricPrefixRegex() {
+    return this.getClass().getName() + "([-.\\w\\d]+)\\.";
+  }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/ConnectorFactory.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/ConnectorFactory.java
@@ -2,7 +2,6 @@ package com.linkedin.datastream.server.api.connector;
 
 import java.util.Properties;
 
-
 /**
  * Connector factory interface, Each connector should implement this which creates the connector instance.
  */

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProviderFactory.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProviderFactory.java
@@ -2,7 +2,6 @@ package com.linkedin.datastream.server.api.transport;
 
 import java.util.Properties;
 
-
 /**
  * Factory to create the Transport provider
  */

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -147,8 +147,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     this(new CoordinatorConfig((config)));
   }
 
-  public Coordinator(CoordinatorConfig config)
-      throws DatastreamException {
+  public Coordinator(CoordinatorConfig config) throws DatastreamException {
     _config = config;
     _clusterName = _config.getCluster();
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
@@ -129,7 +129,8 @@ public class EventProducerPool {
   private List<EventProducer> createProducers(int poolSize, boolean customCheckpointing) {
     return IntStream.range(0, poolSize).mapToObj(i -> {
       // Each distinct destination has its own transport provider
-      TransportProvider transport = _transportProviderFactory.createTransportProvider(_transportProviderConfig);
+      TransportProvider transport =
+          _transportProviderFactory.createTransportProvider(_transportProviderConfig);
       return new EventProducer(transport, _checkpointProvider, _eventProducerConfig, customCheckpointing,
           this::onUnrecoverableError);
     }).collect(Collectors.toList());
@@ -150,7 +151,8 @@ public class EventProducerPool {
 
     _producerPool.get(customCheckpointing).remove(eventProducer);
 
-    TransportProvider transport = _transportProviderFactory.createTransportProvider(_transportProviderConfig);
+    TransportProvider transport =
+        _transportProviderFactory.createTransportProvider(_transportProviderConfig);
     EventProducer newEventProducer =
         new EventProducer(transport, _checkpointProvider, _eventProducerConfig, customCheckpointing,
             this::onUnrecoverableError);


### PR DESCRIPTION
Enable registering metrics to the metric registry on the fly. To allow inGraph to be aware of these metrics, in the MetricsAware.getMetrics() methods, add regular expression to the map of metric name to metric object
