### PR TITLE
Add per topic latency histograms

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamEventMetadata.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamEventMetadata.java
@@ -22,6 +22,9 @@ public class DatastreamEventMetadata {
   // Table for which the event belongs
   public static final String TABLE = "Table";
 
-  // Timestamp of the event.
+  // Timestamp of when the event was last modified in the source
   public static final String EVENT_TIMESTAMP = "EventTimestamp";
+
+  // Timestamp of the event source
+  public static final String SOURCE_TIMESTAMP = "SourceTimestamp";
 }

--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -90,7 +90,7 @@ class FileProcessor implements Runnable {
           LOG.info("sending event " + text);
           DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
           builder.addEvent(event);
-          builder.setEventsTimestamp(currentTimeMillis);
+          builder.setEventsSourceTimestamp(currentTimeMillis);
           // If the destination is user managed, we will use the key to decide the partition.
           if (!_task.isUserManagedDestination()) {
             builder.setPartition(0);

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlBinlogEventListener.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlBinlogEventListener.java
@@ -319,7 +319,7 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
           .map(metadata -> metadata.get(DatastreamEventMetadata.EVENT_TIMESTAMP))
           .map(metaVal -> Long.valueOf(metaVal.toString()));
       if (eventTimestamp.isPresent()) {
-        builder.setEventsTimestamp(eventTimestamp.get());
+        builder.setEventsSourceTimestamp(eventTimestamp.get());
       } else {
         String errorMsg = "Datastream event " + _eventsInTransaction.get(0).toString() + " was missing event timestamp metadata.";
         LOG.error(errorMsg);

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
@@ -15,18 +15,18 @@ public class DatastreamProducerRecord {
   private final Optional<Integer> _partition;
   private final String _checkpoint;
   private final List<Pair<Object, Object>> _events;
-  private final long _eventsTimestamp;
+  private final long _eventsSourceTimestamp;
 
   DatastreamProducerRecord(List<Pair<Object, Object>> events, Optional<Integer> partition, String checkpoint,
-      long eventsTimestamp) {
+      long eventsSourceTimestamp) {
     Validate.notNull(events, "null event");
     events.forEach((e) -> Validate.notNull(e, "null event"));
-    Validate.isTrue(eventsTimestamp > 0, "events timestamp is invalid");
+    Validate.isTrue(eventsSourceTimestamp > 0, "events source timestamp is invalid");
 
     _events = events;
     _partition = partition;
     _checkpoint = checkpoint;
-    _eventsTimestamp = eventsTimestamp;
+    _eventsSourceTimestamp = eventsSourceTimestamp;
   }
 
   /**
@@ -37,10 +37,10 @@ public class DatastreamProducerRecord {
   }
 
   /**
-   * @return timestamp in Epoch-millis when the events were created
+   * @return timestamp in Epoch-millis when the events were produced onto the source
    */
-  public long getEventsTimestamp() {
-    return _eventsTimestamp;
+  public long getEventsSourceTimestamp() {
+    return _eventsSourceTimestamp;
   }
 
   /**

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecordBuilder.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecordBuilder.java
@@ -25,7 +25,7 @@ public class DatastreamProducerRecordBuilder {
   private String _sourceCheckpoint = "";
 
   private List<Pair<Object, Object>> _events = new ArrayList<>();
-  private long _eventsTimestamp;
+  private long _eventsSourceTimestamp;
 
   /**
    * Partition to which this DatastreamProducerRecord should be produced. if the partition is not set, TransportProvider
@@ -71,8 +71,8 @@ public class DatastreamProducerRecordBuilder {
     _events.add(new Pair<>(Base64.getEncoder().encodeToString(datastreamEvent.key.array()), datastreamEvent));
   }
 
-  public void setEventsTimestamp(long eventsTimestamp) {
-    _eventsTimestamp = eventsTimestamp;
+  public void setEventsSourceTimestamp(long eventsSourceTimestamp) {
+    _eventsSourceTimestamp = eventsSourceTimestamp;
   }
 
   /**
@@ -81,6 +81,6 @@ public class DatastreamProducerRecordBuilder {
    *   DatastreamProducerRecord that is created.
    */
   public DatastreamProducerRecord build() {
-    return new DatastreamProducerRecord(_events, _partition, _sourceCheckpoint, _eventsTimestamp);
+    return new DatastreamProducerRecord(_events, _partition, _sourceCheckpoint, _eventsSourceTimestamp);
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -9,8 +9,8 @@ import com.linkedin.datastream.server.DatastreamTask;
 
 /**
  *  Connector interface defines a small set of methods that Coordinator communicates with.
- *  When the Coordinator starts, it will start all connectors it manages by calling the <i>start</i> method. When the Coordinator is
- *  shutting down gracefully, it will stop all connectors by calling the <i>stop</i> method.
+ *  When the Coordinator starts, it will start all connectors it manages by calling the <i>start</i> method. When the
+ *  Coordinator is shutting down gracefully, it will stop all connectors by calling the <i>stop</i> method.
  */
 public interface Connector extends MetricsAware {
 
@@ -26,9 +26,8 @@ public interface Connector extends MetricsAware {
   void stop();
 
   /**
-   * callback when the datastreams assignment to this instance is changed. This is called whenever
-   * there is a change for the assignment. The implementation of the Connector is responsible
-   * to keep a state of the previous assignment.
+   * Callback when the datastreams assignment to this instance is changed. The implementation of the Connector is
+   * responsible to keep a state of the previous assignment.
    *
    * @param tasks the list of the current assignment.
    */

--- a/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestDatastreamProducerRecordBuilder.java
+++ b/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestDatastreamProducerRecordBuilder.java
@@ -24,7 +24,7 @@ public class TestDatastreamProducerRecordBuilder {
     builder.addEvent(event1);
     builder.addEvent(event2);
     builder.setPartition(partition);
-    builder.setEventsTimestamp(timestamp);
+    builder.setEventsSourceTimestamp(timestamp);
     builder.setSourceCheckpoint(sourceCheckpoint);
 
     DatastreamProducerRecord record = builder.build();
@@ -33,7 +33,7 @@ public class TestDatastreamProducerRecordBuilder {
     Assert.assertEquals(record.getEvents().get(1).getValue(), event2);
     Assert.assertEquals(record.getPartition().get().intValue(), partition);
     Assert.assertEquals(record.getCheckpoint(), sourceCheckpoint);
-    Assert.assertEquals(record.getEventsTimestamp(), timestamp);
+    Assert.assertEquals(record.getEventsSourceTimestamp(), timestamp);
   }
 
   private DatastreamEvent createDatastreamEvent() {
@@ -48,7 +48,7 @@ public class TestDatastreamProducerRecordBuilder {
   @Test
   public void testWithoutPartitionWithoutEventsWithoutSourceCheckpoint() {
     DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
-    builder.setEventsTimestamp(System.currentTimeMillis());
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
 
     DatastreamProducerRecord record = builder.build();
     Assert.assertFalse(record.getPartition().isPresent());
@@ -79,7 +79,7 @@ public class TestDatastreamProducerRecordBuilder {
     byte[] key = "key".getBytes();
     byte[] payload = "payload".getBytes();
     builder.addEvent(key, payload);
-    builder.setEventsTimestamp(System.currentTimeMillis());
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
     DatastreamProducerRecord record = builder.build();
 
     Assert.assertEquals(record.getEvents().size(), 1);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/providers/CheckpointProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/providers/CheckpointProvider.java
@@ -19,8 +19,8 @@ public interface CheckpointProvider extends MetricsAware {
   void commit(Map<DatastreamTask, String> checkpoints);
 
   /**
-   * Read the commited checkpoints from the checkpoint store
-   * @param datastreamTasks List of datastream tasks whose checkpoint needs to be read
+   * Read the committed checkpoints from the checkpoint store
+   * @param datastreamTasks List of datastream tasks whose checkpoints need to be read
    * @return Map of the checkpoints associated with the datastream task.
    */
   Map<DatastreamTask, String> getCommitted(List<DatastreamTask> datastreamTasks);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -81,7 +81,7 @@ public class TestEventProducer {
     builder.addEvent(event);
     builder.setPartition(partition);
     builder.setSourceCheckpoint("new dummy checkpoint " + String.valueOf(_eventSeed));
-    builder.setEventsTimestamp(System.currentTimeMillis());
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
     return builder.build();
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducerPool.java
@@ -133,7 +133,7 @@ public class TestEventProducerPool {
     builder.addEvent(event);
     builder.setPartition(partition);
     builder.setSourceCheckpoint("new dummy checkpoint");
-    builder.setEventsTimestamp(System.currentTimeMillis());
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
     return builder.build();
   }
 

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/TestEventProducingConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/TestEventProducingConnector.java
@@ -172,7 +172,7 @@ public class TestEventProducingConnector implements Connector {
     builder.addEvent(event);
     builder.setPartition(partition);
     builder.setSourceCheckpoint(String.valueOf(eventIndex));
-    builder.setEventsTimestamp(System.currentTimeMillis());
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
     return builder.build();
   }
 


### PR DESCRIPTION
Wei and I seem to have done almost identical work for event lag metrics.

I've removed his work (https://rb.corp.linkedin.com/r/820571/diff/4#index_header) and consolidated it with mine by adding histograms for per-topic lag. The proper fix was to use espresso event's produce time, rather than the row image's modified time, for the latency calculation.
