### PR TITLE
Added registerMetric() to DynamicMetrcRegister

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DynamicMetricsManager.java
@@ -1,11 +1,11 @@
 package com.linkedin.datastream.common;
 
-import com.codahale.metrics.Metric;
 import org.apache.commons.lang.Validate;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.server;
 
+import com.linkedin.datastream.common.ThreadTerminationMonitor;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -200,6 +201,7 @@ public class DatastreamServer {
   }
 
   private void initializeMetrics() {
+    registerMetrics(ThreadTerminationMonitor.getMetrics());
     registerMetrics(_coordinator.getMetrics());
     registerMetrics(DatastreamResources.getMetrics());
     registerMetrics(BootstrapActionResources.getMetrics());

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadTerminationMonitor.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadTerminationMonitor.java
@@ -1,0 +1,52 @@
+package com.linkedin.datastream.common;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricRegistry;
+
+
+/**
+ * This class traps threads with unhandled exceptions and
+ * reports abnormal terminations and reports them as metric,
+ * however it doesn't attempt to recover the condition
+ */
+public class ThreadTerminationMonitor {
+
+  private static final String ABNORMAL_TERMINATIONS = "abnormalTerminations";
+
+  private static final Logger LOG = LoggerFactory.getLogger(ThreadTerminationMonitor.class);
+
+  private static final Thread.UncaughtExceptionHandler OLD_HANDLER;
+  private static final Counter TERMINATION_COUNT;
+
+  static {
+    // Create metric
+    TERMINATION_COUNT = new Counter();
+
+    // Replace the default uncaught exception handler
+    OLD_HANDLER = Thread.getDefaultUncaughtExceptionHandler();
+    Thread.setDefaultUncaughtExceptionHandler((Thread t, Throwable e) -> {
+      LOG.error(String.format("Thread %s terminated abnormally", t.getName()), e);
+      TERMINATION_COUNT.inc();
+      // Resume the old behavior
+      if (OLD_HANDLER != null) {
+        OLD_HANDLER.uncaughtException(t, e);
+      }
+    });
+  }
+
+  public static Map<String, Metric> getMetrics() {
+    Map<String, Metric> metrics = new HashMap<>();
+    String metricName = MetricRegistry.name(
+        ThreadTerminationMonitor.class.getSimpleName(), ABNORMAL_TERMINATIONS);
+    metrics.put(metricName, TERMINATION_COUNT);
+    return Collections.unmodifiableMap(metrics);
+  }
+}

--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/TestThreadTerminationMonitor.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/TestThreadTerminationMonitor.java
@@ -1,0 +1,39 @@
+package com.linkedin.datastream.common;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.Counter;
+
+
+public class TestThreadTerminationMonitor {
+
+  private Counter counter;
+
+  @BeforeTest
+  public void prepare() {
+    counter = (Counter) ThreadTerminationMonitor.getMetrics().values().iterator().next();
+    Assert.assertEquals(0, counter.getCount());
+  }
+
+  @Test
+  public void testHappyDay()
+      throws Exception {
+    Thread thread = new Thread(() -> {
+    });
+    thread.join();
+    Assert.assertEquals(0, counter.getCount());
+  }
+
+  @Test
+  public void testLeakage()
+      throws Exception {
+    Thread thread = new Thread(() -> {
+      throw new RuntimeException();
+    });
+    thread.start();
+    thread.join();
+    Assert.assertEquals(1, counter.getCount());
+  }
+}


### PR DESCRIPTION
Added registerMetric() to DynamicMetrcRegister to allow registration of a metric directly, this is needed for metric types such as Gauge, where an implementation to retrieve the value is required and can't be created directly inside DynamicMetrcRegister.
