### PR TITLE
Store dynamic metrics separately

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/MetricsAware.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/MetricsAware.java
@@ -12,6 +12,13 @@ import com.codahale.metrics.MetricRegistry;
 public interface MetricsAware {
 
   /**
+   * Captures any number of dashes (-), periods, alphanumeric characters, underscores (_), or digits, followed by a period.
+   * This is used to capture topic or partition specific metrics, i.e. TOPIC_NAME.numDataEvents, and is typically prefixed
+   * with an exact match on class name (see {@link #getDynamicMetricPrefixRegex()})
+   */
+  String KEY_REGEX = "([-.\\w\\d]+)\\.";
+
+  /**
    * Retrieve metrics
    *
    * For dynamic metrics to be captured by regular expression, since we do not have a reference to the actual Metric object,
@@ -29,7 +36,7 @@ public interface MetricsAware {
   }
 
   /**
-   * Get a regular expression for all dynaminc metrics created within the class.
+   * Get a regular expression for all dynamic metrics created within the class.
    *
    * For example, this regular expression should capture all topic-specific metrics emitted by KafkaTransportProvider
    * with the given format: com.linkedin.datastream.kafka.KafkaTransportProvider.DYNAMIC_TOPIC_NAME.numDataEvents
@@ -41,6 +48,6 @@ public interface MetricsAware {
    * @return the regular expression to capture all dynamic metrics that will be created within the class
    */
   default String getDynamicMetricPrefixRegex() {
-    return this.getClass().getName() + "([-.\\w\\d]+)\\.";
+    return this.getClass().getName() + KEY_REGEX;
   }
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/ReadOnlyMetricRegistry.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/ReadOnlyMetricRegistry.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.common;
 
+import java.util.Collections;
 import java.util.Map;
 import java.util.SortedMap;
 
@@ -14,14 +15,17 @@ import com.codahale.metrics.Timer;
 
 
 /**
- * Read-only MetricRegistry wrapper that only exposes the accessor methods of MetricRegistry.
+ * Read-only MetricRegistry wrapper that only exposes the accessor methods of MetricRegistry. Also exposes the regular
+ * expressions for names of the dynamic metrics.
  */
 public class ReadOnlyMetricRegistry {
 
-  private MetricRegistry _metricRegistry;
+  private final MetricRegistry _metricRegistry;
+  private final Map<String, Metric> _dynamicMetrics;
 
-  public ReadOnlyMetricRegistry(MetricRegistry metricRegistry) {
+  public ReadOnlyMetricRegistry(MetricRegistry metricRegistry, Map<String, Metric> dynamicMetrics) {
     _metricRegistry = metricRegistry;
+    _dynamicMetrics = dynamicMetrics;
   }
 
   /**
@@ -122,5 +126,14 @@ public class ReadOnlyMetricRegistry {
    */
   public Map<String, Metric> getMetrics() {
     return _metricRegistry.getMetrics();
+  }
+
+  /**
+   * Returns a map where keys are regular expressions to match against dynamic metric names, and values are metric
+   * objects which indicate the type of metric that the dynamic metric will be when it is created.
+   * @return the dynamic metrics
+   */
+  public Map<String, Metric> getDynamicMetrics() {
+    return Collections.unmodifiableMap(_dynamicMetrics);
   }
 }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -34,6 +34,7 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import kafka.admin.AdminUtils;
@@ -263,16 +264,16 @@ public class KafkaTransportProvider implements TransportProvider {
     metrics.put(buildMetricName("eventTransportErrorCount"), _eventTransportErrorRate);
 
     /*
-     * For dynamic metrics captured by regular expression, since we do not have a reference to the actual Metric object,
-     * simply put null value into the map.
+     * For dynamic metrics captured by regular expression, put an object corresponding to the type of metric that will be
+     * created dynamically.
      *
      * For example, adding the following metric name:
      *
-     * getDynamicMetricPrefixRegex() + "numEvents"
-     * will capture metrics with name matching "com.linkedin.datastream.kafka.KafkaTransportProvider.xxx.numEvents",
+     * metrics.put(getDynamicMetricPrefixRegex() + "numEvents", new Counter());
+     * will capture a counter metric with name matching "com.linkedin.datastream.kafka.KafkaTransportProvider.xxx.numEvents",
      * where xxx is the topic name.
      */
-    metrics.put(getDynamicMetricPrefixRegex() + "numEvents", null);
+    metrics.put(getDynamicMetricPrefixRegex() + "numEvents", new Counter());
 
     return Collections.unmodifiableMap(metrics);
   }


### PR DESCRIPTION
Dynamic metrics need to be stored separately because we don't have references to the actual metrics objects before the server starts, so we cannot add them to the metrics registry. 

Additionally, we need to know what type of metric each dynamic metric will be, so that we know whether to configure the MBeanSensorFactory to create counter vs. gauge (https://rb.corp.linkedin.com/r/742235/)
