### PR TITLE
Adding a check for transportProviderName in datastream

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -193,7 +193,12 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   public void setDatastream(Datastream datastream) {
     _datastream = datastream;
-    _transportProviderName = datastream.getTransportProviderName();
+
+    // It is possible that the datastream doesn't have transport provider name in which case
+    // coordinator will set this to defaultTransportProviderName.
+    if (datastream.hasTransportProviderName()) {
+      _transportProviderName = datastream.getTransportProviderName();
+    }
   }
 
   @JsonIgnore


### PR DESCRIPTION
For the datastreams that were created using the old brooklin servers, transportPRoviderName fields don't exist, So when this happens coordinator will automatically set the transportProviderName to defaultTransportProviderName. But datastreamTaskImpl doesn't check whether datastream has the transportProviderName.