### PR TITLE
Making Tasks Assignments process more robust.

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -706,6 +706,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     boolean succeeded = true;
     try {
         _adapter.updateAllAssignments(newAssignmentsByInstance);
+      _adapter.updateAllAssignments(newAssignmentsByInstance);
     } catch (RuntimeException e) {
       _log.error("handleLeaderDoAssignment: runtime Exception while updating Zookeeper.", e);
       succeeded = false;
@@ -715,7 +716,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
     // clean up tasks under dead instances if everything went well
     if (succeeded) {
-      _adapter.cleanupDeadInstanceAssignments();
+      _adapter.cleanupDeadInstanceAssignments(liveInstances);
       _adapter.cleanupOldUnusedTasks(previousAssignmentByInstance, newAssignmentsByInstance);
       _dynamicMetricsManager.createOrUpdateMeter(this.getClass(), NUM_REBALANCES, 1);
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -754,8 +754,7 @@ public class ZkAdapter {
    * invoking the assignment strategy and pass the saved assignment
    * to us to figure out the obsolete tasks.
    */
-  public void cleanupDeadInstanceAssignments() {
-    List<String> liveInstances = getLiveInstances();
+  public void cleanupDeadInstanceAssignments(List<String> liveInstances) {
     List<String> deadInstances = getAllInstances();
     deadInstances.removeAll(liveInstances);
     if (deadInstances.size() > 0) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -310,14 +310,17 @@ public class TestZkAdapter {
     //
     DatastreamTaskImpl task1 = new DatastreamTaskImpl();
     task1.setDatastreamName("task1");
+    task1.setTaskPrefix("task1");
     task1.setConnectorType(connectorType);
 
     DatastreamTaskImpl task2 = new DatastreamTaskImpl();
     task2.setDatastreamName("task2");
+    task2.setTaskPrefix("task2");
     task2.setConnectorType(connectorType);
 
     DatastreamTaskImpl task3 = new DatastreamTaskImpl();
     task3.setDatastreamName("task3");
+    task3.setTaskPrefix("task3");
     task3.setConnectorType(connectorType);
 
     Map<String, List<DatastreamTask>> assignmentsByInstance = new HashMap<>();


### PR DESCRIPTION
Making sure that new tasks are added to zookeeper before old tasks are
removed. Ensuring that this happen across all instances.

Fixing a retry logic bug, in case there is a failure writing to
zookeeper.