### PR TITLE
creating a new api for Dynamic Metrics the supports cacheing of the f…

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/MetricsAware.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/MetricsAware.java
@@ -35,6 +35,13 @@ public interface MetricsAware {
   }
 
   /**
+   * @return the metric name prepended with the caller's class name
+   */
+  default String buildMetricName(String classSimpleName, String metricName) {
+    return MetricRegistry.name(classSimpleName, metricName);
+  }
+
+  /**
    * Get a regular expression for all dynamic metrics created within the class.
    *
    * For example, this regular expression should capture all topic-specific metrics emitted by KafkaTransportProvider
@@ -47,5 +54,9 @@ public interface MetricsAware {
    */
   default String getDynamicMetricPrefixRegex() {
     return this.getClass().getSimpleName() + KEY_REGEX;
+  }
+
+  default String getDynamicMetricPrefixRegex(String classSimpleName) {
+    return classSimpleName + KEY_REGEX;
   }
 }


### PR DESCRIPTION
…ullMetricName

The profiler indicated a CPU performance issue when running `#getSimpleName()`. The `#getSimpleName()` method along with `metricName` was simply used to dynamically generate the `fullMetricName`. By cacheing the `fullMetricName` we hope to increase CPU performance .

This PR maintains backwards compatibility with the pervious API.

Has **not** been locally unit tested.