### PR TITLE
Initialize Dummy bootstrap stream with configs supplied to connector

### DIFF
--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyBootstrapConnector.java
@@ -48,7 +48,9 @@ public class DummyBootstrapConnector implements Connector {
       throw new DatastreamValidationException("Failed to get source from datastream.");
     }
 
-    stream.getMetadata().putAll(_config);
+    if (!stream.hasMetadata()) {
+      stream.getMetadata().putAll(_config);
+    }
   }
 
   @Override


### PR DESCRIPTION
Since bootstrap stream is created automatically when datastream consumer needs to
bootstrap, the datastream might need configs set like schema registry etc.
Allow setting these up through the configs supplied to connector.