### PR TITLE
Adding the CachedDatastreamReader to maintains the list of all datastreams in the system.

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.server;
 import java.util.List;
 import java.util.Map;
 
+import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
@@ -87,7 +88,7 @@ public interface DatastreamTask {
   /**
    * @return the list of datastreams for which this task is producing events for.
    */
-  List<String> getDatastreams();
+  List<Datastream> getDatastreams();
 
   /**
    * A connector must acquire a task before starting to process it. This ensures no

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -1,0 +1,112 @@
+package com.linkedin.datastream.server;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import org.I0Itec.zkclient.IZkChildListener;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamUtils;
+import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.server.zk.KeyBuilder;
+
+
+/**
+ * Class that maintains the cache of all the datastreams in the datastream cluster.
+ *
+ * List of all the datastream names are always kept up-to date. But the complete datastream objects are lazily read
+ * from the zookeeper when they are requested.
+ *
+ * Note : This layer assumes that the datastreams are not updated once they are created.
+ */
+public class CachedDatastreamReader {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CachedDatastreamReader.class.getName());
+
+  private final String _cluster;
+  private List<String> _datastreamList = Collections.emptyList();
+  private Map<String, Datastream> _datastreams = new HashMap<>();
+  private final ZkClient _zkclient;
+
+  public CachedDatastreamReader(ZkClient zkclient, String cluster) {
+    _zkclient = zkclient;
+    _cluster = cluster;
+
+    // Get the initial datastream list.
+    _datastreamList = fetchAllDatastreamNamesFromZk();
+
+    String path = KeyBuilder.datastreams(_cluster);
+    LOG.info("Subscribing to notification on zk path " + path);
+
+    // Be notified of changes to the children list in order to cache it. The listener creates a copy of the list
+    // because other listeners could potentially get access to it and modify its contents.
+    _zkclient.subscribeChildChanges(path, new IZkChildListener() {
+      @Override
+      public void handleChildChange(String parentPath, List<String> currentChildren) throws Exception {
+        synchronized (CachedDatastreamReader.this) {
+          LOG.debug(
+              String.format("Received datastream add or delete notification. parentPath %s, children %s", parentPath,
+                  currentChildren));
+          _datastreamList =
+              currentChildren.stream().collect(Collectors.toCollection(() -> new ArrayList<>(currentChildren.size())));
+          List<String> datastreamsRemoved =
+              _datastreams.keySet().stream().filter(x -> !_datastreamList.contains(x)).collect(Collectors.toList());
+
+          if (!datastreamsRemoved.isEmpty()) {
+            LOG.info(String.format("Removing the deleted datastreams {%s} from cache", datastreamsRemoved));
+            datastreamsRemoved.stream().forEach(_datastreams::remove);
+          }
+
+          LOG.debug(String.format("New datastream list in the cache: %s", _datastreamList));
+        }
+      }
+    });
+  }
+
+  public synchronized List<String> getAllDatastreamNames() {
+    return Collections.unmodifiableList(_datastreamList);
+  }
+
+  public synchronized List<Datastream> getAllDatastreams() {
+    return getAllDatastreams(false);
+  }
+
+  public List<Datastream> getAllDatastreams(boolean flushCache) {
+    if (flushCache) {
+      _datastreamList = fetchAllDatastreamNamesFromZk();
+    }
+
+    return _datastreamList.stream().map(this::getDatastream).collect(Collectors.toList());
+  }
+
+  public Datastream getDatastream(String datastreamName) {
+    Datastream ds = _datastreams.get(datastreamName);
+    if (ds == null) {
+      ds = getDatastreamFromZk(datastreamName);
+
+      // If it has destination connection string populated then it is a complete datastream, cache it.
+      if (ds.hasDestination() && ds.getDestination().hasConnectionString()) {
+        _datastreams.put(datastreamName, ds);
+      }
+    }
+    return ds;
+  }
+
+  private Datastream getDatastreamFromZk(String datastreamName) {
+    String path = KeyBuilder.datastream(_cluster, datastreamName);
+    String content = _zkclient.ensureReadData(path);
+    return DatastreamUtils.fromJSON(content);
+  }
+
+  private List<String> fetchAllDatastreamNamesFromZk() {
+    String path = KeyBuilder.datastreams(_cluster);
+    _zkclient.ensurePath(path);
+    return _zkclient.getChildren(path, true);
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -127,11 +127,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
   }
 
   @JsonIgnore
-  public Datastream getDatastream() {
-    return _datastream;
-  }
-
-  @JsonIgnore
   public String getDatastreamTaskName() {
     return _id.equals("") ? _datastreamName : _datastreamName + "_" + _id;
   }
@@ -178,8 +173,8 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   @JsonIgnore
   @Override
-  public List<String> getDatastreams() {
-    return Collections.singletonList(_datastreamName);
+  public List<Datastream> getDatastreams() {
+    return Collections.singletonList(_datastream);
   }
 
   @Override

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -39,7 +39,7 @@ public class BroadcastStrategy implements AssignmentStrategy {
           currentAssignment.get(instance) :  new HashSet<>();
 
       for (DatastreamTask datastreamTask : currentAssignmentForInstance) {
-        datastreamTask.getDatastreams().stream().forEach(d -> datastreamToTaskMap.put(d, datastreamTask));
+        datastreamTask.getDatastreams().stream().forEach(d -> datastreamToTaskMap.put(d.getName(), datastreamTask));
       }
 
       for (Datastream datastream : datastreams) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -59,8 +59,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
     }
 
     LOG.info(String.format("Datastreams: %s, instances: %s, currentAssignment: %s, NewAssignment: %s",
-        datastreams.stream().map(x -> x.getName()).collect(Collectors.toList()),
-        instances, currentAssignment, assignment));
+        datastreams.stream().map(x -> x.getName()).collect(Collectors.toList()), instances, currentAssignment,
+        assignment));
 
     return assignment;
   }
