### PR TITLE
Performance Improvement for Brooklin Server.

### DIFF
--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -104,14 +104,13 @@ public class KafkaTransportProvider implements TransportProvider {
   }
 
   @Override
-
   public void send(String destinationUri, DatastreamProducerRecord record, SendCallback onSendComplete) {
     KafkaDestination destination = KafkaDestination.parse(destinationUri);
     try {
       Validate.notNull(record, "null event record.");
       Validate.notNull(record.getEvents(), "null datastream events.");
 
-      LOG.debug("Sending Datastream event record: " + record);
+      LOG.debug("Sending Datastream event record: %s", record);
 
       for (Pair<Object, Object> event : record.getEvents()) {
         ProducerRecord<byte[], byte[]> outgoing;
@@ -143,7 +142,7 @@ public class KafkaTransportProvider implements TransportProvider {
       ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, e);
     }
 
-    LOG.debug("Done sending Datastream event record: " + record);
+    LOG.debug("Done sending Datastream event record: %s", record);
   }
 
   @Override

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlBinlogEventListener.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlBinlogEventListener.java
@@ -213,8 +213,7 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
     }
 
     String[] tableNameParts = currFullDBTableName.split("[.]");
-    LOG.debug(
-        "File Number: " + _currFileName + ", Position: " + (int) binlogEventHeader.getPosition() + ", SCN =" + _scn);
+    LOG.debug("File Number: %s, Position: %d, SCN = %d", _currFileName, (int) binlogEventHeader.getPosition(), _scn);
 
     List<ColumnInfo> columnMetadata = _tableInfoProvider.getColumnList(tableNameParts[0], tableNameParts[1]);
 
@@ -291,7 +290,7 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
       QueryEvent qe = (QueryEvent) event;
       String sql = qe.getSql().toString();
       if ("ROLLBACK".equalsIgnoreCase(sql)) {
-        LOG.debug("ROLLBACK sql: " + sql);
+        LOG.debug("ROLLBACK sql: %s", sql);
         return true;
       }
     }
@@ -344,14 +343,14 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
       QueryEvent qe = (QueryEvent) event;
       String sql = qe.getSql().toString();
       if ("COMMIT".equalsIgnoreCase(sql)) {
-        LOG.debug("COMMIT sql: " + sql);
+        LOG.debug("COMMIT sql: %s", sql);
         return true;
       }
     } else if (event instanceof XidEvent) {
       // A transaction can end with either COMMIT or XID event.
       XidEvent xe = (XidEvent) event;
       long xid = xe.getXid();
-      LOG.debug("Treating XID event with xid = " + xid + " as commit for the transaction");
+      LOG.debug("Treating XID event with xid = %d as commit for the transaction", xid);
       return true;
     }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -62,7 +62,7 @@ public class CachedDatastreamReader {
             _datastreams.keySet().removeAll(datastreamsRemoved);
           }
 
-          LOG.debug(String.format("New datastream list in the cache: %s", _datastreamNames));
+          LOG.debug("New datastream list in the cache: %s", _datastreamNames);
         }
       }
     });

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -603,11 +603,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       if (!streams.containsKey(ds.getDestination())) {
         streams.put(ds.getDestination(), ds);
       } else {
-        _log.debug(String.format("Datastream %s is de-duped by %s", ds, streams.get(ds.getDestination())));
+        _log.debug("Datastream %s is de-duped by %s", ds, streams.get(ds.getDestination()));
       }
     }
 
-    _log.debug("handleLeaderDoAssignment: final datastreams for task assignment: " + streamsByConnectorType);
+    _log.debug("handleLeaderDoAssignment: final datastreams for task assignment: %s", streamsByConnectorType);
 
     // Map between Instance and the tasks
     Map<String, List<DatastreamTask>> assignmentsByInstance = new HashMap<>();
