### PR TITLE
Mysql connector metrics

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -51,15 +51,13 @@ public class TestDatastreamRestClient {
   private EmbeddedZookeeper _embeddedZookeeper;
 
   @BeforeTest
-  public void setUp()
-      throws Exception {
+  public void setUp() throws Exception {
     org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
     setupServer();
   }
 
   @AfterTest
-  public void tearDown()
-      throws Exception {
+  public void tearDown() throws Exception {
     _datastreamServer.shutdown();
     _embeddedZookeeper.shutdown();
   }
@@ -76,8 +74,7 @@ public class TestDatastreamRestClient {
     return ds;
   }
 
-  private void setupServer()
-      throws Exception {
+  private void setupServer() throws Exception {
     _embeddedZookeeper = new EmbeddedZookeeper();
     _embeddedZookeeper.startup();
     setupDatastreamServer(8080);
@@ -106,14 +103,26 @@ public class TestDatastreamRestClient {
   }
 
   @Test
-  public void testCreateDatastream()
-      throws DatastreamException, IOException, RemoteInvocationException {
-    Datastream datastream = generateDatastream(1);
+  public void testCreateTwoDatastreams() throws DatastreamException, IOException, RemoteInvocationException {
+    Datastream datastream = generateDatastream(6);
     LOG.info("Datastream : " + datastream);
     DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080");
     restClient.createDatastream(datastream);
     Datastream createdDatastream = restClient.getDatastream(datastream.getName());
     LOG.info("Created Datastream : " + createdDatastream);
+
+    datastream.setDestination(new DatastreamDestination());
+    // server might have already set the destination so we need to unset it for comparison
+    clearDatastreamDestination(Collections.singletonList(createdDatastream));
+    clearDynamicMetadata(Collections.singletonList(createdDatastream));
+    Assert.assertEquals(createdDatastream, datastream);
+
+    datastream = generateDatastream(7);
+    LOG.info("Datastream : " + datastream);
+    restClient.createDatastream(datastream);
+    createdDatastream = restClient.getDatastream(datastream.getName());
+    LOG.info("Created Datastream : " + createdDatastream);
+
     datastream.setDestination(new DatastreamDestination());
     // server might have already set the destination so we need to unset it for comparison
     clearDatastreamDestination(Collections.singletonList(createdDatastream));
@@ -122,8 +131,7 @@ public class TestDatastreamRestClient {
   }
 
   @Test
-  public void testCreateDatastreamToNonLeader()
-      throws DatastreamException, IOException, RemoteInvocationException {
+  public void testCreateDatastreamToNonLeader() throws DatastreamException, IOException, RemoteInvocationException {
     setupDatastreamServer(8083);
     Datastream datastream = generateDatastream(5);
     LOG.info("Datastream : " + datastream);
@@ -224,8 +232,7 @@ public class TestDatastreamRestClient {
   }
 
   @Test(expectedExceptions = DatastreamNotFoundException.class)
-  public void testDeleteDatastream()
-      throws DatastreamException {
+  public void testDeleteDatastream() throws DatastreamException {
     Datastream datastream = generateDatastream(2);
     LOG.info("Datastream : " + datastream);
     DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
@@ -235,8 +242,7 @@ public class TestDatastreamRestClient {
   }
 
   @Test
-  public void testCreateBootstrapDatastream()
-      throws IOException, DatastreamException, RemoteInvocationException {
+  public void testCreateBootstrapDatastream() throws IOException, DatastreamException, RemoteInvocationException {
     Datastream bootstrapDatastream = generateDatastream(3);
     LOG.info("Bootstrap datastream : " + bootstrapDatastream);
     DatastreamRestClient restClient = new DatastreamRestClient("http://localhost:8080/");
@@ -256,7 +262,6 @@ public class TestDatastreamRestClient {
     restClient.createBootstrapDatastream(bootstrapDatastream);
     restClient.createBootstrapDatastream(bootstrapDatastream);
   }
-
 
   @Test(expectedExceptions = DatastreamNotFoundException.class)
   public void testGetDatastreamThrowsDatastreamNotFoundExceptionWhenDatastreamIsNotfound()

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlSourceBinlogRowEventFilter.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlSourceBinlogRowEventFilter.java
@@ -1,24 +1,41 @@
 package com.linkedin.datastream.connectors.mysql.or;
 
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Metric;
 import com.google.code.or.binlog.BinlogEventV4Header;
 import com.google.code.or.binlog.BinlogParserContext;
 import com.google.code.or.binlog.BinlogRowEventFilter;
 import com.google.code.or.binlog.impl.event.TableMapEvent;
 
+import com.linkedin.datastream.common.DynamicMetricsManager;
+import com.linkedin.datastream.common.MetricsAware;
+
 
 public class MysqlSourceBinlogRowEventFilter implements BinlogRowEventFilter {
+  private static final String TOTAL_EVENTS_COUNT = "totalEvents";
+  private static final String CLASSNAME = MysqlSourceBinlogRowEventFilter.class.getSimpleName();
   private final String _databaseName;
   private final String _tableName;
   private final Boolean _acceptAllTables;
+  private final DynamicMetricsManager _dynamicMetricsManager;
+  private final String _taskName;
 
-  public MysqlSourceBinlogRowEventFilter(String databaseName, Boolean acceptAllTables, String tableName) {
+  public MysqlSourceBinlogRowEventFilter(String taskName, String databaseName, Boolean acceptAllTables, String tableName,
+      DynamicMetricsManager dynamicMetricsManager) {
+    _taskName = taskName;
     _databaseName = databaseName;
     _tableName = tableName;
     _acceptAllTables = acceptAllTables;
+    _dynamicMetricsManager = dynamicMetricsManager;
   }
 
   @Override
   public boolean accepts(BinlogEventV4Header header, BinlogParserContext context, TableMapEvent event) {
+    _dynamicMetricsManager.createOrUpdateCounter(this.getClass(), _taskName, TOTAL_EVENTS_COUNT, 1);
     if (event.getDatabaseName() == null || event.getTableName() == null) {
       return false;
     }
@@ -36,5 +53,11 @@ public class MysqlSourceBinlogRowEventFilter implements BinlogRowEventFilter {
     } else {
       return false;
     }
+  }
+
+  public static Map<String, Metric> getMetrics() {
+    Map<String, Metric> metrics = new HashMap<>();
+    metrics.put(CLASSNAME + MetricsAware.KEY_REGEX  + TOTAL_EVENTS_COUNT, new Counter());
+    return Collections.unmodifiableMap(metrics);
   }
 }


### PR DESCRIPTION
Added additional Mysql connector metrics.
TOTAL EVENTS COUNT : count of all the events that are read from the binlogs for a particular datastream.
PROCESSED EVENTS COUNT : count of all the events that are processed and sent to the transport provider for a particular datastream.
PROCESSED TXNS COUNT : count of all the transactions that are processed and sent to the transport provider. 

Converted the testCreateDatastream to testCreateTwoDatastreams to test scenarios that client can create two datastreams.
