### PR TITLE
Allow connector to set timeout for task acquisition

### DIFF
--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -6,6 +6,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.nio.ByteBuffer;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -24,6 +25,7 @@ class FileProcessor implements Runnable {
 
   private static final int PARTITION = 0;
   private static final int POLL_WAIT_MS = 100;
+  private static final Duration ACQUIRE_TIMEOUT = Duration.ofMinutes(5);
 
   private final DatastreamTask _task;
   private final String _fileName;
@@ -67,7 +69,7 @@ class FileProcessor implements Runnable {
   @Override
   public void run() {
     try {
-      _task.acquire();
+      _task.acquire(ACQUIRE_TIMEOUT);
 
       Integer lineNo = loadCheckpoint();
       while (!_cancelRequested) {

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamTask.java
@@ -1,11 +1,11 @@
 package com.linkedin.datastream.server;
 
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
-import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamSource;
 
 
@@ -95,8 +95,9 @@ public interface DatastreamTask {
    * two instances will work on the same task concurrently thus causing duplicate
    * events. This can happen in task reassignment induced by new or dead instances.
    * This is a no-op if the task is already acquired by the same instance.
+   * @param timeout duration to wait before timeout in acquiring the task
    */
-  void acquire() throws DatastreamException;
+  void acquire(Duration timeout);
 
   /**
    * A connector should remember to release a task if the task is unassigned to it

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -2,7 +2,6 @@ package com.linkedin.datastream.server;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
-import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.JsonUtils;
@@ -14,6 +13,7 @@ import org.codehaus.jackson.annotate.JsonIgnore;
 import org.apache.commons.lang.Validate;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -44,9 +44,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamTask.class.getName());
 
   private static final String STATUS = "STATUS";
-
-  // Wait at most 60 seconds for acquiring the task
-  private static final Integer ACQUIRE_TIMEOUT_MS = 60000;
 
   // connector type. Type of the connector to be used for reading the change capture events
   // from the source, e.g. Oracle-Change, Espresso-Change, Oracle-Bootstrap, Espresso-Bootstrap,
@@ -179,15 +176,11 @@ public class DatastreamTaskImpl implements DatastreamTask {
   }
 
   @Override
-  public void acquire() throws DatastreamException {
-    acquire(ACQUIRE_TIMEOUT_MS);
-  }
-
-  public void acquire(int timeout) throws DatastreamException {
+  public void acquire(Duration timeout) {
     Validate.notNull(_zkAdapter, "Task is not properly initialized for processing.");
     try {
       _zkAdapter.acquireTask(this, timeout);
-    } catch (DatastreamException e) {
+    } catch (Exception e) {
       LOG.error("Failed to acquire task: " + this, e);
       setStatus(DatastreamTaskStatus.error("Acquire failed, exception: " + e));
       throw e;


### PR DESCRIPTION
Previously, the default timeout for task acquire is 60s and there is no
way for connector to specify how long it wants to wait to acquire the
task. This change changes the acquire() API to allow specifying a custom
timeout to be more flexible.