### PR TITLE
Mysql snapshot connector

### DIFF
--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlConnectorFactory.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlConnectorFactory.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.connectors.mysql;
 import java.util.Properties;
 
 import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.server.api.connector.Connector;
 import com.linkedin.datastream.server.api.connector.ConnectorFactory;
 
@@ -13,7 +14,7 @@ public class MysqlConnectorFactory implements ConnectorFactory {
     try {
       return new MysqlConnector(config);
     } catch (DatastreamException e) {
-      throw new RuntimeException("Instantiating Mysql connector failed with exception", e);
+      throw new DatastreamRuntimeException("Instantiating Mysql connector failed with exception", e);
     }
   }
 }

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlSnapshotConnector.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlSnapshotConnector.java
@@ -1,0 +1,170 @@
+package com.linkedin.datastream.connectors.mysql;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Metric;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.connectors.mysql.or.InMemoryTableInfoProvider;
+import com.linkedin.datastream.connectors.mysql.or.MysqlQueryUtils;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.api.connector.Connector;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+
+
+/**
+ * Mysql snapshot connector that reads the current snapshot of the entire Mysql table and writes to the
+ * transport provider.
+ *
+ * If the datastream gets rebalanced in during the process in between. Then the new datastream instance that gets the
+ * datastream reassigned will start the snapshot write process from the beginning. This is done because there is
+ * no way to get to the right position of the older snapshot without disabling any writes on the table or db.
+ */
+public class MysqlSnapshotConnector implements Connector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MysqlSnapshotConnector.class);
+
+  public static final String CONNECTOR_TYPE = "mysqlsnapshot";
+  private static final String CFG_NUM_THREADS = "numThreads";
+  private static final String DEFAULT_NUM_THREADS = "10";
+  private static final String CFG_BUFFER_SIZE = "bufferSize";
+  private static final String DEFAULT_BUFFER_SIZE = "100";
+  private static final String USE_IN_MEMORY_TABLE_INFO_PROVIDER = "useInMemoryTableInfoProvider";
+  private static final String DEFAULT_SQL_TIMEOUT = "5";
+  private static final String CFG_SQL_TIMEOUT = "sqlTimeout";
+  private static final Duration DEFAULT_STOP_TIMEOUT = Duration.ofMinutes(1);
+
+  private final String _defaultUserName;
+  private final String _defaultPassword;
+  private final ExecutorService _executorService;
+  private final int _bufferSizeInRows;
+  private final Duration _sqlTimeout;
+  private InMemoryTableInfoProvider _tableInfoProvider = null;
+  private Map<DatastreamTask, SnapshotTaskHandler> _taskHandlers = new HashMap<>();
+
+  public MysqlSnapshotConnector(Properties config) {
+    _defaultUserName = config.getProperty(MysqlConnector.CFG_MYSQL_USERNAME, "");
+    _defaultPassword = config.getProperty(MysqlConnector.CFG_MYSQL_PASSWORD, "");
+    _bufferSizeInRows = Integer.parseInt(config.getProperty(CFG_BUFFER_SIZE, DEFAULT_BUFFER_SIZE));
+
+    if (Boolean.parseBoolean(config.getProperty(USE_IN_MEMORY_TABLE_INFO_PROVIDER, "false"))) {
+      _tableInfoProvider = InMemoryTableInfoProvider.getTableInfoProvider();
+    }
+
+    _sqlTimeout = Duration.ofMillis(Integer.parseInt(config.getProperty(CFG_SQL_TIMEOUT, DEFAULT_SQL_TIMEOUT)));
+    int numberOfThreads = Integer.parseInt(config.getProperty(CFG_NUM_THREADS, DEFAULT_NUM_THREADS));
+    _executorService = Executors.newFixedThreadPool(numberOfThreads);
+  }
+
+  @Override
+  public void start() {
+    LOG.info("Start called.");
+  }
+
+  @Override
+  public void stop() {
+    stopAndRemoveHandlers(_taskHandlers.keySet());
+    try {
+      _executorService.awaitTermination(DEFAULT_STOP_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted while waiting for snapshot tasks to complete.", e);
+    }
+
+    LOG.info("Mysql snapshot connector is stopped.");
+  }
+
+  @Override
+  public void onAssignmentChange(List<DatastreamTask> tasks) {
+    LOG.info(String.format("Mysql snapshot connector is assigned tasks %s", tasks));
+    List<DatastreamTask> tasksAdded =
+        tasks.stream().filter(x -> !_taskHandlers.containsKey(x)).collect(Collectors.toList());
+    List<DatastreamTask> tasksRemoved =
+        _taskHandlers.keySet().stream().filter(x -> !tasks.contains(x)).collect(Collectors.toList());
+
+    // Stop the handlers for the removed tasks.
+    stopAndRemoveHandlers(tasksRemoved);
+
+    // Start the handlers for the added tasks.
+    Map<DatastreamTask, SnapshotTaskHandler> addedHandlers = tasksAdded.stream()
+        .collect(Collectors.toMap(Function.identity(),
+            x -> new SnapshotTaskHandler(x, _tableInfoProvider, getUsername(x), getPassword(x), _bufferSizeInRows,
+                _sqlTimeout)));
+
+    addedHandlers.values().stream().forEach(_executorService::submit);
+
+    _taskHandlers.putAll(addedHandlers);
+  }
+
+  private String getUsername(DatastreamTask task) {
+    return getUserNameFromDatastream(task.getDatastreams().get(0));
+  }
+
+  private String getPassword(DatastreamTask task) {
+    return getPasswordFromDatastream(task.getDatastreams().get(0));
+  }
+
+  private String getUserNameFromDatastream(Datastream datastream) {
+    return datastream.hasMetadata() ? datastream.getMetadata()
+        .getOrDefault(MysqlConnector.CFG_MYSQL_USERNAME, _defaultUserName) : _defaultUserName;
+  }
+
+  private String getPasswordFromDatastream(Datastream datastream) {
+    return datastream.hasMetadata() ? datastream.getMetadata()
+        .getOrDefault(MysqlConnector.CFG_MYSQL_PASSWORD, _defaultPassword) : _defaultPassword;
+  }
+
+  private void stopAndRemoveHandlers(Collection<DatastreamTask> tasksRemoved) {
+    tasksRemoved.stream().map(_taskHandlers::get).forEach(SnapshotTaskHandler::stop);
+    tasksRemoved.stream().forEach(_taskHandlers::remove);
+  }
+
+  @Override
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
+    LOG.info("validating datastream " + stream.toString());
+    try {
+      MysqlSource source = MysqlSource.createFromUri(stream.getSource().getConnectionString());
+      if (source.getSourceType() != MysqlConnector.SourceType.MYSQLSERVER) {
+        String msg = "Connector can only support datastreams of MYSQLSERVER source type";
+        LOG.error(msg);
+        throw new DatastreamValidationException(msg);
+      }
+
+      if (!MysqlQueryUtils.checkTableExists(source, getUserNameFromDatastream(stream),
+          getPasswordFromDatastream(stream))) {
+        throw new DatastreamValidationException(
+            String.format("Invalid datastream: Can't find table %s in db %s.", source.getDatabaseName(),
+                source.getTableName()));
+      }
+
+      if (stream.getSource().hasPartitions() && stream.getSource().getPartitions() != 1) {
+        String msg = "Mysql snapshot connector can only support single partition sources";
+        LOG.error(msg);
+        throw new DatastreamValidationException(msg);
+      }
+    } catch (SourceNotValidException | SQLException e) {
+      LOG.error("Received exception while validating the Mysql source", e);
+      throw new DatastreamValidationException(e);
+    }
+  }
+
+  @Override
+  public Map<String, Metric> getMetrics() {
+    return Collections.emptyMap();
+  }
+}

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlSnapshotConnectorFactory.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlSnapshotConnectorFactory.java
@@ -1,0 +1,15 @@
+package com.linkedin.datastream.connectors.mysql;
+
+import java.util.Properties;
+
+import com.linkedin.datastream.server.api.connector.Connector;
+import com.linkedin.datastream.server.api.connector.ConnectorFactory;
+
+
+public class MysqlSnapshotConnectorFactory implements ConnectorFactory {
+
+  @Override
+  public Connector createConnector(Properties config) {
+    return new MysqlSnapshotConnector(config);
+  }
+}

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlTableReader.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlTableReader.java
@@ -1,0 +1,179 @@
+package com.linkedin.datastream.connectors.mysql;
+
+import java.nio.ByteBuffer;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.DatastreamEvent;
+import com.linkedin.datastream.common.DatastreamEventMetadata;
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.JsonUtils;
+import com.linkedin.datastream.connectors.mysql.or.ColumnInfo;
+import com.linkedin.datastream.connectors.mysql.or.MysqlQueryUtils;
+import com.linkedin.datastream.connectors.mysql.or.TableInfoProvider;
+
+
+/**
+ * A closeable iterator implementation that iterates over all the rows in a table.
+ * This implementation buffers rows fetched from the database.
+ * <p/>
+ * Note: The behavior of this iterator is undefined in the face of concurrent updates to the base data. Also, it is up to the
+ * responsibility of the caller to call close explicitly to free up resources.
+ */
+public class MysqlTableReader {
+  private static final Logger LOG = LoggerFactory.getLogger(MysqlTableReader.class);
+
+  private final Connection _conn;
+  private final MysqlSource _source;
+  private final String _username;
+  private final String _password;
+  private final List<ColumnInfo> _columnInfo;
+  private Statement _stmt;
+  private ResultSet _rs;
+  private boolean _next;
+  // The number of rows fetched from the database when the buffer has to be refilled.
+  private final int _bufSize;
+  private boolean _isEof;
+  private boolean _closed;
+
+  /**
+   * Constructs a new {@code MysqlTableReader}.
+   *
+   */
+  public MysqlTableReader(MysqlSource source, String username, String password, TableInfoProvider tableInfoProvider,
+      int bufSize) throws SQLException {
+    _bufSize = bufSize;
+    _source = source;
+    _username = username;
+    _password = password;
+    _columnInfo = tableInfoProvider.getColumnList(source.getDatabaseName(), source.getTableName());
+    _conn = MysqlQueryUtils.initMysqlConn(source.getHostName(), source.getPort(), username, password);
+
+    _conn.setTransactionIsolation(Connection.TRANSACTION_READ_COMMITTED);
+    _stmt = _conn.createStatement();
+
+    String fullyQualifiedTableName = String.format("%s.%s", source.getDatabaseName(), source.getTableName());
+    _stmt.executeUpdate(new SqlStringBuilder().append("HANDLER ")
+        .append(fullyQualifiedTableName)
+        .append(" OPEN AS ")
+        .appendIdent(source.getTableName(), "Iterator")
+        .toString());
+    _rs = _stmt.executeQuery(new SqlStringBuilder().append("HANDLER ")
+        .appendIdent(source.getTableName(), "Iterator")
+        .append(" READ `PRIMARY` FIRST LIMIT ")
+        .append(_bufSize)
+        .toString());
+    _next = false;
+    _closed = false;
+    _isEof = false;
+  }
+
+  public void close() {
+    if (_closed) {
+      LOG.debug("Iterator was already closed. Ignoring current close command.");
+      return;
+    }
+    try {
+      _rs.close();
+      _stmt.executeUpdate(new SqlStringBuilder().append("HANDLER ")
+          .appendIdent(_source.getTableName(), "Iterator")
+          .append(" CLOSE")
+          .toString());
+    } catch (SQLException e) {
+      LOG.warn("Closing the handler threw an exception", e);
+    } finally {
+      try {
+        _stmt.close();
+        _conn.close();
+      } catch (SQLException e) {
+        LOG.warn("Closing the Mysql connnection threw an exception", e);
+      }
+
+      _closed = true;
+    }
+
+  }
+
+  private boolean hasNext() throws SQLException {
+    if (_isEof || _closed) {
+      return false;
+    }
+
+    if (_next) {
+      return true;
+    }
+
+    if (_stmt == null) {
+      return false;
+    }
+
+    _next = _rs.next();
+
+    if (!_next) {
+      _rs.close();
+      _rs = _stmt.executeQuery(new SqlStringBuilder().append("HANDLER ")
+          .appendIdent(_source.getTableName(), "Iterator")
+          .append(" READ `PRIMARY` NEXT LIMIT ")
+          .append(_bufSize)
+          .toString());
+      _next = _rs.next();
+      if (!_next) {
+        _isEof = true;
+      }
+    }
+    return _next;
+  }
+
+  public DatastreamEvent next() throws SQLException {
+
+    if (!_isEof || _closed) {
+      String msg = "TableReader needs to be closed or it is closed already.";
+      LOG.warn(msg);
+      throw new DatastreamRuntimeException(msg);
+    }
+
+    if (!hasNext()) {
+      throw new NoSuchElementException("No more elements in this iterator.");
+    }
+
+    try {
+      Map<String, String> rowValues = new HashMap<>();
+      Map<String, String> keyValues = new HashMap<>();
+      for (ColumnInfo column : _columnInfo) {
+        rowValues.put(column.getColumnName(), _rs.getString(column.getColumnName()));
+        if (column.isKey()) {
+          keyValues.put(column.getColumnName(), _rs.getString(column.getColumnName()));
+        }
+      }
+      return buildDatastreamEvent(System.currentTimeMillis(), _source.getDatabaseName(), _source.getTableName(),
+          JsonUtils.toJson(keyValues), JsonUtils.toJson(rowValues));
+    } finally {
+      _next = false;
+    }
+  }
+
+  private DatastreamEvent buildDatastreamEvent(long eventTimestamp, String dbName, String tableName, String key,
+      String value) {
+    Map<CharSequence, CharSequence> metadata = new HashMap<>();
+    metadata.put(DatastreamEventMetadata.OPCODE, DatastreamEventMetadata.OpCode.INSERT.toString());
+    metadata.put(DatastreamEventMetadata.EVENT_TIMESTAMP, String.valueOf(eventTimestamp));
+    metadata.put(DatastreamEventMetadata.DATABASE, dbName);
+    metadata.put(DatastreamEventMetadata.TABLE, tableName);
+
+    DatastreamEvent datastreamEvent = new DatastreamEvent();
+    datastreamEvent.payload = ByteBuffer.wrap(value.getBytes());
+    datastreamEvent.key = ByteBuffer.wrap(key.getBytes());
+    datastreamEvent.metadata = metadata;
+    return datastreamEvent;
+  }
+}
+

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/SnapshotTaskHandler.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/SnapshotTaskHandler.java
@@ -1,0 +1,121 @@
+package com.linkedin.datastream.connectors.mysql;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.DatastreamEvent;
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.RetriableException;
+import com.linkedin.datastream.common.RetryUtils;
+import com.linkedin.datastream.connectors.mysql.or.MysqlServerTableInfoProvider;
+import com.linkedin.datastream.connectors.mysql.or.TableInfoProvider;
+import com.linkedin.datastream.server.DatastreamEventProducer;
+import com.linkedin.datastream.server.DatastreamProducerRecord;
+import com.linkedin.datastream.server.DatastreamProducerRecordBuilder;
+import com.linkedin.datastream.server.DatastreamTask;
+
+
+/**
+ * Snapshot task handler runs on a tight loop to read the data from mysql table one by one and writes it to the producer.
+ */
+public class SnapshotTaskHandler implements Runnable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SnapshotTaskHandler.class);
+  private static final Duration SQL_RETRY_PERIOD = Duration.ofMinutes(1);
+  private final Duration _sqlTimeout;
+
+  private final DatastreamTask _datastreamTask;
+  private final String _password;
+  private final String _username;
+  private TableInfoProvider _tableInfoProvider;
+  private final int _bufferSize;
+  private final DatastreamEventProducer _eventProducer;
+  private boolean _stopRequested = false;
+  private boolean _stopped = false;
+
+  public SnapshotTaskHandler(DatastreamTask datastreamTask, TableInfoProvider tableInfoProvider, String username,
+      String password, int bufferSizeInRows, Duration sqlTimeout) {
+    _datastreamTask = datastreamTask;
+    _eventProducer = datastreamTask.getEventProducer();
+    _bufferSize = bufferSizeInRows;
+    _tableInfoProvider = tableInfoProvider;
+    _sqlTimeout = sqlTimeout;
+    _username = username;
+    _password = password;
+  }
+
+  @Override
+  public void run() {
+    MysqlTableReader tableReader = createTableReaderWithRetries();
+    DatastreamEvent event;
+    while ((event = getNextEventWithRetries(tableReader)) != null) {
+      sendEvent(event);
+    }
+
+    tableReader.close();
+    _stopped = true;
+  }
+
+  private DatastreamEvent getNextEventWithRetries(MysqlTableReader tableReader) {
+
+    return RetryUtils.retry(() -> {
+      try {
+        if (!_stopRequested) {
+          return tableReader.next();
+        }
+        return null;
+      } catch (NoSuchElementException e) {
+        return null;
+      } catch (SQLException e) {
+        throw new RetriableException(e);
+      }
+    }, SQL_RETRY_PERIOD, _sqlTimeout);
+  }
+
+  private MysqlTableReader createTableReaderWithRetries() {
+    MysqlSource source;
+    try {
+      source = MysqlSource.createFromUri(_datastreamTask.getDatastreamSource().getConnectionString());
+    } catch (SourceNotValidException e) {
+      String msg =
+          String.format("SourceUri %s is invalid", _datastreamTask.getDatastreamSource().getConnectionString());
+      LOG.error(msg, e);
+      throw new DatastreamRuntimeException(msg, e);
+    }
+
+    return RetryUtils.retry(() -> {
+      try {
+        if (_tableInfoProvider == null) {
+          _tableInfoProvider = new MysqlServerTableInfoProvider(source, _username, _password);
+        }
+
+        return new MysqlTableReader(source, _username, _password, _tableInfoProvider, _bufferSize);
+      } catch (SQLException e) {
+        throw new RetriableException(e);
+      }
+    }, SQL_RETRY_PERIOD, _sqlTimeout);
+  }
+
+  private void sendEvent(DatastreamEvent event) {
+    // TODO producer error handling.
+    _eventProducer.send(buildProducerRecord(event), null);
+  }
+
+  private DatastreamProducerRecord buildProducerRecord(DatastreamEvent event) {
+    DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
+    builder.addEvent(event);
+    return builder.build();
+  }
+
+  public void stop() {
+    if (_stopped) {
+      return;
+    }
+
+    _stopRequested = true;
+  }
+}

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/SqlStringBuilder.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/SqlStringBuilder.java
@@ -1,0 +1,593 @@
+package com.linkedin.datastream.connectors.mysql;
+
+import java.util.Arrays;
+
+
+public class SqlStringBuilder implements CharSequence {
+  // SQL Statements are very rarely as little as 16 characters which is the default size used by
+  // the default constructor for StringBuilder.
+  private static final int INITIAL_CAPACITY = 128;
+
+  private final StringBuilder _sqlString;
+
+  public SqlStringBuilder() {
+    this(INITIAL_CAPACITY);
+  }
+
+  public SqlStringBuilder(int capacity) {
+    _sqlString = new StringBuilder(capacity);
+  }
+
+  public SqlStringBuilder(String str) {
+    _sqlString = new StringBuilder(str);
+  }
+
+  public SqlStringBuilder(CharSequence seq) {
+    _sqlString = new StringBuilder(seq);
+  }
+
+  /**
+   * Appends a string to the Sql Statement
+   *
+   * @param str   the String to append
+   * @return a reference to this object
+   */
+  public SqlStringBuilder append(String str) {
+    _sqlString.append(str);
+    return this;
+  }
+
+  /**
+   * Appends a concatenated string with backticks (`) around it.
+   * Note: The backtick is appended before and after the concatenated String, not individual Strings.
+   * Backticks within each string are properly escaped.
+   *
+   * Example:
+   * appendIdent("A","B") will return SqlStringBuilder representation of `AB`.
+   * appendIdent("A","B`") will return SqlStringBuilder representation of `AB```.
+   *
+   * @param   strs  Strings to append
+   * @return a reference to this object
+   */
+  public SqlStringBuilder appendIdent(CharSequence... strs) {
+    _sqlString.append('`');
+    for (CharSequence s : strs) {
+      for (int i = 0; i < s.length(); i++) {
+        char ch = s.charAt(i);
+        if (ch == '`') {
+          _sqlString.append('`');
+        }
+        _sqlString.append(ch);
+      }
+    }
+    _sqlString.append('`');
+    return this;
+  }
+
+  /**
+   * Comma separates one or more CharSequence identifiers. Each identifier is appropriately wrapped around a backtick.
+   *
+   * Example:
+   * appendCommandSeperatedIdent("A","B") will return the SqlStringBuilder representation of `A`,`B`
+   * @param strs  One or more identifiers to return
+   * @return A reference to this object
+   */
+  public <T extends CharSequence> SqlStringBuilder appendCommaSeperatedIdent(Iterable<T> strs) {
+    if (strs == null) {
+      return this;
+    }
+
+    int size = length();
+    for (T str : strs) {
+      appendIdent(str);
+      append(',');
+    }
+    if (length() > size) {
+      deleteCharAt(length() - 1); //remove the trailing comma
+    }
+
+    return this;
+  }
+
+  /**
+   * Comma separates one or more CharSequence identifiers. Each identifier is appropriately wrapped around a backtick.
+   *
+   * Example:
+   * appendCommandSeperatedIdent("A","B") will return the SqlStringBuilder representation of `A`,`B`
+   * @param strs  One or more identifiers to return
+   * @return A reference to this object
+   */
+  public SqlStringBuilder appendCommaSeperatedIdent(CharSequence... strs) {
+    return appendCommaSeperatedIdent(Arrays.asList(strs));
+  }
+
+  /**
+   * Appends a concatenated string with single quote (') around it.
+   * Note: The single quote is appended before and after the concatenated String, not individual Strings.
+   * Each String is properly escaped and concatenated.
+   *
+   * Example:
+   * appendLiteral("A","B","C") will return SqlStringBuilder representation of "ABC".
+   * appendLiteral("A","B'","C") will return SqlStringBuilder representation of "AB\'C".
+   *
+   * @param   strs  Strings to append
+   * @return a reference to this object
+   */
+  public SqlStringBuilder appendLiteral(CharSequence... strs) {
+    _sqlString.append("'");
+    escapeAndAppendText(strs);
+    _sqlString.append("'");
+    return this;
+  }
+
+  /**
+   * Comma-seperates one or more CharSequence literals. Each literal is appropriately escaped and wrapped around a single-quote
+   *
+   * Example:
+   * appendCommaSeperatedLiterals("A","B") returns the SqlStringBuilder representation of 'A','B'
+   *
+   * @param strs  One or more CharSequence literal
+   * @return a reference to this object
+   */
+  public SqlStringBuilder appendCommaSeperatedLiterals(CharSequence... strs) {
+    return appendCommaSeperatedLiterals(Arrays.asList(strs));
+  }
+
+  /**
+   * Comma-seperates one or more CharSequence literals. Each literal is appropriately escaped and wrapped around a single-quote
+   *
+   * Example:
+   * appendCommaSeperatedLiterals("A","B") returns the SqlStringBuilder representation of 'A','B'
+   *
+   * @param strs  One or more CharSequence literal
+   * @return a reference to this object
+   */
+  public <T extends CharSequence> SqlStringBuilder appendCommaSeperatedLiterals(Iterable<T> strs) {
+    if (strs == null) {
+      return this;
+    }
+
+    int size = length();
+    for (T str : strs) {
+      appendLiteral(str);
+      append(',');
+    }
+
+    if (length() > size) {
+      deleteCharAt(length() - 1); //remove the trailing comma
+    }
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#length()
+   */
+  @Override
+  public int length() {
+    return _sqlString.length();
+  }
+
+  /**
+   * @see java.lang.StringBuilder#capacity()
+   */
+  public int capacity() {
+    return _sqlString.capacity();
+  }
+
+  /**
+   * @see java.lang.StringBuilder#ensureCapacity(int)
+   */
+  public void ensureCapacity(int minimumCapacity) {
+    _sqlString.ensureCapacity(minimumCapacity);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#trimToSize()
+   */
+  public void trimToSize() {
+    _sqlString.trimToSize();
+  }
+
+  /**
+   * @see java.lang.StringBuilder#setLength(int)
+   */
+  public void setLength(int newLength) {
+    _sqlString.setLength(newLength);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(Object)
+   */
+  public SqlStringBuilder append(Object obj) {
+    _sqlString.append(obj);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(StringBuffer)
+   */
+  public SqlStringBuilder append(StringBuffer sb) {
+    _sqlString.append(sb);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#charAt(int)
+   */
+  @Override
+  public char charAt(int index) {
+    return _sqlString.charAt(index);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(CharSequence)
+   */
+  public SqlStringBuilder append(CharSequence s) {
+    _sqlString.append(s);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#codePointAt(int)
+   */
+  public int codePointAt(int index) {
+    return _sqlString.codePointAt(index);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(CharSequence, int, int)
+   */
+  public SqlStringBuilder append(CharSequence s, int start, int end) {
+    _sqlString.append(s, start, end);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(char[])
+   */
+  public SqlStringBuilder append(char[] str) {
+    _sqlString.append(str);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(char[], int, int)
+   */
+  public SqlStringBuilder append(char[] str, int offset, int len) {
+    _sqlString.append(str, offset, len);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(boolean)
+   */
+  public SqlStringBuilder append(boolean b) {
+    _sqlString.append(b);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(char)
+   */
+  public SqlStringBuilder append(char c) {
+    _sqlString.append(c);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(int)
+   */
+  public SqlStringBuilder append(int i) {
+    _sqlString.append(i);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#codePointBefore(int)
+   */
+  public int codePointBefore(int index) {
+    return _sqlString.codePointBefore(index);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(long)
+   */
+  public SqlStringBuilder append(long lng) {
+    _sqlString.append(lng);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(float)
+   */
+  public SqlStringBuilder append(float f) {
+    _sqlString.append(f);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#append(double)
+   */
+  public SqlStringBuilder append(double d) {
+    _sqlString.append(d);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#appendCodePoint(int)
+   */
+  public SqlStringBuilder appendCodePoint(int codePoint) {
+    _sqlString.appendCodePoint(codePoint);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#delete(int, int)
+   */
+  public SqlStringBuilder delete(int start, int end) {
+    _sqlString.delete(start, end);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#deleteCharAt(int)
+   */
+  public SqlStringBuilder deleteCharAt(int index) {
+    _sqlString.deleteCharAt(index);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#replace(int, int, String)
+   */
+  public SqlStringBuilder replace(int start, int end, String str) {
+    _sqlString.replace(start, end, str);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#codePointCount(int, int)
+   */
+  public int codePointCount(int beginIndex, int endIndex) {
+    return _sqlString.codePointCount(beginIndex, endIndex);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, char[], int, int)
+   */
+  public SqlStringBuilder insert(int index, char[] str, int offset, int len) {
+    _sqlString.insert(index, str, offset, len);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, Object)
+   */
+  public SqlStringBuilder insert(int offset, Object obj) {
+    _sqlString.insert(offset, obj);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, String)
+   */
+  public SqlStringBuilder insert(int offset, String str) {
+    _sqlString.insert(offset, str);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, char[])
+   */
+  public SqlStringBuilder insert(int offset, char[] str) {
+    _sqlString.insert(offset, str);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, CharSequence)
+   */
+  public SqlStringBuilder insert(int dstOffset, CharSequence s) {
+    _sqlString.insert(dstOffset, s);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#offsetByCodePoints(int, int)
+   */
+  public int offsetByCodePoints(int index, int codePointOffset) {
+    return _sqlString.offsetByCodePoints(index, codePointOffset);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, CharSequence, int, int)
+   */
+  public SqlStringBuilder insert(int dstOffset, CharSequence s, int start, int end) {
+    _sqlString.insert(dstOffset, s, start, end);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, boolean)
+   */
+  public SqlStringBuilder insert(int offset, boolean b) {
+    _sqlString.insert(offset, b);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, char)
+   */
+  public SqlStringBuilder insert(int offset, char c) {
+    _sqlString.insert(offset, c);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, int)
+   */
+  public SqlStringBuilder insert(int offset, int i) {
+    _sqlString.insert(offset, i);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#getChars(int, int, char[], int)
+   */
+  public void getChars(int srcBegin, int srcEnd, char[] dst, int dstBegin) {
+    _sqlString.getChars(srcBegin, srcEnd, dst, dstBegin);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, long)
+   */
+  public SqlStringBuilder insert(int offset, long l) {
+    _sqlString.insert(offset, l);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, float)
+   */
+  public SqlStringBuilder insert(int offset, float f) {
+    _sqlString.insert(offset, f);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#insert(int, double)
+   */
+  public SqlStringBuilder insert(int offset, double d) {
+    _sqlString.insert(offset, d);
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#indexOf(String)
+   */
+  public int indexOf(String str) {
+    return _sqlString.indexOf(str);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#indexOf(String, int)
+   */
+  public int indexOf(String str, int fromIndex) {
+    return _sqlString.indexOf(str, fromIndex);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#lastIndexOf(String)
+   */
+  public int lastIndexOf(String str) {
+    return _sqlString.lastIndexOf(str);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#lastIndexOf(String, int)
+   */
+  public int lastIndexOf(String str, int fromIndex) {
+    return _sqlString.lastIndexOf(str, fromIndex);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#reverse()
+   */
+  public SqlStringBuilder reverse() {
+    _sqlString.reverse();
+    return this;
+  }
+
+  /**
+   * @see java.lang.StringBuilder#setCharAt(int, char)
+   */
+  public void setCharAt(int index, char ch) {
+    _sqlString.setCharAt(index, ch);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#substring(int)
+   */
+  public String substring(int start) {
+    return _sqlString.substring(start);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#subSequence(int, int)
+   */
+  @Override
+  public CharSequence subSequence(int start, int end) {
+    return _sqlString.subSequence(start, end);
+  }
+
+  /**
+   * @see java.lang.StringBuilder#substring(int, int)
+   */
+  public String substring(int start, int end) {
+    return _sqlString.substring(start, end);
+  }
+
+  private void escapeAndAppendText(CharSequence... strs) {
+    for (CharSequence str : strs) {
+      for (int i = 0; i < str.length(); i++) {
+        char ch = str.charAt(i);
+        switch (ch) {
+          case 0:
+            _sqlString.append("\\0");
+            break;
+          case '\'':
+            _sqlString.append("\\'");
+            break;
+          case '"':
+            _sqlString.append("\\\"");
+            break;
+          case '\b':
+            _sqlString.append("\\b");
+            break;
+          case '\n':
+            _sqlString.append("\\n");
+            break;
+          case '\r':
+            _sqlString.append("\\r");
+            break;
+          case '\t':
+            _sqlString.append("\\t");
+            break;
+          case 26:
+            _sqlString.append("\\Z");
+            break;
+          case '\\':
+            _sqlString.append("\\\\");
+            break;
+          default:
+            _sqlString.append(ch);
+            break;
+        }
+      }
+    }
+  }
+
+  /**
+   * @see java.lang.StringBuilder#toString()
+   */
+  @Override
+  public String toString() {
+    return _sqlString.toString();
+  }
+
+  /**
+   * @see java.lang.StringBuilder#equals(Object)
+   */
+  @Override
+  public boolean equals(Object obj) {
+    return (this == obj) || (obj instanceof SqlStringBuilder && toString().equals(obj.toString()));
+  }
+
+  /**
+   * @see java.lang.StringBuilder#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return _sqlString.hashCode();
+  }
+}

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlQueryUtils.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlQueryUtils.java
@@ -100,16 +100,18 @@ public class MysqlQueryUtils {
     reinit();
   }
 
-  private void initMysqlConn() throws SQLException {
+  public static Connection initMysqlConn(String hostName, int port, String username, String password)
+      throws SQLException {
+
     StringBuilder urlStr = new StringBuilder();
 
-    urlStr.append("jdbc:mysql://" + _source.getHostName());
-    urlStr.append(":" + _source.getPort());
+    urlStr.append("jdbc:mysql://" + hostName);
+    urlStr.append(":" + port);
 
-    urlStr.append("?user=").append(_username);
+    urlStr.append("?user=").append(username);
 
-    if (!StringUtils.isBlank(_password)) {
-      urlStr.append("&password=").append(_password);
+    if (!StringUtils.isBlank(password)) {
+      urlStr.append("&password=").append(password);
     }
 
     try {
@@ -117,7 +119,7 @@ public class MysqlQueryUtils {
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-    _conn = DriverManager.getConnection(urlStr.toString());
+    return DriverManager.getConnection(urlStr.toString());
   }
 
   public void closeConnection() throws SQLException {
@@ -356,7 +358,7 @@ public class MysqlQueryUtils {
       _conn = null;
     }
 
-    initMysqlConn();
+    _conn = initMysqlConn(_source.getHostName(), _source.getPort(), _username, _password);
   }
 
   public List<ColumnInfo> getColumnList(String dbName, String tableName) throws SQLException {
@@ -426,6 +428,16 @@ public class MysqlQueryUtils {
     } finally {
       rs.close();
       stmt.close();
+    }
+  }
+
+  public static boolean checkTableExists(MysqlSource source, String userName, String password) throws SQLException {
+    MysqlQueryUtils queryUtils = new MysqlQueryUtils(source, userName, password);
+    try {
+      queryUtils.initializeConnection();
+      return queryUtils.checkTableExist(source.getDatabaseName(), source.getTableName());
+    } finally {
+      queryUtils.closeConnection();
     }
   }
 

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/PollUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/PollUtils.java
@@ -32,7 +32,7 @@ public final class PollUtils {
    */
   public static <T> boolean poll(Predicate<T> cond, long periodMs, long timeoutMs, T arg) {
     long elapsedMs = 0;
-    if (periodMs > timeoutMs) {
+    if (timeoutMs > 0 && periodMs > timeoutMs) {
       return false;
     }
     while (true) {
@@ -45,7 +45,7 @@ public final class PollUtils {
         break;
       }
       elapsedMs += periodMs;
-      if (elapsedMs >= timeoutMs) {
+      if (timeoutMs > 0 && elapsedMs >= timeoutMs) {
         break;
       }
     }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/RetriableException.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/RetriableException.java
@@ -1,0 +1,24 @@
+package com.linkedin.datastream.common;
+
+/**
+ * Represents an exception that can be retried.
+ */
+public class RetriableException extends RuntimeException  {
+  private static final long serialVersionUID = 1;
+
+  public RetriableException() {
+    super();
+  }
+
+  public RetriableException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public RetriableException(String message) {
+    super(message);
+  }
+
+  public RetriableException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/RetriesExhaustedExeption.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/RetriesExhaustedExeption.java
@@ -1,0 +1,24 @@
+package com.linkedin.datastream.common;
+
+/**
+ *
+ */
+public class RetriesExhaustedExeption extends RuntimeException {
+  private static final long serialVersionUID = 1;
+
+  public RetriesExhaustedExeption() {
+    super();
+  }
+
+  public RetriesExhaustedExeption(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public RetriesExhaustedExeption(String message) {
+    super(message);
+  }
+
+  public RetriesExhaustedExeption(Throwable cause) {
+    super(cause);
+  }
+}

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/RetryUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/RetryUtils.java
@@ -1,0 +1,33 @@
+package com.linkedin.datastream.common;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Supplier;
+
+
+public class RetryUtils {
+
+  public static <T> T retry(Supplier<T> func, Duration period, Duration timeout) {
+    final List<T> returnValue = new ArrayList<>();
+
+    boolean result = PollUtils.poll(() -> {
+      try {
+        returnValue.add(func.get());
+      } catch (Exception e) {
+        if (e instanceof RetriableException) {
+          return false;
+        }
+        throw e;
+      }
+
+      return true;
+    }, period.toMillis(), timeout.toMillis());
+
+    if (!result) {
+      throw new RetriesExhaustedExeption();
+    }
+
+    return returnValue.get(0);
+  }
+}


### PR DESCRIPTION
Early version of mysql snapshot connector to get early feedback.
- Uses the code from Espresso snapshot service to read the table. 
- Right now mysql snapshot connector only supports table level datastreams like Mysql connector. 
- Doesn't handle the producer failures yet. 
- When the mysql snapshot datastream gets rebalanced to a different connector instance, connector will restart the bootstrapping because there is no easy way to lock the snapshot since the database is constantly getting updated.
