### PR TITLE
Exposing the properties of the EmbeddedDatastreamCluster

### DIFF
--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1258,7 +1258,7 @@ public class TestCoordinator {
     EmbeddedDatastreamCluster datastreamKafkaCluster =
         TestDatastreamServer.initializeTestDatastreamServerWithDummyConnector(null);
     datastreamKafkaCluster.startup();
-    Properties properties = datastreamKafkaCluster.getPrimaryDatastreamServerProperties();
+    Properties properties = datastreamKafkaCluster.getDatastreamServerProperties().get(0);
     DatastreamResources resource = new DatastreamResources(datastreamKafkaCluster.getPrimaryDatastreamServer());
 
     Coordinator coordinator = createCoordinator(properties.getProperty(DatastreamServer.CONFIG_ZK_ADDRESS),

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -285,7 +285,7 @@ public class TestDatastreamServer {
 
     // Ensure 1st instance was assigned the task
     String cluster =
-        _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(DatastreamServer.CONFIG_CLUSTER_NAME);
+        _datastreamCluster.getDatastreamServerProperties().get(0).getProperty(DatastreamServer.CONFIG_CLUSTER_NAME);
     ZkClient zkclient = new ZkClient(_datastreamCluster.getZkConnection());
     String instance = server1.getCoordinator().getInstanceName();
     String assignmentPath = KeyBuilder.instanceAssignments(cluster, instance);
@@ -358,7 +358,7 @@ public class TestDatastreamServer {
 
     // Ensure both instances were assigned the task
     String cluster =
-        _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(DatastreamServer.CONFIG_CLUSTER_NAME);
+        _datastreamCluster.getDatastreamServerProperties().get(0).getProperty(DatastreamServer.CONFIG_CLUSTER_NAME);
     ZkClient zkclient = new ZkClient(_datastreamCluster.getZkConnection());
     String instance = server1.getCoordinator().getInstanceName();
     String assignmentPath = KeyBuilder.instanceAssignments(cluster, instance);
@@ -448,7 +448,7 @@ public class TestDatastreamServer {
 
     // Ensure 1st instance was assigned both tasks
     String cluster =
-        _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(DatastreamServer.CONFIG_CLUSTER_NAME);
+        _datastreamCluster.getDatastreamServerProperties().get(0).getProperty(DatastreamServer.CONFIG_CLUSTER_NAME);
     ZkClient zkclient = new ZkClient(_datastreamCluster.getZkConnection());
     String instance1 = server1.getCoordinator().getInstanceName();
     String assignmentPath = KeyBuilder.instanceAssignments(cluster, instance1);
@@ -506,7 +506,7 @@ public class TestDatastreamServer {
         KafkaDestination.parseKafkaDestinationUri(datastream.getDestination().getConnectionString());
     final int[] numberOfMessages = {0};
     List<String> eventsReceived = new ArrayList<>();
-    KafkaTestUtils.readTopic(kafkaDestination.topicName(), partition, _datastreamCluster.getBrokerList(),
+    KafkaTestUtils.readTopic(kafkaDestination.topicName(), partition, _datastreamCluster.getKafkaCluster().getBrokers(),
         (key, value) -> {
           DatastreamEvent datastreamEvent = AvroUtils.decodeAvroSpecificRecord(DatastreamEvent.class, value);
           String eventValue = new String(datastreamEvent.payload.array());

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestServerHealth.java
@@ -68,13 +68,13 @@ public class TestServerHealth {
   public void testServerHealthHasRightClusterNameAndInstanceName() throws RemoteInvocationException {
     ServerHealth serverHealth = fetchServerHealth();
     Assert.assertEquals(serverHealth.getClusterName(),
-        _datastreamCluster.getPrimaryDatastreamServerProperties().getProperty(DatastreamServer.CONFIG_CLUSTER_NAME));
+        _datastreamCluster.getDatastreamServerProperties().get(0).getProperty(DatastreamServer.CONFIG_CLUSTER_NAME));
     Assert.assertEquals(serverHealth.getInstanceName(),
         _datastreamCluster.getPrimaryDatastreamServer().getCoordinator().getInstanceName());
   }
 
   public ServerHealth fetchServerHealth() throws RemoteInvocationException {
-    String healthUri = "http://localhost:" + _datastreamCluster.getPrimaryDatastreamPort() + "/";
+    String healthUri = "http://localhost:" + _datastreamCluster.getDatastreamPorts().get(0) + "/";
     _builders = new HealthRequestBuilders();
     final HttpClientFactory http = new HttpClientFactory();
     final Client r2Client = new TransportClientAdapter(http.getClient(Collections.<String, String>emptyMap()));

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -32,6 +32,7 @@ public class EmbeddedDatastreamCluster {
   private EmbeddedZookeeper _zk = null;
 
   private int _numServers;
+
   private List<Integer> _datastreamPorts = new ArrayList<>();
   private List<Properties> _datastreamServerProperties = new ArrayList<>();
   private List<DatastreamServer> _servers = new ArrayList<>();
@@ -142,20 +143,20 @@ public class EmbeddedDatastreamCluster {
     return new EmbeddedDatastreamCluster(connectorProperties, override, kafkaCluster, numServers, dmsPorts);
   }
 
-  /**
-   * Get the datastream server config for the primary datastream server
-   * Configs for different servers in the cluster only differ by http port
-   * number.
-   */
-  public Properties getPrimaryDatastreamServerProperties() {
-    return _datastreamServerProperties.get(0);
+  public KafkaCluster getKafkaCluster() {
+    return _kafkaCluster;
   }
 
-  /**
-   * Get the http port for the primary datastream server
-   */
-  public int getPrimaryDatastreamPort() {
-    return _datastreamPorts.get(0);
+  public int getNumServers() {
+    return _numServers;
+  }
+
+  public List<Integer> getDatastreamPorts() {
+    return _datastreamPorts;
+  }
+
+  public List<Properties> getDatastreamServerProperties() {
+    return _datastreamServerProperties;
   }
 
   /**
@@ -178,15 +179,6 @@ public class EmbeddedDatastreamCluster {
 
   public List<DatastreamServer> getAllDatastreamServers() {
     return Collections.unmodifiableList(_servers);
-  }
-
-  public String getBrokerList() {
-    if (_kafkaCluster == null) {
-      LOG.error("This datastream cluster doesn't use kafka for transport");
-      return null;
-    }
-
-    return _kafkaCluster.getBrokers();
   }
 
   public String getZkConnection() {


### PR DESCRIPTION
EmbeddedDatastreamCluster right now doesn't expose the kafkaCluster and other datastream server properties, exposing them so that the tests can access them.
