### PR TITLE
Pass datastreams of the same connector name to initializeDatastream

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -178,11 +178,11 @@ public class EventProducer {
     _safeCheckpoints = new ConcurrentHashMap<>();
     _onUnrecoverableError = onUnrecoverableError;
 
-    // Start checkpoint handler
-    _checkpointHandler = new CheckpointHandler(config);
-
     _producerId = PRODUCER_ID_SEED.getAndIncrement();
     _logger = LoggerFactory.getLogger(String.format("%s:%s", MODULE, _producerId));
+
+    // Start checkpoint handler
+    _checkpointHandler = new CheckpointHandler(config);
 
     _availabilityThresholdSlaMs =
         Integer.parseInt(config.getProperty(AVAILABILITY_THRESHOLD_SLA_MS, DEFAULT_AVAILABILITY_THRESHOLD_SLA_MS));


### PR DESCRIPTION
This is the original semantics of the initializeDatastream but got removed by the DatastreamCache change inadvertently.

Also create the checkpoint handler after logger is setup to avoid potential NPE.
