### PR TITLE
Modify metric naming convention

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/MetricsAware.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/MetricsAware.java
@@ -32,22 +32,21 @@ public interface MetricsAware {
    * @return the metric name prepended with the caller's class name
    */
   default String buildMetricName(String metricName) {
-    return MetricRegistry.name(this.getClass(), metricName);
+    return MetricRegistry.name(this.getClass().getSimpleName(), metricName);
   }
 
   /**
    * Get a regular expression for all dynamic metrics created within the class.
    *
    * For example, this regular expression should capture all topic-specific metrics emitted by KafkaTransportProvider
-   * with the given format: com.linkedin.datastream.kafka.KafkaTransportProvider.DYNAMIC_TOPIC_NAME.numDataEvents
+   * with the given format: KafkaTransportProvider.DYNAMIC_TOPIC_NAME.numDataEvents
    *
    * This regular expression purposely does not capture non topic-specific metrics. For example, non topic-specific
-   * metric emitted by KafkaTransportProvider with the format com.linkedin.datastream.kafka.KafkaTransportProvider.numDataEvents
-   * will not be captured.
+   * metric emitted by KafkaTransportProvider with the format KafkaTransportProvider.numDataEvents will not be captured.
    *
    * @return the regular expression to capture all dynamic metrics that will be created within the class
    */
   default String getDynamicMetricPrefixRegex() {
-    return this.getClass().getName() + KEY_REGEX;
+    return this.getClass().getSimpleName() + KEY_REGEX;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/BootstrapActionResources.java
@@ -29,6 +29,7 @@ import com.linkedin.restli.server.annotations.RestLiActions;
 @RestLiActions(name = "bootstrap", namespace = "com.linkedin.datastream.server.dms")
 public class BootstrapActionResources {
   private static final Logger LOG = LoggerFactory.getLogger(BootstrapActionResources.class);
+  private static final String CLASS_NAME = BootstrapActionResources.class.getSimpleName();
 
   private final DatastreamStore _store;
   private final Coordinator _coordinator;
@@ -94,9 +95,9 @@ public class BootstrapActionResources {
   public static Map<String, Metric> getMetrics() {
     Map<String, Metric> metrics = new HashMap<>();
 
-    metrics.put(MetricRegistry.name(BootstrapActionResources.class, "createCall"), CREATE_CALL);
-    metrics.put(MetricRegistry.name(BootstrapActionResources.class, "callError"), CALL_ERROR);
-    metrics.put(MetricRegistry.name(BootstrapActionResources.class, "createCallLatency"), CREATE_CALL_LATENCY);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "createCall"), CREATE_CALL);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "callError"), CALL_ERROR);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "createCallLatency"), CREATE_CALL_LATENCY);
 
     return Collections.unmodifiableMap(metrics);
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -41,6 +41,7 @@ import com.linkedin.restli.server.resources.CollectionResourceTemplate;
 @RestLiCollection(name = "datastream", namespace = "com.linkedin.datastream.server.dms")
 public class DatastreamResources extends CollectionResourceTemplate<String, Datastream> {
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamResources.class);
+  private static final String CLASS_NAME = DatastreamResources.class.getSimpleName();
 
   private final DatastreamStore _store;
   private final Coordinator _coordinator;
@@ -155,15 +156,15 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
   public static Map<String, Metric> getMetrics() {
     Map<String, Metric> metrics = new HashMap<>();
 
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "updateCall"), UPDATE_CALL);
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "deleteCall"), DELETE_CALL);
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "getCall"), GET_CALL);
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "getAllCall"), GET_ALL_CALL);
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "createCall"), CREATE_CALL);
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "callError"), CALL_ERROR);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "updateCall"), UPDATE_CALL);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "deleteCall"), DELETE_CALL);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "getCall"), GET_CALL);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "getAllCall"), GET_ALL_CALL);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "createCall"), CREATE_CALL);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "callError"), CALL_ERROR);
 
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "createCallLatency"), CREATE_CALL_LATENCY);
-    metrics.put(MetricRegistry.name(DatastreamResources.class, "deleteCallLatency"), DELETE_CALL_LATENCY);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "createCallLatency"), CREATE_CALL_LATENCY);
+    metrics.put(MetricRegistry.name(CLASS_NAME, "deleteCallLatency"), DELETE_CALL_LATENCY);
 
     return Collections.unmodifiableMap(metrics);
   }


### PR DESCRIPTION
shorten the metric names by using class' simple name instead of full name
