### PR TITLE
Log warning when getDatastream fails to find

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
@@ -75,10 +75,9 @@ public class DatastreamRestClient {
     } catch (RemoteInvocationException e) {
       if (e instanceof RestLiResponseException
           && ((RestLiResponseException) e).getStatus() == HttpStatus.S_404_NOT_FOUND.getCode()) {
-        LOG.error(String.format("Datastream {%s} is not found", datastreamName), e);
+        LOG.warn(String.format("Datastream {%s} is not found", datastreamName), e);
         throw new DatastreamNotFoundException(datastreamName, e);
       } else {
-
         String errorMessage = String.format("Get Datastream {%s} failed with error.", datastreamName);
         LOG.error(errorMessage, e);
         throw new DatastreamRuntimeException(errorMessage, e);


### PR DESCRIPTION
Fails to find a datastream can be an expected scenario, in which case it
is misleading to log as ERROR. This change replaces ERROR with WARN.
