### PR TITLE
Fix metrics for availability calculation

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -343,9 +343,9 @@ public class EventProducer {
                 _sourceToDestinationLatencyMs, task.getDatastreamSource().getConnectionString(), metadata.getTopic(),
                 metadata.getPartition(), _availabilityThresholdSlaMs));
       }
+      TOTAL_EVENTS_PRODUCED.inc(numberOfEvents);
     }
 
-    TOTAL_EVENTS_PRODUCED.inc(numberOfEvents);
     EVENT_PRODUCE_RATE.mark(numberOfEvents);
   }
 


### PR DESCRIPTION
Calculation for availability: {number of events produced within SLA} / {total number of events produced}

Currently we're incrementing the numerator variable only if records have the event timestamp, yet we are always incrementing the denominator variable. This can negatively impact the availability, by displaying a lower metric than actual.

Fix is to only increment the denominator if event timestamp existed as well.
