### PR TITLE
Include Event producer and transport provider metrics to the datastream server

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProviderAdmin.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProviderAdmin.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.server.api.transport;
 import java.time.Duration;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.metrics.MetricsAware;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 
@@ -10,7 +11,7 @@ import com.linkedin.datastream.server.api.connector.DatastreamValidationExceptio
 /**
  * Transport provider Admin interface that each of the transport providers need to implement.
  */
-public interface TransportProviderAdmin {
+public interface TransportProviderAdmin extends MetricsAware {
 
   /**
    * assign the instance of the TransportProvider to the DatastreamTask. TransportProviderAdmin can


### PR DESCRIPTION
After transport provider refactoring event producer and transport provider metrics were not being collected at the datastream server level. This PR fixes that.