### PR TITLE
Updating comment for send message.

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
@@ -17,7 +17,15 @@ import com.linkedin.datastream.server.api.transport.SendCallback;
 public interface DatastreamEventProducer {
   /**
    * Send event onto the transport
+   *
+   * <p>
+   * Note that the onComplete callbacks will generally execute in the I/O thread of the TransportPrvider and
+   * should be reasonably fast or they will delay sending messages for other threads.
+   * If you want to execute an expensive callbacks it is recommended to use your own
+   * {@link java.util.concurrent.Executor} in the callback body to parallelize processing.
+   *
    * @param event
+   * @param callback call back that needs to called when the send completes.
    */
   void send(DatastreamProducerRecord event, SendCallback callback);
 

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
@@ -10,6 +10,13 @@ import com.linkedin.datastream.server.DatastreamProducerRecord;
 public interface TransportProvider {
   /**
    * Send the DatastreamEvent to the topic.
+   *
+   * <p>
+   * Note that the onComplete callbacks will generally execute in the I/O thread of
+   * the TransportProvider and should be reasonably fast or they will delay sending messages
+   * for other threads. If you want to execute an expensive callbacks it is recommended to use
+   * your own {@link java.util.concurrent.Executor} in the callback body to parallelize processing.
+   *
    * @param destination the destination topic to which the record should be sent.
    * @param record DatastreamEvent that needs to be sent to the stream.
    * @param onComplete call back that needs to called when the send completes.


### PR DESCRIPTION
Adding a warning that the callback should be fast to avoid blocking the
transportProvider IO thread (e.g. for kafka this is important).

For example, a miss behaving connector that hold the thread in a
callback, will allow down other connectors using the same transport provider.