### PR TITLE
Misc cleanup

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentStrategy.java
@@ -2,6 +2,7 @@ package com.linkedin.datastream.server;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import com.linkedin.datastream.common.Datastream;
@@ -9,7 +10,7 @@ import com.linkedin.datastream.common.Datastream;
 
 public interface AssignmentStrategy {
   /**
-   * assign a list of datastreams to a list of instances, and return a map from instances-> list of streams.
+   * Assign a list of datastreams to a list of instances, and return a map from instances-> set of datastream tasks.
    * Each connector is associated with one implementation of the AssignmentStrategy, and it is only called
    * by the Coordinator Leader.
    *
@@ -20,15 +21,15 @@ public interface AssignmentStrategy {
    * {@link DatastreamTask} is the minimum assignable element of Datastream.
    * This makes it possible to split a Datastream into multiple assignable DatastreamTask so that they
    * can be assigned to multiple instances, and hence allowing load balancing. For example, the Oracle
-   * bootstrap Datastream can be splitted into multiple instances of DatastreamTask, one per partition,
+   * bootstrap Datastream can be split into multiple instances of DatastreamTask, one per partition,
    * if the bootstrap files are hosted on HDFS. This allows the concurrent processing of the partitions
    * to maximize the network IO.
    *
    * @param datastreams all data streams defined in Datastream Management Service to be assigned
    * @param instances all live instances
    * @param currentAssignment existing assignment
-   * @return
+   * @return map of instances to set of datastream tasks
    */
   Map<String, Set<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignment);
