### PR TITLE
Record transport send exception for callback

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/SendFailedException.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/SendFailedException.java
@@ -10,7 +10,8 @@ public class SendFailedException extends Exception {
 
   private Map<DatastreamTask, Map<Integer, String>> _checkpoints;
 
-  public SendFailedException(Map<DatastreamTask, Map<Integer, String>> checkpoints) {
+  public SendFailedException(Map<DatastreamTask, Map<Integer, String>> checkpoints, Exception exception) {
+    super(exception);
     _checkpoints = checkpoints;
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -142,7 +142,7 @@ public class TestEventProducer {
     _config = new Properties();
     _config.put(EventProducer.CHECKPOINT_PERIOD_MS, "50");
 
-    _producer = new EventProducer(_transport, _cpProvider, _config, customCheckpointing, onUnrecoverableError);
+    _producer = new EventProducer(_transport, _cpProvider, _config, customCheckpointing, onUnrecoverableError, 0);
     _tasks.forEach(t -> _producer.assignTask(t));
   }
 
@@ -285,7 +285,7 @@ public class TestEventProducer {
     _producer.shutdown();
 
     // Create a new producer
-    _producer = new EventProducer(_transport, _cpProvider, _config, false, null);
+    _producer = new EventProducer(_transport, _cpProvider, _config, false, null, 0);
 
     _tasks.forEach(t -> _producer.assignTask(t));
     // Expect saved checkpoint to match that of the last event

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
@@ -7,11 +7,15 @@ import java.util.Properties;
 
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
+
+import com.codahale.metrics.MetricRegistry;
 
 import static org.mockito.Mockito.mock;
 
 import com.linkedin.datastream.common.DatastreamEvent;
+import com.linkedin.datastream.common.DynamicMetricsManager;
 import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
 import com.linkedin.datastream.server.api.transport.TransportProviderFactory;
 import com.linkedin.datastream.server.providers.CheckpointProvider;
@@ -23,6 +27,11 @@ import com.linkedin.datastream.server.providers.CheckpointProvider;
 public class TestEventProducerPool {
 
   private EventProducerPool _eventProducerPool;
+
+  @BeforeTest
+  public void init() {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
+  }
 
   public void setup(boolean throwOnSend) throws Exception {
     CheckpointProvider checkpointProvider = mock(CheckpointProvider.class);
@@ -85,6 +94,8 @@ public class TestEventProducerPool {
     Assert.assertNotEquals(oldEventProducer, newDatastreamEventProducer.getEventProducer());
     Assert.assertEquals(metadata.size(), 1);
     Assert.assertEquals(exceptions.size(), 1);
+    Assert.assertNotNull(exceptions.get(0).getCause());
+    Assert.assertEquals(newDatastreamEventProducer.getEventProducer().getGeneration(), 1);
   }
 
   private DatastreamProducerRecord createEventRecord(Integer partition) {


### PR DESCRIPTION
Retain the transport exception for the callback. Also add a generation
field to the event producer which gets torn down and recreated when
there is any transport send error. This should help filter out failed
producer operations that are called on the bad producer which can happen
because the producer -> task mapping is not updated atomically.
