### PR TITLE
Add creation timestamp metadata for datastream

### DIFF
--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -191,6 +191,7 @@ public class TestDatastreamRestClient {
     for (Datastream stream : datastreams) {
       stream.getMetadata().remove(DatastreamMetadataConstants.DESTINATION_CREATION_MS);
       stream.getMetadata().remove(DatastreamMetadataConstants.DESTINATION_RETENION_MS);
+      stream.getMetadata().remove(DatastreamMetadataConstants.CREATION_MS);
     }
   }
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -29,4 +29,9 @@ public class DatastreamMetadataConstants {
    * Duration in Epoch-millis before destination starts to delete messages
    */
   public static final String DESTINATION_RETENION_MS = "destination.retention.ms";
+
+  /**
+   * Timestamp of datastream creation in epoch-milis
+   */
+  public static final String CREATION_MS = "creation.ms";
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -7,6 +7,7 @@ import com.linkedin.datastream.server.CachedDatastreamReader;
 import com.linkedin.datastream.server.dms.ZookeeperBackedDatastreamStore;
 import com.linkedin.datastream.server.zk.KeyBuilder;
 
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -78,6 +79,7 @@ public class DatastreamTestUtils {
     ds.setStatus(DatastreamStatus.INITIALIZING);
     StringMap metadata = new StringMap();
     metadata.put(DatastreamMetadataConstants.OWNER_KEY, "dummy_owner");
+    metadata.put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(Instant.now().toEpochMilli()));
     ds.setMetadata(metadata);
     return ds;
   }


### PR DESCRIPTION
This timestamp is used to sort the datastreams before de-duping and task
reassignment. This ensures coordinator does not create tasks for a new
datastream sharing destination with an existing one, which can happen
when the new name is alphabetically "smaller" than that of the existing
datastream (zookeeper returns zknodes sorted based on alphabetic order).

Also fixed an issue of metrics for initializeDatastream. Additionally,
remove instanceError handling for initializeDatastream which is most
likely caused by invalid input datastream instead of server issue.
