### PR TITLE
Bug fixes in the datastream server and KafkaTransportProvider

### DIFF
--- a/config/server1.properties
+++ b/config/server1.properties
@@ -8,8 +8,9 @@ datastream.server.connectorNames=File,Test
 
 ########################### Transport provider configs ######################
 
-datastream.server.transportProvider.kafka.bootstrap.servers=localhost:9092
-datastream.server.transportProvider.kafka.zookeeper.connect=localhost:2181
+datastream.server.transportProvider.bootstrap.servers=localhost:9092
+datastream.server.transportProvider.zookeeper.connect=localhost:2181
+datastream.server.transportProvider.client.id=datastream-producer
 
 ########################### File connector Configs ######################
 

--- a/config/server2.properties
+++ b/config/server2.properties
@@ -8,8 +8,9 @@ datastream.server.connectorNames=File,Test
 
 ########################### Transport provider configs ######################
 
-datastream.server.transportProvider.kafka.bootstrap.servers=localhost:9092
-datastream.server.transportProvider.kafka.zookeeper.connect=localhost:2181
+datastream.server.transportProvider.bootstrap.servers=localhost:9092
+datastream.server.transportProvider.zookeeper.connect=localhost:2181
+datastream.server.transportProvider.client.id=datastream-producer
 
 ########################### File connector Configs ######################
 

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -201,7 +201,7 @@ public class KafkaTransportProvider implements TransportProvider {
         _eventByteWriteRate.mark(event.getKey().length + event.getValue().length);
 
         _producer.send(outgoing, (metadata, exception) -> onSendComplete.onCompletion(
-                new DatastreamRecordMetadata(String.valueOf(metadata.offset()), metadata.topic(), metadata.partition()),
+                new DatastreamRecordMetadata(record.getCheckpoint(), metadata.topic(), metadata.partition()),
                 exception));
         // Update topic-specific metrics and aggregate metrics
         int numBytes = event.getKey().length + event.getValue().length;

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderFactory.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderFactory.java
@@ -4,7 +4,6 @@ import java.util.Properties;
 
 import org.apache.commons.lang.Validate;
 
-import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.server.api.transport.TransportProvider;
 import com.linkedin.datastream.server.api.transport.TransportProviderFactory;
 
@@ -14,12 +13,9 @@ import com.linkedin.datastream.server.api.transport.TransportProviderFactory;
  */
 public class KafkaTransportProviderFactory implements TransportProviderFactory {
 
-  public static final String KAFKA_CONFIG_PREFIX = "kafka";
-
   @Override
   public TransportProvider createTransportProvider(Properties config) {
     Validate.notNull(config, "null config");
-    VerifiableProperties kafkaProps = new VerifiableProperties(config);
-    return new KafkaTransportProvider(kafkaProps.getDomainProperties(KAFKA_CONFIG_PREFIX));
+    return new KafkaTransportProvider(config);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -58,7 +58,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
   @Override
   public Map<String, Set<DatastreamTask>> assign(List<Datastream> datastreams, List<String> instances,
       Map<String, Set<DatastreamTask>> currentAssignment) {
-
+    LOG.info(String.format("Assign called with datastreams: %s, instances: %s, currentAssignment: %s", datastreams,
+        instances, currentAssignment));
     // if there are no live instances, return empty assignment
     if (instances.size() == 0) {
       return new HashMap<>();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -728,7 +728,7 @@ public class ZkAdapter {
         .map(DatastreamTask::getDatastreamTaskName)
         .collect(Collectors.toSet());
 
-    List<String> connectors = _zkclient.getChildren(KeyBuilder.connectors(_cluster));
+    List<String> connectors = getConnectors();
     for (String connector : connectors) {
       Set<String> deadTasks = new HashSet<>(_zkclient.getChildren(KeyBuilder.connector(_cluster, connector)));
       deadTasks.removeAll(liveTasks);
@@ -745,6 +745,16 @@ public class ZkAdapter {
         }
       }
     }
+  }
+
+  private List<String> getConnectors() {
+
+    String connectorsPath = KeyBuilder.connectors(_cluster);
+    if (_zkclient.exists(connectorsPath)) {
+      return _zkclient.getChildren(connectorsPath);
+    }
+
+    return Collections.emptyList();
   }
 
   private void waitForTaskRelease(DatastreamTask task, long timeoutMs, String lockPath) {

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/TestEventProducingConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/TestEventProducingConnector.java
@@ -134,10 +134,10 @@ public class TestEventProducingConnector implements Connector {
           DatastreamProducerRecord record = createDatastreamEvent(index, messageSize, partition);
           task.getEventProducer().send(record, (metadata, exception) -> {
             if (exception != null) {
+              LOG.info("metadata is " + metadata.toString());
               LOG.error("Send failed for event " + metadata.getCheckpoint(), exception);
             }
           });
-
           try {
             Thread.sleep(sleepBetweenSendMs);
           } catch (InterruptedException e) {
@@ -150,7 +150,7 @@ public class TestEventProducingConnector implements Connector {
         index++;
       }
     } catch (Exception ex) {
-      LOG.error("Event producer threw exception ", ex);
+      LOG.error("Producer thread threw exception, Stopping event producer for task " + task, ex);
     }
   }
 

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -94,9 +94,9 @@ public class EmbeddedDatastreamCluster {
     if (_kafkaCluster != null) {
       properties.put(DatastreamServer.CONFIG_TRANSPORT_PROVIDER_FACTORY, KAFKA_TRANSPORT_FACTORY);
       properties.put(
-          String.format("%s.kafka.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, BOOTSTRAP_SERVERS_CONFIG),
+          String.format("%s.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, BOOTSTRAP_SERVERS_CONFIG),
           kafkaCluster.getBrokers());
-      properties.put(String.format("%s.kafka.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, CONFIG_ZK_CONNECT),
+      properties.put(String.format("%s.%s", Coordinator.TRANSPORT_PROVIDER_CONFIG_DOMAIN, CONFIG_ZK_CONNECT),
           kafkaCluster.getZkConnection());
     } else {
       properties.put(DatastreamServer.CONFIG_TRANSPORT_PROVIDER_FACTORY,

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -5,6 +5,7 @@ import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
+import com.linkedin.datastream.common.DatastreamStatus;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.server.CachedDatastreamReader;
 import com.linkedin.datastream.server.dms.ZookeeperBackedDatastreamStore;
@@ -77,6 +78,7 @@ public class DatastreamTestUtils {
     ds.setDestination(new DatastreamDestination());
     ds.getDestination().setConnectionString(destination);
     ds.getDestination().setPartitions(destinationPartitions);
+    ds.setStatus(DatastreamStatus.INITIALIZING);
     StringMap metadata = new StringMap();
     ds.setMetadata(metadata);
     return ds;

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
@@ -47,10 +47,7 @@ public class DatastreamRestClientCli {
 
   private static void printHelp(Options options) {
     HelpFormatter formatter = new HelpFormatter();
-    formatter.printHelp("DatastreamRestClientCmd",
-        "Console app to manage datastreams. Available operations: read, readall, "
-            + "create, delete Example usage: ./datastream-rest-client.sh read --dms localhost:32211 -n datastream -e",
-        options, "", true);
+    formatter.printHelp("DatastreamRestClientCmd", "Console app to manage datastreams.", options, "", true);
   }
 
   private enum Operation {


### PR DESCRIPTION
- Making the configs between the KafkaTransportProvider and LiKafkaTransportprovider uniform so that it is possible to test LiKafkaTransportProvider in open source easily.
- Fixes in the coordinator to do the assignment only for the datastreams that are ready.
