### PR TITLE
Adding metrics for the kafka connector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnector.java
@@ -2,6 +2,7 @@ package com.linkedin.datastream.connectors.kafka;
 
 import java.time.Duration;
 import java.time.temporal.ChronoUnit;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
@@ -17,6 +18,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.ThreadUtils;
+import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.api.connector.Connector;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
@@ -95,6 +97,11 @@ public class KafkaConnector implements Connector {
       _runningTasks.put(task, connectorTask);
       _executor.submit(connectorTask);
     }
+  }
+
+  @Override
+  public List<BrooklinMetricInfo> getMetricInfos() {
+    return Collections.unmodifiableList(KafkaConnectorTask.getMetricInfos());
   }
 
   @Override

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -12,11 +12,14 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.MetricRegistry;
+
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.kafka.EmbeddedZookeeperKafkaCluster;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
 
 
@@ -25,6 +28,7 @@ public class TestKafkaConnectorTask {
 
   @BeforeTest
   public void setup() throws Exception {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
     _kafkaCluster = new EmbeddedZookeeperKafkaCluster();
     _kafkaCluster.startup();
   }


### PR DESCRIPTION
Adding the following metrics for the kafka connector. Most of them are inspired by the espresso connector metrics.

eventsProcessedRate
eventsByteProcessedRate
errorRate
rebalanceRate
numKafkaPolls
eventCountsPerPoll
timeSinceLastEventReceivedMs
timeSinceLastEventProcessedMs
