### PR TITLE
Adding destination uri and destination partitions for the restclient 

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -39,6 +39,7 @@ import com.linkedin.datastream.common.DatastreamEvent;
 import com.linkedin.datastream.common.DatastreamEventMetadata;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.DatastreamSource;
+import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
 import com.linkedin.datastream.metrics.BrooklinHistogramInfo;
 import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
@@ -257,8 +258,8 @@ public class KafkaConnectorTask implements Runnable {
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + REBALANCE_RATE));
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + NUM_KAFKA_POLLS));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX_REGEX + EVENT_COUNTS_PER_POLL));
-    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX_REGEX + TIME_SINCE_LAST_EVENT_RECEIVED));
-    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX_REGEX + TIME_SINCE_LAST_EVENT_PROCESSED));
+    metrics.add(new BrooklinGaugeInfo(METRICS_PREFIX_REGEX + TIME_SINCE_LAST_EVENT_RECEIVED));
+    metrics.add(new BrooklinGaugeInfo(METRICS_PREFIX_REGEX + TIME_SINCE_LAST_EVENT_PROCESSED));
     return metrics;
   }
 

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
@@ -12,8 +12,8 @@ public class OptionConstants {
   public static final String OPT_ARG_OPERATION = "DATASTREAM_OPERATION";
   public static final String OPT_DESC_OPERATION = "Operation to perform accepted values [CREATE, READ, DELETE, READALL]";
 
-  public static final String OPT_SHORT_DATASTREAM_NAME = "d";
-  public static final String OPT_LONG_DATASTREAM_NAME = "datastream";
+  public static final String OPT_SHORT_DATASTREAM_NAME = "n";
+  public static final String OPT_LONG_DATASTREAM_NAME = "name";
   public static final String OPT_ARG_DATASTREAM_NAME = "DATASTREAM_NAME";
   public static final String OPT_DESC_DATASTREAM_NAME = "Name of the datastream";
 
@@ -21,6 +21,16 @@ public class OptionConstants {
   public static final String OPT_LONG_TRANSPORT_NAME = "transport";
   public static final String OPT_ARG_TRANSPORT_NAME = "TRANSPORT_NAME";
   public static final String OPT_DESC_TRANSPORT_NAME = "Name of the Datastream Transport to use, default kafka.";
+
+  public static final String OPT_SHORT_DESTINATION_URI = "d";
+  public static final String OPT_LONG_DESTINATION_URI = "destination";
+  public static final String OPT_ARG_DESTINATION_URI = "DESTINATION_URI";
+  public static final String OPT_DESC_DESTINATION_URI = "Datastream destination uri";
+
+  public static final String OPT_SHORT_DESTINATION_PARTITIONS = "dp";
+  public static final String OPT_LONG_DESTINATION_PARTITIONS = "destinationpartitions";
+  public static final String OPT_ARG_DESTINATION_PARTITIONS = "DESTINATION_PARTITIONS";
+  public static final String OPT_DESC_DESTINATION_PARTITIONS = "Number of partitions in the destination";
 
   public static final String OPT_SHORT_CONNECTOR_NAME = "c";
   public static final String OPT_LONG_CONNECTOR_NAME = "connector";


### PR DESCRIPTION
Destinations like event hub and kinesis needs the destination topics pre-created. And they need to filled in when we create the datastream. So taking in destination uri and destination partitions as part of the create datastream tool.