### PR TITLE
Fix possible concurrent modification exception

### DIFF
--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -219,7 +219,8 @@ public class EmbeddedDatastreamCluster {
     }
 
     // Make sure all servers have started fully
-    _servers.stream().forEach(s -> PollUtils.poll(() -> s.isInitialized(), 1000, SERVER_INIT_TIMEOUT_MS));
+    _servers.stream().forEach(s -> PollUtils.poll(() -> s.isStarted(), 1000, SERVER_INIT_TIMEOUT_MS));
+
   }
 
   public void shutdownServer(int index) {


### PR DESCRIPTION
CachedDatatreamReader can trigger ConcurrentModificationException when
both getAllDatastreams and handleChildChange are called concurrently
given the former is not synchronized. One option is to use concurrent
hash map but given the rest of the class is using synchronized thus also
adding synchronized to getAllDatastreams. Also simplified some of the
code.