@@ -90,7 +90,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
 
     for (Datastream datastream : datastreams) {
       Set<DatastreamTask> tasksForDatastream = currentlyAssignedDatastreamTasks.stream()
-          .filter(x -> x.getDatastreams().stream().anyMatch(y -> y.equals(datastream.getName())))
+          .filter(
+              x -> x.getDatastreams().stream().map(Datastream::getName).anyMatch(y -> y.contains(datastream.getName())))
           .collect(Collectors.toSet());
 
       // If there are no datastream tasks that are currently assigned for this datastream.
@@ -98,9 +99,9 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
         tasksForDatastream = createTasksForDatastream(datastream, maxTasksPerDatastream);
       } else {
         // Filter out any COMPLETE tasks
-        tasksForDatastream = tasksForDatastream.stream().filter(
-                t -> t.getStatus() == null || t.getStatus().getCode() != DatastreamTaskStatus.Code.COMPLETE)
-                .collect(Collectors.toSet());
+        tasksForDatastream = tasksForDatastream.stream()
+            .filter(t -> t.getStatus() == null || t.getStatus().getCode() != DatastreamTaskStatus.Code.COMPLETE)
+            .collect(Collectors.toSet());
       }
 
       allTasks.addAll(tasksForDatastream);
@@ -114,7 +115,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
     if (datastream.hasSource() && datastream.getSource().hasPartitions()) {
       numberOfDatastreamPartitions = datastream.getSource().getPartitions();
     }
