### PR TITLE
Removing locking from connector wrapper

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -16,26 +16,30 @@ public interface Connector extends MetricsAware {
 
   /**
    * Method to start the connector. This is called immediately after the connector is instantiated.
-   * This typically happens when datastream instance starts up.
+   * This typically happens when brooklin server starts up.
    */
   void start();
 
   /**
-   * Method to stop the connector. This is called when the datastream instance is being stopped.
+   * Method to stop the connector. This is called when the brooklin server is being stopped.
    */
   void stop();
 
   /**
-   * Callback when the datastreams assignment to this instance is changed. The implementation of the Connector is
+   * Callback when the datastreams assigned to this instance is changed. The implementation of the Connector is
    * responsible to keep a state of the previous assignment.
-   *
    * @param tasks the list of the current assignment.
    */
   void onAssignmentChange(List<DatastreamTask> tasks);
 
   /**
-   * Initialize the datastream. Datastream management service call this before writing the
-   * Datastream into zookeeper. DMS ensures that stream.source has sufficient details.
+   * Initialize the datastream. Any connector specific validations for the datastream needs to performed here.
+   * Connector can mutate the datastream object in this call. Framework will write the updated datastream object.
+   * NOTE:
+   *   1. This method is called by the rest li service before the datastream is written to the zookeeper, So please make sure,
+   *   this call doesn't block for more then few seconds otherwise the rest call will timeout.
+   *   2. It is possible that the brooklin framework may call this method in parallel to another onAssignmentChange
+   *   call. It is upto the connector to perform the synchronization if it needs between initialize and onAssignmentChange.
    * @param stream: Datastream model
    * @param allDatastreams: all existing datastreams in the system of connector type of the datastream that is being
    *                       initialized.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -69,7 +69,7 @@ public class ConnectorWrapper {
         _connectorType, _instanceName, _endTime - _startTime));
   }
 
-  public synchronized void start() {
+  public void start() {
     logApiStart("start");
 
     try {
@@ -82,7 +82,7 @@ public class ConnectorWrapper {
     logApiEnd("start");
   }
 
-  public synchronized void stop() {
+  public void stop() {
     logApiStart("stop");
 
     try {
@@ -99,11 +99,11 @@ public class ConnectorWrapper {
     return _connectorType;
   }
 
-  public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
+  public void onAssignmentChange(List<DatastreamTask> tasks) {
     logApiStart("onAssignmentChange");
 
     _numDatastreamTasks.set(tasks.size());
-    _numDatastreams.set(tasks.stream().map(t -> t.getDatastreams()).flatMap(List::stream).distinct().count());
+    _numDatastreams.set(tasks.stream().map(DatastreamTask::getDatastreams).flatMap(List::stream).distinct().count());
 
     try {
       _connector.onAssignmentChange(tasks);
@@ -115,7 +115,7 @@ public class ConnectorWrapper {
     logApiEnd("onAssignmentChange");
   }
 
-  public synchronized void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     logApiStart("initializeDatastream");
 


### PR DESCRIPTION
Connector wrapper added the synchronization to ensure all the calls to a particular instance are not parallelized. This was done hoping that the connector implementation needn't be thread safe. But this has caused deadlocks in the espresso connector and causes our REST calls to timeout. Management operations timing out is just unacceptable, Hence removing these locks and letting connector do the synchronization if it needs it across the initialize and onAssignmentChange which most of the connectors don't need.  