### PR TITLE
Support for pluggable event formats between the connectors and transport providers

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
@@ -93,7 +93,7 @@ public class FileConnector implements Connector {
     // Ensure the processors have actually stopped
     for (DatastreamTask task : unassigned) {
       FileProcessor processor = _fileProcessors.get(task);
-      if (!PollUtils.poll(() -> processor.isStopped(), 200, SHUTDOWN_TIMEOUT_MS)) {
+      if (!PollUtils.poll(processor::isStopped, 200, SHUTDOWN_TIMEOUT_MS)) {
         throw new RuntimeException("Failed to stop processor for " + task);
       }
       _fileProcessors.remove(task);

--- a/datastream-mysql-connector/src/test/java/com/linkedin/datastream/connectors/mysql/TestMysqlConnector.java
+++ b/datastream-mysql-connector/src/test/java/com/linkedin/datastream/connectors/mysql/TestMysqlConnector.java
@@ -17,13 +17,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.linkedin.datastream.DatastreamRestClient;
-import com.linkedin.datastream.common.AvroUtils;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamEvent;
 import com.linkedin.datastream.common.DatastreamEventMetadata;
 import com.linkedin.datastream.common.DatastreamException;
-import com.linkedin.datastream.common.DatastreamRuntimeException;
-import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.connectors.mysql.MysqlConnector.SourceType;
 import com.linkedin.datastream.connectors.mysql.or.ColumnInfo;
@@ -125,17 +122,7 @@ public class TestMysqlConnector {
   }
 
   private List<DatastreamEvent> getEventsFromRecord(DatastreamProducerRecord record) {
-    return record.getEvents().stream().map(x -> decodePayload(x.getValue())).collect(Collectors.toList());
-  }
-
-  private DatastreamEvent decodePayload(byte[] value) {
-    try {
-      DatastreamEvent event = AvroUtils.decodeAvroSpecificRecord(DatastreamEvent.SCHEMA$, value, null);
-      DatastreamUtils.processEventMetadata(event);
-      return event;
-    } catch (IOException e) {
-      throw new DatastreamRuntimeException("Error while decoding event");
-    }
+    return record.getEvents().stream().map(x -> (DatastreamEvent) x.getValue()).collect(Collectors.toList());
   }
 
   @Test

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
@@ -14,10 +14,10 @@ import org.apache.commons.lang.Validate;
 public class DatastreamProducerRecord {
   private final Optional<Integer> _partition;
   private final String _checkpoint;
-  private final List<Pair<byte[], byte[]>> _events;
+  private final List<Pair<Object, Object>> _events;
   private final long _eventsTimestamp;
 
-  DatastreamProducerRecord(List<Pair<byte[], byte[]>> events, Optional<Integer> partition, String checkpoint,
+  DatastreamProducerRecord(List<Pair<Object, Object>> events, Optional<Integer> partition, String checkpoint,
       long eventsTimestamp) {
     Validate.notNull(events, "null event");
     events.forEach((e) -> Validate.notNull(e, "null event"));
@@ -32,7 +32,7 @@ public class DatastreamProducerRecord {
   /**
    * @return all events in the event record
    */
-  public List<Pair<byte[], byte[]>> getEvents() {
+  public List<Pair<Object, Object>> getEvents() {
     return Collections.unmodifiableList(_events);
   }
 

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecordBuilder.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecordBuilder.java
@@ -1,8 +1,8 @@
 package com.linkedin.datastream.server;
 
-import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -11,10 +11,7 @@ import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
-import com.linkedin.datastream.common.AvroUtils;
 import com.linkedin.datastream.common.DatastreamEvent;
-import com.linkedin.datastream.common.ErrorLogger;
 
 
 /**
@@ -27,7 +24,7 @@ public class DatastreamProducerRecordBuilder {
   private Optional<Integer> _partition = Optional.empty();
   private String _sourceCheckpoint = "";
 
-  private List<Pair<byte[], byte[]>> _events = new ArrayList<>();
+  private List<Pair<Object, Object>> _events = new ArrayList<>();
   private long _eventsTimestamp;
 
   /**
@@ -51,7 +48,7 @@ public class DatastreamProducerRecordBuilder {
   /**
    * Add the event with key and value to the DatatreamProducerRecord. Datastream producer record can have multiple events.
    */
-  public void addEvent(byte[] key, byte[] value) {
+  public void addEvent(Object key, Object value) {
     key = key == null ? new byte[0] : key;
     value = value == null ? new byte[0] : value;
     _events.add(new Pair<>(key, value));
@@ -68,16 +65,10 @@ public class DatastreamProducerRecordBuilder {
     datastreamEvent.metadata = datastreamEvent.metadata == null ? new HashMap<>() : datastreamEvent.metadata;
     datastreamEvent.key = datastreamEvent.key == null ? ByteBuffer.allocate(0) : datastreamEvent.key;
     datastreamEvent.payload = datastreamEvent.payload == null ? ByteBuffer.allocate(0) : datastreamEvent.payload;
-    datastreamEvent.previous_payload = datastreamEvent.previous_payload == null ? ByteBuffer.allocate(0) : datastreamEvent.previous_payload;
+    datastreamEvent.previous_payload =
+        datastreamEvent.previous_payload == null ? ByteBuffer.allocate(0) : datastreamEvent.previous_payload;
 
-    byte[] event = null;
-    try {
-      event = AvroUtils.encodeAvroSpecificRecord(DatastreamEvent.class, datastreamEvent);
-    } catch (IOException e) {
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, "Failed to encode event in Avro, event=" + datastreamEvent, e);
-    }
-
-    _events.add(new Pair<>(datastreamEvent.key.array(), event));
+    _events.add(new Pair<>(Base64.getEncoder().encodeToString(datastreamEvent.key.array()), datastreamEvent));
   }
 
   public void setEventsTimestamp(long eventsTimestamp) {

--- a/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestDatastreamProducerRecordBuilder.java
+++ b/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestDatastreamProducerRecordBuilder.java
@@ -7,15 +7,13 @@ import java.util.HashMap;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.linkedin.datastream.common.AvroUtils;
 import com.linkedin.datastream.common.DatastreamEvent;
 
 
 public class TestDatastreamProducerRecordBuilder {
 
   @Test
-  public void testBuilderWithAddDatastreamEventAndValidateFields()
-      throws IOException {
+  public void testBuilderWithAddDatastreamEventAndValidateFields() throws IOException {
     String sourceCheckpoint = "checkpoint";
     int partition = 0;
     long timestamp = System.currentTimeMillis();
@@ -31,10 +29,8 @@ public class TestDatastreamProducerRecordBuilder {
 
     DatastreamProducerRecord record = builder.build();
     Assert.assertEquals(record.getEvents().size(), 2);
-    Assert.assertEquals(record.getEvents().get(0).getValue(),
-        AvroUtils.encodeAvroSpecificRecord(DatastreamEvent.class, event1));
-    Assert.assertEquals(record.getEvents().get(1).getValue(),
-        AvroUtils.encodeAvroSpecificRecord(DatastreamEvent.class, event2));
+    Assert.assertEquals(record.getEvents().get(0).getValue(), event1);
+    Assert.assertEquals(record.getEvents().get(1).getValue(), event2);
     Assert.assertEquals(record.getPartition().get().intValue(), partition);
     Assert.assertEquals(record.getCheckpoint(), sourceCheckpoint);
     Assert.assertEquals(record.getEventsTimestamp(), timestamp);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -99,7 +99,6 @@ public class EventProducer {
   private final DynamicMetricsManager _dynamicMetricsManager;
   private static final Counter TOTAL_EVENTS_PRODUCED = new Counter();
   private static final Counter EVENTS_PRODUCED_WITHIN_SLA = new Counter();
-  private static final Meter EVENT_BYTES_PRODUCE_RATE = new Meter();
   private static final Meter EVENT_PRODUCE_RATE = new Meter();
   private static Long _sourceToDestinationLatencyMs = 0L;
   private static final Gauge<Long> EVENTS_LATENCY_MS = () -> _sourceToDestinationLatencyMs;
@@ -241,7 +240,7 @@ public class EventProducer {
     Validate.notNull(record.getEvents(), "null event payload.");
     Validate.notNull(record.getCheckpoint(), "null event checkpoint.");
 
-    for (Pair<byte[], byte[]> event : record.getEvents()) {
+    for (Pair<Object, Object> event : record.getEvents()) {
       Validate.notNull(event, "null event");
       Validate.notNull(event.getKey(), "null key");
       Validate.notNull(event.getValue(), "null value");
@@ -338,7 +337,6 @@ public class EventProducer {
     int numberOfEvents = record.getEvents().size();
     TOTAL_EVENTS_PRODUCED.inc(numberOfEvents);
     EVENT_PRODUCE_RATE.mark(numberOfEvents);
-    record.getEvents().forEach(e -> EVENT_BYTES_PRODUCE_RATE.mark(e.getKey().length + e.getValue().length));
   }
 
   private void onSendCallback(DatastreamRecordMetadata metadata, Exception exception, SendCallback sendCallback,
@@ -498,8 +496,6 @@ public class EventProducer {
         TOTAL_EVENTS_PRODUCED);
     metrics.put(MetricRegistry.name(EventProducer.class.getSimpleName(), AGGREGATE, "eventsLatencyMs"),
         EVENTS_LATENCY_MS);
-    metrics.put(MetricRegistry.name(EventProducer.class.getSimpleName(), AGGREGATE, "eventByteProduceRate"),
-        EVENT_BYTES_PRODUCE_RATE);
     metrics.put(MetricRegistry.name(EventProducer.class.getSimpleName(), AGGREGATE, "eventProduceRate"),
         EVENT_PRODUCE_RATE);
     metrics.put(EventProducer.class.getSimpleName() + MetricsAware.KEY_REGEX + EVENTS_PRODUCED_OUTSIDE_SLA,

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -185,8 +185,8 @@ public class TestDatastreamServer {
     Collection<String> eventsWritten1 = TestUtils.generateStrings(totalEvents);
     FileUtils.writeLines(new File(fileName1), eventsWritten1);
 
-    Collection<String> eventsReceived1 = readFileDatastreamEvents(fileDatastream1, 0, 4);
-    Collection<String> eventsReceived2 = readFileDatastreamEvents(fileDatastream1, 1, 6);
+    Collection<String> eventsReceived1 = readFileDatastreamEvents(fileDatastream1, 0, 5);
+    Collection<String> eventsReceived2 = readFileDatastreamEvents(fileDatastream1, 1, 5);
     eventsReceived1.addAll(eventsReceived2);
 
     LOG.info("Events Received " + eventsReceived1);

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/AvroUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/AvroUtils.java
@@ -7,6 +7,7 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.BinaryEncoder;
 import org.apache.avro.io.DatumWriter;
@@ -46,8 +47,14 @@ public class AvroUtils {
    * @return encoded bytes
    * @throws IOException
    */
-  public static byte[] encodeAvroGenericRecord(Schema schema, GenericRecord record) throws IOException {
-    DatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(schema);
+  public static byte[] encodeAvroIndexedRecord(Schema schema, IndexedRecord record) throws IOException {
+    DatumWriter<IndexedRecord> datumWriter;
+
+    if (record instanceof GenericRecord) {
+      datumWriter = new GenericDatumWriter<>(schema);
+    } else {
+      datumWriter = new SpecificDatumWriter<>(schema);
+    }
     ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
     BinaryEncoder binaryEncoder = new BinaryEncoder(outputStream);
     datumWriter.write(record, binaryEncoder);
@@ -112,8 +119,7 @@ public class AvroUtils {
    * @return decoded instance of T
    * @throws IOException
    */
-  public static <T> T decodeAvroGenericRecord(Schema schema, byte[] bytes, T reuse)
-      throws IOException {
+  public static <T> T decodeAvroGenericRecord(Schema schema, byte[] bytes, T reuse) throws IOException {
     BinaryDecoder binDecoder = DecoderFactory.defaultFactory().createBinaryDecoder(bytes, null);
     GenericDatumReader<T> reader = new GenericDatumReader<>(schema);
     return reader.read(reuse, binDecoder);


### PR DESCRIPTION
Right now with the way Event producer is implemented. DatastreamEvent is serialized in the event producer, It is again deserialized by the LiKafkaTransportProvider and sent as Avro IndexedRecord to the LiKafkaProducer which again serializes into a byte array. To avoid this double serialization, and an extra deserialization. Rather than send a serialized byte array as a contract between the producer and transport provider, We are giving full object to the transport provider which now can serialize into a byte array before sending it to the transport (like KafkaTransportProvider) or use transports serialization mechanism (like LiKafkaTransportProvider). 

This also makes our API very similar to Samza's system consumer's IncomingMessageEnvelope. This way it is easy to bridge the gap between the Samza and Datastream in future if need be.