-    int tasksPerDatastream = maxTasksPerDatastream < numberOfDatastreamPartitions ? maxTasksPerDatastream : numberOfDatastreamPartitions;
+    int tasksPerDatastream =
+        maxTasksPerDatastream < numberOfDatastreamPartitions ? maxTasksPerDatastream : numberOfDatastreamPartitions;
     Set<DatastreamTask> tasks = new HashSet<>();
     for (int index = 0; index < tasksPerDatastream; index++) {
       tasks.add(new DatastreamTaskImpl(datastream, Integer.toString(index),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerHealthResources.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.diagnostics.ConnectorHealth;
 import com.linkedin.datastream.diagnostics.ConnectorHealthArray;
 import com.linkedin.datastream.diagnostics.ServerHealth;
@@ -75,6 +76,7 @@ public class ServerHealthResources extends SimpleResourceTemplate<ServerHealth> 
       TaskHealth taskHealth = new TaskHealth();
       taskHealth.setDatastreams(task.getDatastreams().toString());
       taskHealth.setDatastreams(task.getDatastreams().stream()
+          .map(Datastream::getName)
           .collect(Collectors.joining(",")));
 
       if (task.getDatastreamDestination() != null) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -73,20 +73,20 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_SCHEMA_REGISTRY_PROVIDER_FACTORY,
         "com.linkedin.datastream.server.MockSchemaRegistryProviderFactory");
 
-    return new Coordinator(props);
+    ZkClient client = new ZkClient(zkAddr);
+    CachedDatastreamReader datastreamCache = new CachedDatastreamReader(client, cluster);
+    return new Coordinator(datastreamCache, props);
   }
 
   @BeforeMethod
-  public void setup()
-      throws IOException {
+  public void setup() throws IOException {
     _embeddedZookeeper = new EmbeddedZookeeper();
     _zkConnectionString = _embeddedZookeeper.getConnection();
     _embeddedZookeeper.startup();
   }
 
   @AfterMethod
-  public void teardown()
-      throws IOException {
+  public void teardown() throws IOException {
     _embeddedZookeeper.shutdown();
   }
 
@@ -166,8 +166,7 @@ public class TestCoordinator {
   // This test is disabled because there are still some issues around saving the state. This should be fixed as part of
   // Scenario #3.
   @Test
-  public void testConnectorStateSetAndGet()
-      throws Exception {
+  public void testConnectorStateSetAndGet() throws Exception {
     String testCluster = "testConnectorStateSetAndGet";
     String testConectorType = "testConnectorType";
 
@@ -258,8 +257,7 @@ public class TestCoordinator {
 
   // verify that connector znodes are created as soon as Coordinator instance is started
   @Test
-  public void testConnectorZkNodes()
-      throws Exception {
+  public void testConnectorZkNodes() throws Exception {
     String testCluster = "testConnectorZkNodes";
     String testConectorType = "testConnectorType";
 
@@ -293,8 +291,7 @@ public class TestCoordinator {
    * @throws Exception
    */
   @Test
-  public void testCoordinationWithBroadcastStrategy()
-      throws Exception {
+  public void testCoordinationWithBroadcastStrategy() throws Exception {
     String testCluster = "testCoordinationSmoke";
     String testConectorType = "testConnectorType";
     String datastreamName1 = "datastream1";
@@ -354,8 +351,7 @@ public class TestCoordinator {
   // using onAssignmentChange, so that the connector would not start producing events for this
   // datastream when there is no target to accept it.
   @Test
-  public void testUnassignableStreams()
-      throws Exception {
+  public void testUnassignableStreams() throws Exception {
 
     String testCluster = "testUnassignableStreams";
     String connectorType1 = "unassignable";
@@ -449,8 +445,7 @@ public class TestCoordinator {
   }
 
   @Test
-  public void testCoordinationMultipleConnectorTypesForBroadcastStrategy()
-      throws Exception {
+  public void testCoordinationMultipleConnectorTypesForBroadcastStrategy() throws Exception {
     String testCluster = "testCoordinationMultipleConnectors";
 
     String connectorType1 = "connectorType1";
@@ -525,8 +520,7 @@ public class TestCoordinator {
   // will get a unique instance name
   //
   @Test(enabled = false)
-  public void testStressLargeNumberOfLiveInstances()
-      throws Exception {
+  public void testStressLargeNumberOfLiveInstances() throws Exception {
     int concurrencyLevel = 100;
     String testCluster = "testStressUniqueInstanceNames";
     ThreadPoolExecutor executor = (ThreadPoolExecutor) Executors.newCachedThreadPool();
@@ -572,8 +566,7 @@ public class TestCoordinator {
   }
 
   @Test
-  public void testStressLargeNumberOfDatastreams()
-      throws Exception {
+  public void testStressLargeNumberOfDatastreams() throws Exception {
 
     int concurrencyLevel = 10;
 
@@ -625,8 +618,7 @@ public class TestCoordinator {
   // will be moved from existing live instance to the new live instance
   //
   @Test
-  public void testSimpleAssignmentReassignWithNewInstances()
-      throws Exception {
+  public void testSimpleAssignmentReassignWithNewInstances() throws Exception {
     String testCluster = "testSimpleAssignmentReassignWithNewInstances";
     String testConnectoryType = "testConnectoryType";
     ZkClient zkClient = new ZkClient(_zkConnectionString);
@@ -700,8 +692,7 @@ public class TestCoordinator {
   // Verify that when instance dies, the assigned tasks will be re-assigned to remaining live instances
   //
   @Test
-  public void testSimpleAssignmentReassignAfterDeath()
-      throws Exception {
+  public void testSimpleAssignmentReassignAfterDeath() throws Exception {
     String testCluster = "testSimpleAssignmentReassignAfterDeath";
     String testConnectoryType = "testConnectoryType";
     String datastreamName = "datastream";
@@ -779,8 +770,7 @@ public class TestCoordinator {
   }
 
   @Test
-  public void testBroadcastAssignmentReassignAfterDeath()
-      throws Exception {
+  public void testBroadcastAssignmentReassignAfterDeath() throws Exception {
     String testCluster = "testBroadcastAssignmentReassignAfterDeath";
     String testConnectoryType = "testConnectoryType";
     String datastreamName = "datastream";
@@ -861,8 +851,7 @@ public class TestCoordinator {
   // the assignment will be taken over by the new leader.
   //
   @Test
-  public void testSimpleAssignmentReassignAfterLeaderDeath()
-      throws Exception {
+  public void testSimpleAssignmentReassignAfterLeaderDeath() throws Exception {
     String testCluster = "testSimpleAssignmentReassignAfterLeaderDeath";
     String testConnectoryType = "testConnectoryType";
     String datastreamName = "datastream";
@@ -966,8 +955,7 @@ public class TestCoordinator {
   // this test covers the scenario when multiple instances die at the same time
   //
   @Test
-  public void testMultipleInstanceDeath()
-      throws Exception {
+  public void testMultipleInstanceDeath() throws Exception {
     String testCluster = "testMultipleInstanceDeath";
     String testConnectoryType = "testConnectoryType";
     String datastreamName = "datastream";
@@ -1038,8 +1026,7 @@ public class TestCoordinator {
   // Put it in another word, this is how Kafka consumer rebalancing works.
   //
   @Test
-  public void testSimpleAssignmentRebalancing()
-      throws Exception {
+  public void testSimpleAssignmentRebalancing() throws Exception {
     String testCluster = "testSimpleAssignmentRebalancing";
     String testConnectoryType = "testConnectoryType";
     ZkClient zkClient = new ZkClient(_zkConnectionString);
@@ -1105,8 +1092,7 @@ public class TestCoordinator {
   // strategies, BroadcastStrategy and SimpleStrategy respectively.
   //
   @Test
-  public void testSimpleAssignmentStrategyIndependent()
-      throws Exception {
+  public void testSimpleAssignmentStrategyIndependent() throws Exception {
     String testCluster = "testSimpleAssignmentStrategy";
     String connectoryType1 = "ConnectoryType1";
     String connectoryType2 = "ConnectoryType2";
@@ -1201,8 +1187,7 @@ public class TestCoordinator {
   }
 
   @Test
-  public void testCoordinatorErrorHandling()
-      throws Exception {
+  public void testCoordinatorErrorHandling() throws Exception {
     String testCluster = "testCoordinatorErrorHandling";
     String connectoryType1 = "ConnectoryType1";
     ZkClient zkClient = new ZkClient(_zkConnectionString);
@@ -1266,8 +1251,7 @@ public class TestCoordinator {
     }
   }
 
-  private TestSetup createTestCoordinator()
-      throws Exception {
+  private TestSetup createTestCoordinator() throws Exception {
     EmbeddedDatastreamCluster datastreamKafkaCluster =
         TestDatastreamServer.initializeTestDatastreamServerWithDummyConnector(null);
     datastreamKafkaCluster.startup();
@@ -1308,8 +1292,7 @@ public class TestCoordinator {
    * @throws Exception
    */
   @Test
-  public void testCreateDatastreamHappyPath()
-      throws Exception {
+  public void testCreateDatastreamHappyPath() throws Exception {
     TestSetup setup = createTestCoordinator();
 
     // Check retention when it's specific in topicConfig
@@ -1317,7 +1300,8 @@ public class TestCoordinator {
     String datastreamName = "TestDatastream";
     Datastream stream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, datastreamName)[0];
     stream.getSource().setConnectionString(DummyConnector.VALID_DUMMY_SOURCE);
-    stream.getMetadata().put(DatastreamMetadataConstants.DESTINATION_RETENION_MS, String.valueOf(myRetention.toMillis()));
+    stream.getMetadata()
+        .put(DatastreamMetadataConstants.DESTINATION_RETENION_MS, String.valueOf(myRetention.toMillis()));
     CreateResponse response = setup._resource.create(stream);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
@@ -1328,8 +1312,7 @@ public class TestCoordinator {
   }
 
   @Test
-  public void testCreateDatastreamHappyPathDefaultRetention()
-      throws Exception {
+  public void testCreateDatastreamHappyPathDefaultRetention() throws Exception {
     TestSetup setup = createTestCoordinator();
 
     // Check default retention when no topicConfig is specified

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
@@ -206,11 +206,11 @@ public class TestLoadbalancingStrategy {
     }
 
     assignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
-    Assert.assertEquals(assignment.values().stream().mapToInt(ts -> ts.size()).sum(), numPending);
+    Assert.assertEquals(assignment.values().stream().mapToInt(Set::size).sum(), numPending);
 
     // Complete all
     tasks.forEach(t -> t.setStatus(DatastreamTaskStatus.complete()));
     assignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
-    Assert.assertEquals(assignment.values().stream().mapToInt(ts -> ts.size()).sum(), 0);
+    Assert.assertEquals(assignment.values().stream().mapToInt(Set::size).sum(), 0);
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
@@ -12,6 +12,7 @@ import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.server.CachedDatastreamReader;
 import com.linkedin.datastream.testutil.EmbeddedZookeeper;
 
 
@@ -23,11 +24,13 @@ public class TestZookeeperBackedDatastreamStore {
 
   @BeforeMethod
   public void setup() throws IOException {
+    String clusterName = "testcluster";
     _embeddedZookeeper = new EmbeddedZookeeper();
     _zkConnectionString = _embeddedZookeeper.getConnection();
     _embeddedZookeeper.startup();
     _zkClient = new ZkClient(_zkConnectionString);
-    _store = new ZookeeperBackedDatastreamStore(_zkClient, "testcluster");
+    CachedDatastreamReader datastreamCache = new CachedDatastreamReader(_zkClient, clusterName);
+    _store = new ZookeeperBackedDatastreamStore(datastreamCache, _zkClient, clusterName);
   }
 
   @AfterMethod

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
@@ -11,6 +11,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.server.TestDestinationManager;
@@ -35,7 +36,8 @@ public class TestZookeeperCheckpointProvider {
 
   @Test
   public void testCommitAndReadCheckpoints() {
-    ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster");
+    ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster", ZkClient.DEFAULT_SESSION_TIMEOUT,
+        ZkClient.DEFAULT_CONNECTION_TIMEOUT, null, null);
     adapter.connect();
     ZookeeperCheckpointProvider checkpointProvider = new ZookeeperCheckpointProvider(adapter);
     Map<DatastreamTask, String> checkpoints = new HashMap<>();
@@ -58,7 +60,8 @@ public class TestZookeeperCheckpointProvider {
 
   @Test
   public void testReadCommitedShouldIncludeDatastreamTasksWhoseCheckpointsAreNotCommitted() {
-    ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster");
+    ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster", ZkClient.DEFAULT_SESSION_TIMEOUT,
+        ZkClient.DEFAULT_CONNECTION_TIMEOUT, null, null);
     adapter.connect();
     ZookeeperCheckpointProvider checkpointProvider = new ZookeeperCheckpointProvider(adapter);
     Map<DatastreamTask, String> checkpoints = new HashMap<>();

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -6,6 +6,7 @@ import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.server.CachedDatastreamReader;
 import com.linkedin.datastream.server.dms.ZookeeperBackedDatastreamStore;
 import com.linkedin.datastream.server.zk.KeyBuilder;
 
@@ -90,7 +91,8 @@ public class DatastreamTestUtils {
   public static void storeDatastreams(ZkClient zkClient, String cluster, Datastream... datastreams) throws DatastreamException {
     for (Datastream datastream : datastreams) {
       zkClient.ensurePath(KeyBuilder.datastreams(cluster));
-      ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(zkClient, cluster);
+      CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, cluster);
+      ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, cluster);
       dsStore.createDatastream(datastream.getName(), datastream);
     }
   }


### PR DESCRIPTION
Previously ZkAdapter.getAllDatastreams used to work only on the leaders. Since leaders are the only ones that were maintaining the list of all datastreams. ZookeeperBackedDatastreamStore also managed list of all datastreams. There was this state (all datastreams) which was distributed in multiple places. 

Consolidating that logic to maintain the list of all datastreams and also maintaining a cache of the complete datastream objects. So that datastream instances won't need to go to zookeeper multiple times for every getAllDatastreams call.