+      Optional<Map<String, Set<DatastreamTask>>> currentAssignment);
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -26,7 +26,7 @@ import java.util.UUID;
 /**
  * DatastreamTask is the minimum assignable element of a Datastream. It is mainly used to partition the datastream
  * defined by Datastream. For example, the user can define an instance of Datastream for an Oracle bootstrap
- * connector, but this logical datastream can be splitted to a number of DatastreamTask instances, each is tied
+ * connector, but this logical datastream can be split to a number of DatastreamTask instances, each is tied
  * to one partition. This way, each instance of DatastreamTask can be assigned independently, which in turn can
  * result in bigger output and better concurrent IO.
  *
@@ -34,7 +34,7 @@ import java.util.UUID;
  * Datastream object, DatastreamTask also contains a key-value store Properties. This allows the assignment
  * strategy to attach extra parameters.
  *
- * <p>DatastreamTask has a unique name called _datastreamtaskName. This is used as the znode name in zookeeper
+ * <p>DatastreamTask has a unique name called _datastreamTaskName. This is used as the znode name in zookeeper
  * This should be unique for each instance of DatastreamTask, especially in the case when a Datastream is
  * split into multiple DatastreamTasks. This is because we will have a state associated with each DatastreamTask.
  *

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
@@ -2,9 +2,9 @@ package com.linkedin.datastream.server.assignment;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -29,7 +29,7 @@ public class TestBroadcastStrategy {
     List<Datastream> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), datastreams.size());
     }
@@ -52,8 +52,9 @@ public class TestBroadcastStrategy {
     List<Datastream> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
-    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, Arrays.asList(instances),
+        Optional.ofNullable(assignment));
     for (String instance : instances) {
       Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
       Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
@@ -69,11 +70,11 @@ public class TestBroadcastStrategy {
     List<String> instances = Arrays.asList("instance1", "instance2", "instance3");
     List<Datastream> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy();
-    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, new HashMap<>());
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, Optional.empty());
 
     datastreams.remove(0);
 
-    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, instances, assignment);
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, instances, Optional.ofNullable(assignment));
 
     // Ensure that the datastream tasks for the existing instances didn't change.
     for (String instance : instances) {
@@ -88,13 +89,13 @@ public class TestBroadcastStrategy {
     List<String> instances = Arrays.asList("instance1", "instance2", "instance3");
     List<Datastream> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy();
-    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, new HashMap<>());
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, Optional.empty());
 
     List<Datastream> newDatastreams = new ArrayList<>(datastreams);
     Datastream newDatastream = generateDatastreams("newds", 1).get(0);
     newDatastreams.add(newDatastream);
 
-    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(newDatastreams, instances, assignment);
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(newDatastreams, instances, Optional.ofNullable(assignment));
 
     // Ensure that the datastream tasks for the existing instances didn't change.
     for (String instance : instances) {
@@ -112,10 +113,10 @@ public class TestBroadcastStrategy {
     String instance4 = "instance4";
     List<Datastream> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy();
-    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, new HashMap<>());
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, Optional.empty());
     List<String> newInstances = new ArrayList<>(instances);
     newInstances.add(instance4);
-    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, newInstances, assignment);
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, newInstances, Optional.ofNullable(assignment));
 
     // Ensure that the datastream tasks for the existing instances didn't change.
     for (String instance : instances) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
@@ -6,6 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.testng.Assert;
@@ -56,7 +57,7 @@ public class TestLoadbalancingStrategy {
     datastreams.forEach(x -> x.getSource().setPartitions(12));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
     }
@@ -69,7 +70,7 @@ public class TestLoadbalancingStrategy {
     datastreams.forEach(x -> x.getSource().setPartitions(2));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
 
     List<String> sortedInstances = Arrays.asList(instances);
     Collections.sort(sortedInstances);
@@ -87,7 +88,7 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
@@ -96,7 +97,7 @@ public class TestLoadbalancingStrategy {
 
     String[] newInstances = new String[] { "instance1", "instance2" };
     Map<String, Set<DatastreamTask>> newAssignment =
-        strategy.assign(datastreams, Arrays.asList(newInstances), assignment);
+        strategy.assign(datastreams, Arrays.asList(newInstances), Optional.ofNullable(assignment));
 
     Assert.assertEquals(newAssignment.get(newInstances[0]).size(), 3);
     Assert.assertEquals(newAssignment.get(newInstances[1]).size(), 3);
@@ -110,7 +111,7 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
@@ -119,7 +120,7 @@ public class TestLoadbalancingStrategy {
 
     String[] newInstances = new String[] { "instance1", "instance2", "instance3", "instance4" };
     Map<String, Set<DatastreamTask>> newAssignment =
-        strategy.assign(datastreams, Arrays.asList(newInstances), assignment);
+        strategy.assign(datastreams, Arrays.asList(newInstances), Optional.ofNullable(assignment));
 
     for (String instance : newInstances) {
       Assert.assertEquals(newAssignment.get(instance).size(), 1);
@@ -134,7 +135,7 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
@@ -148,7 +149,7 @@ public class TestLoadbalancingStrategy {
     });
 
     Map<String, Set<DatastreamTask>> newAssignment =
-        strategy.assign(datastreams, Arrays.asList(instances), assignment);
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.ofNullable(assignment));
 
     for (String instance : instances) {
       Assert.assertEquals(newAssignment.get(instance).size(), 4);
@@ -163,7 +164,7 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 4);
@@ -174,7 +175,7 @@ public class TestLoadbalancingStrategy {
     datastreams.remove(1);
 
     Map<String, Set<DatastreamTask>> newAssignment =
-        strategy.assign(datastreams, Arrays.asList(instances), assignment);
+        strategy.assign(datastreams, Arrays.asList(instances), Optional.ofNullable(assignment));
 
     for (String instance : instances) {
       Assert.assertEquals(newAssignment.get(instance).size(), 2);
@@ -188,7 +189,7 @@ public class TestLoadbalancingStrategy {
     datastreams.forEach(x -> x.getSource().setPartitions(12));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
-            strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+            strategy.assign(datastreams, Arrays.asList(instances), Optional.empty());
 
     List<DatastreamTask> tasks = new ArrayList<>();
 
@@ -205,12 +206,12 @@ public class TestLoadbalancingStrategy {
       tasks.get(i).setStatus(DatastreamTaskStatus.complete());
     }
 
-    assignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
+    assignment = strategy.assign(datastreams, Arrays.asList(instances), Optional.ofNullable(assignment));
     Assert.assertEquals(assignment.values().stream().mapToInt(Set::size).sum(), numPending);
 
     // Complete all
     tasks.forEach(t -> t.setStatus(DatastreamTaskStatus.complete()));
-    assignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
+    assignment = strategy.assign(datastreams, Arrays.asList(instances), Optional.ofNullable(assignment));
     Assert.assertEquals(assignment.values().stream().mapToInt(Set::size).sum(), 0);
   }
 }


### PR DESCRIPTION
Convert static metrics in KafkaTransportProvider to dynamic metrics for aggregate counts/rates. This is because we don't have references to the actual transportProviders before the server starts. They are instantiated by the EventProducerPool.

Also some misc cleanups/refactor, which are not completely necessary, as I was reading code. Feel free to comment if you feel they should be reverted.
