### PR TITLE
Fix assignment validation and sort datastream task in LB strategy

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -62,8 +62,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
     }
 
     int maxTasksPerDatastream = Math.max(instances.size() * overPartitioningFactor, minTasks);
-    datastreams = sortDatastreams(datastreams);
     List<DatastreamTask> datastreamTasks = getDatastreamTasks(datastreams, currentAssignment, maxTasksPerDatastream);
+    Collections.sort(datastreamTasks, (a, b) -> a.getDatastreamTaskName().compareTo(b.getDatastreamTaskName()));
     Collections.sort(instances);
 
     Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
@@ -81,22 +81,6 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
         assignment));
 
     return assignment;
-  }
-
-  private List<Datastream> sortDatastreams(List<Datastream> datastreams) {
-    Map<String, Datastream> m = new HashMap<>();
-    List<String> keys = new ArrayList<>();
-    datastreams.forEach(ds -> {
-      m.put(ds.getName(), ds);
-      keys.add(ds.getName());
-    });
-
-    Collections.sort(keys);
-
-    List<Datastream> result = new ArrayList<>();
-    keys.forEach(k -> result.add(m.get(k)));
-
-    return result;
   }
 
   private List<DatastreamTask> getDatastreamTasks(List<Datastream> datastreams,

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1349,8 +1349,8 @@ public class TestCoordinator {
     }
 
     Set<String> nameSet = new HashSet<>(Arrays.asList(datastreamNames));
-    return assignment.stream().anyMatch(t -> !nameSet.contains(t.getDatastreams().get(0)) ||
-        t.getEventProducer() == null);
+    return assignment.stream().allMatch(t -> nameSet.contains(t.getDatastreams().get(0).getName()) &&
+        t.getEventProducer() != null);
   }
 
   private void deleteLiveInstanceNode(ZkClient zkClient, String cluster, Coordinator instance) {


### PR DESCRIPTION
The following line always returns true, which always allows validation to pass. The problem is that nameSet is a Set String which will never contain an object of type Datastream: 

assignment.stream().anyMatch(t -> !nameSet.contains(t.getDatastreams().get(0)) || t.getEventProducer() == null);

In addition, sorting on Datastream name won't work because the tasks are the entities that are actually assigned. If requirement for predictable and lexicographical assignment still exists, we should sort the datastream tasks.