@@ -752,7 +752,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
 
     try {
-      _log.debug(String.format("About to initialize datastream %s with connector %s", datastream, connectorName));
+      _log.debug("About to initialize datastream %s with connector %s", datastream, connectorName);
       connector.initializeDatastream(datastream, allDatastreams);
       _destinationManager.populateDatastreamDestination(datastream, allDatastreams);
     } catch (Exception e) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -36,7 +36,7 @@ public class CoordinatorEventBlockingQueue {
 
     // always overwrite the event in the map
     _eventMap.put(event.getType(), event);
-    LOG.debug("Event queue size " + _eventQueue.size());
+    LOG.debug("Event queue size %d", _eventQueue.size());
     notify();
   }
 
@@ -49,7 +49,7 @@ public class CoordinatorEventBlockingQueue {
 
     if (queuedEvent != null) {
       LOG.info("De-queuing event " + queuedEvent.getType());
-      LOG.debug("Event queue size: " + _eventQueue.size());
+      LOG.debug("Event queue size: %d", _eventQueue.size());
       return _eventMap.remove(queuedEvent.getType());
     }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -114,7 +114,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public static DatastreamTaskImpl fromJson(String json) {
     DatastreamTaskImpl task = JsonUtils.fromJson(json, DatastreamTaskImpl.class);
-    LOG.debug("Loaded existing DatastreamTask: " + task);
+    LOG.debug("Loaded existing DatastreamTask: %s", task);
     return task;
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DestinationManager.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DestinationManager.java
@@ -56,7 +56,7 @@ public class DestinationManager {
     datastreams.stream().filter(d -> d.hasDestination() && d.getDestination().hasConnectionString() &&
         !d.getDestination().getConnectionString().isEmpty()).forEach(d -> sourceStreamMapping.put(d.getSource(), d));
 
-    LOG.debug("Datastream Source -> Datastream mapping before populating new datastream destinations",
+    LOG.debug("Datastream Source -> Datastream mapping before populating new datastream destinations: %s",
         sourceStreamMapping);
 
     boolean topicReuse = _reuseExistingTopic;
@@ -85,7 +85,7 @@ public class DestinationManager {
       sourceStreamMapping.put(datastream.getSource(), datastream);
     }
 
-    LOG.debug("Datastream Source -> Destination mapping after the populating new datastream destinations",
+    LOG.debug("Datastream Source -> Destination mapping after the populating new datastream destinations: %s",
         sourceStreamMapping);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -126,6 +126,7 @@ public class EventProducer implements DatastreamEventProducer {
    * @param record DatastreamEvent envelope
    * @param sendCallback
    */
+  @Override
   public void send(DatastreamProducerRecord record, SendCallback sendCallback) {
     validateEventRecord(record);
 
@@ -193,6 +194,7 @@ public class EventProducer implements DatastreamEventProducer {
     }
   }
 
+  @Override
   public void flush() {
     _transportProvider.flush();
     _checkpointProvider.flush();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -132,7 +132,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       List<Datastream> ret = RestliUtils.withPaging(_store.getAllDatastreams(), pagingContext).map(_store::getDatastream)
         .filter(stream -> stream != null).collect(Collectors.toList());
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Result collected for getAll: " + ret);
+        LOG.debug("Result collected for getAll: %s" + ret);
       }
       return ret;
     } catch (Exception e) {
@@ -149,7 +149,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
     try {
       LOG.info(String.format("Create datastream called with datastream %s", datastream));
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Handling request on object: " + toString() + " thread: " + Thread.currentThread());
+        LOG.debug("Handling request on object: %s thread: %s", this, Thread.currentThread());
       }
 
       _dynamicMetricsManager.createOrUpdateMeter(getClass(), CREATE_CALL, 1);
@@ -173,14 +173,14 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
       _coordinator.initializeDatastream(datastream);
 
-      LOG.debug("Persisting initialized datastream to zookeeper: " + datastream);
+      LOG.debug("Persisting initialized datastream to zookeeper: %s",  datastream);
 
       _store.createDatastream(datastream.getName(), datastream);
 
       Duration delta = Duration.between(startTime, Instant.now());
       _createCallLatencyMs.set(delta.toMillis());
 
-      LOG.debug(String.format("Datastream persisted to zookeeper, total time used: %dms", delta.toMillis()));
+      LOG.debug("Datastream persisted to zookeeper, total time used: %dms", delta.toMillis());
       return new CreateResponse(datastream.getName(), HttpStatus.S_201_CREATED);
     } catch (IllegalArgumentException e) {
       _dynamicMetricsManager.createOrUpdateMeter(getClass(), CALL_ERROR, 1);

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
@@ -94,6 +94,9 @@ public class DatastreamRestClientCli {
     options.addOption(
         OptionUtils.createOption(OptionConstants.OPT_SHORT_HELP, OptionConstants.OPT_LONG_HELP, null, false,
             OptionConstants.OPT_DESC_HELP));
+    options.addOption(
+        OptionUtils.createOption(OptionConstants.OPT_SHORT_TRANSPORT_NAME, OptionConstants.OPT_LONG_TRANSPORT_NAME,
+            OptionConstants.OPT_ARG_TRANSPORT_NAME, false, OptionConstants.OPT_DESC_TRANSPORT_NAME));
 
     CommandLineParser parser = new BasicParser();
     CommandLine cmd;
@@ -137,10 +140,14 @@ public class DatastreamRestClientCli {
           String connectorName = getOptionValue(cmd, OptionConstants.OPT_SHORT_CONNECTOR_NAME, options);
           int partitions = Integer.parseInt(getOptionValue(cmd, OptionConstants.OPT_SHORT_NUM_PARTITION, options));
           Map<String, String> metadata = new HashMap<>();
+          String transport = "kafka"; // default value.
           if (cmd.hasOption(OptionConstants.OPT_SHORT_METADATA)) {
             metadata = JsonUtils.fromJson(getOptionValue(cmd, OptionConstants.OPT_SHORT_METADATA, options),
                 new TypeReference<Map<String, String>>() {
                 });
+          }
+          if (cmd.hasOption(OptionConstants.OPT_SHORT_TRANSPORT_NAME)) {
+            transport = getOptionValue(cmd, OptionConstants.OPT_SHORT_TRANSPORT_NAME, options);
           }
 
           Datastream datastream = new Datastream();
@@ -151,6 +158,7 @@ public class DatastreamRestClientCli {
           datastreamSource.setPartitions(partitions);
           datastream.setSource(datastreamSource);
           datastream.setMetadata(new StringMap(metadata));
+          datastream.setTransportProviderName(transport);
           System.out.printf("Trying to create datastream %s", datastream);
           datastreamRestClient.createDatastream(datastream);
           System.out.printf("Created %s datastream. Now waiting for initialization (timeout = 10 seconds)\n",

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
@@ -17,6 +17,11 @@ public class OptionConstants {
   public static final String OPT_ARG_DATASTREAM_NAME = "DATASTREAM_NAME";
   public static final String OPT_DESC_DATASTREAM_NAME = "Name of the datastream";
 
+  public static final String OPT_SHORT_TRANSPORT_NAME = "t";
+  public static final String OPT_LONG_TRANSPORT_NAME = "transport";
+  public static final String OPT_ARG_TRANSPORT_NAME = "TRANSPORT_NAME";
+  public static final String OPT_DESC_TRANSPORT_NAME = "Name of the Datastream Transport to use, default kafka.";
+
   public static final String OPT_SHORT_CONNECTOR_NAME = "c";
   public static final String OPT_LONG_CONNECTOR_NAME = "connector";
   public static final String OPT_ARG_CONNECTOR_NAME = "CONNECTOR_NAME";


### PR DESCRIPTION
1) Removing Syncronized Methods from DynamicMetricsManager.
   (Using ConcurrentHashMap to keep the class Thread Safe)
   It was causing slowdown in multi streams scenario.

2) Change LOG.debug, to use the formmated method.
   The idea is to avoid unnecesary object creation when
   not doing debug logs.

Other Changes:

3) Adding Transport parameter to the datastream tools.