### PR TITLE
Make KafkaDestination backward compatible

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,7 @@ project(':datastream-mysql-connector') {
 project(':datastream-kafka') {
   dependencies {
     compile "org.apache.kafka:kafka_2.10:$kafkaVersion"
+    compile "commons-httpclient:commons-httpclient:$commonsHttpClientVersion"
 
     compile project(':datastream-server-api')
     compile project(':datastream-utils')

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaDestination.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaDestination.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.kafka;
 
+import org.apache.commons.httpclient.util.URIUtil;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,42 +13,62 @@ public class TestKafkaDestination {
     String topicName = "testtopic_test";
     KafkaDestination destination = new KafkaDestination(zkAddress, topicName, false);
     Assert.assertEquals(destination.getDestinationURI(),
-        "kafka://localhost:12913/kafka-datastream?testtopic_test");
+        "kafka://localhost:12913/kafka-datastream/testtopic_test");
 
     destination = new KafkaDestination(zkAddress, topicName, true);
     Assert.assertEquals(destination.getDestinationURI(),
-        "kafkassl://localhost:12913/kafka-datastream?testtopic_test");
+        "kafkassl://localhost:12913/kafka-datastream/testtopic_test");
+
+    // No path case
+    zkAddress = "localhost:12913";
+    destination = new KafkaDestination(zkAddress, topicName, true);
+    Assert.assertEquals(destination.getDestinationURI(),
+        "kafkassl://localhost:12913/testtopic_test");
   }
 
   @Test
   public void testDestinationParsing() {
     String zkAddress = "localhost:12913/kafka-datastream";
     String topicName = "testtopic_test";
-    String uri = "kafka://localhost:12913/kafka-datastream?testtopic_test";
+    String uri = "kafka://localhost:12913/kafka-datastream/testtopic_test";
     KafkaDestination destination = KafkaDestination.parse(uri);
     Assert.assertEquals(destination.getZkAddress(), zkAddress);
     Assert.assertEquals(destination.getTopicName(), topicName);
     Assert.assertFalse(destination.isSecure());
 
     // Secure case
-    uri = "kafkassl://localhost:12913/kafka-datastream?testtopic_test";
+    uri = "kafkassl://localhost:12913/kafka-datastream/testtopic_test";
     destination = KafkaDestination.parse(uri);
     Assert.assertTrue(destination.isSecure());
 
     // No path case
-    uri = "kafkassl://localhost:12913?testtopic_test";
+    uri = "kafkassl://localhost:12913/testtopic_test";
     destination = KafkaDestination.parse(uri);
     Assert.assertEquals(destination.getZkAddress(), "localhost:12913");
+    Assert.assertEquals(destination.getTopicName(), "testtopic_test");
+  }
+
+  @Test
+  public void testEscapedUri() throws Exception {
+    String uri = "kafka://localhost%3A12913%2Fkafka-datastream/testtopic_test";
+    KafkaDestination destination = KafkaDestination.parse(uri);
+    Assert.assertEquals(destination.getZkAddress(), "localhost:12913/kafka-datastream");
+    Assert.assertEquals(destination.getTopicName(), "testtopic_test");
+
+    uri = URIUtil.encodeWithinAuthority("kafka://localhost:12913/kafka-datastream/testtopic_test");
+    destination = KafkaDestination.parse(uri);
+    Assert.assertEquals(destination.getZkAddress(), "localhost:12913/kafka-datastream");
+    Assert.assertEquals(destination.getTopicName(), "testtopic_test");
   }
 
   @Test(expectedExceptions = Exception.class)
   public void testUriMissingAuthority() {
-    KafkaDestination.parse("kafka://?foobar");
+    KafkaDestination.parse("kafka:///foobar");
   }
 
   @Test(expectedExceptions = Exception.class)
   public void testUriMissingPort() {
-    KafkaDestination.parse("kafka://abc?foobar");
+    KafkaDestination.parse("kafka://abc/foobar");
   }
 
   @Test(expectedExceptions = Exception.class)

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -1,5 +1,6 @@
 ext {
     commonsCliVersion = "1.2"
+    commonsHttpClientVersion = "3.1"
     slf4jVersion = "1.7.5"
     log4jVersion = "1.2.17"
     kafkaVersion = "0.9.0.0"


### PR DESCRIPTION
The last commit makes KafkaDestination to use query string to store
topic name which breaks backward compatibility. Given it is hard to
coordinate such change operational-wise. This change make it back
compatible.