### PR TITLE
Fixed event producer pool size can't be one

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducerPool.java
@@ -82,7 +82,9 @@ public class EventProducerPool implements MetricsAware {
     Validate.notEmpty(connectorType);
 
     if (!_producerPool.containsKey(customCheckpointing)) {
-      _producerPool.put(customCheckpointing, createProducers(_poolSize / 2, customCheckpointing));
+      // The minimal size of a chuck must be >= 1
+      int chuckSize = Math.max(_poolSize / 2, 1);
+      _producerPool.put(customCheckpointing, createProducers(chuckSize, customCheckpointing));
     }
 
     List<EventProducer> producers = _producerPool.get(customCheckpointing);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.server;
 
+import com.linkedin.datastream.common.ReflectionUtils;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -54,6 +55,31 @@ public class TestEventProducerPool {
   @Test
   public void testEmptyPool() throws Exception {
     setup(false);
+    List<DatastreamTask> connectorTasks = new ArrayList<>();
+    String connectorType = "connectortype";
+    connectorTasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(1, true)));
+    connectorTasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(2, true)));
+
+    _eventProducerPool.assignEventProducers(connectorType, connectorTasks, new ArrayList<>(), false);
+
+    // All the tasks that were passed in have a corresponding producer
+    connectorTasks.forEach(task -> Assert.assertNotNull(task.getEventProducer()));
+
+    // The producers are unique for different tasks
+    Assert.assertNotEquals(connectorTasks.get(0).getEventProducer(), connectorTasks.get(1).getEventProducer());
+  }
+
+  /**
+   * Validates if producers are created when pool size is set to 1
+   * See DDSDBUS-8318
+   */
+  @Test
+  public void testPoolOfSizeOne() throws Exception {
+    setup(false);
+
+    // Force size to be 1
+    ReflectionUtils.setField(_eventProducerPool, "_poolSize", 1);
+
     List<DatastreamTask> connectorTasks = new ArrayList<>();
     String connectorType = "connectortype";
     connectorTasks.add(new DatastreamTaskImpl(TestDestinationManager.generateDatastream(1, true)));


### PR DESCRIPTION
As we use 1/2 of the configured pool size as internal chunk size, the chunk size would be 0 when the pool size is set to 1. Now force chunk size to be greater or equal to 1.
