### PR TITLE
implementing the Oracle TB connector

### DIFF
--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connector/oracle/triggerbased/OracleConnector.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connector/oracle/triggerbased/OracleConnector.java
@@ -1,0 +1,160 @@
+package com.linkedin.datastream.connector.oracle.triggerbased;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.ErrorLogger;
+import com.linkedin.datastream.common.ReflectionUtils;
+import com.linkedin.datastream.common.SchemaRegistryClient;
+import com.linkedin.datastream.common.SchemaRegistryClientFactory;
+import com.linkedin.datastream.metrics.BrooklinMetricInfo;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.api.connector.Connector;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.time.Duration;
+import java.util.Properties;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class OracleConnector implements Connector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OracleConnector.class);
+
+  static final String CONNECTOR_TYPE = "OracleTriggerBased";
+  private static final String SCHEMA_REGISTRY_FACTORY_KEY = "schemaRegistryFactory";
+
+  private static final Duration SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
+  private ScheduledExecutorService _daemonThreadExecutorService = null;
+  private final OracleConnectorConfig _config;
+  private final SchemaRegistryClient _schemaRegistry;
+
+  private ExecutorService _executorService = Executors.newCachedThreadPool(new ThreadFactory() {
+    private AtomicInteger threadCounter = new AtomicInteger(0);
+
+    @Override
+    public Thread newThread(Runnable r) {
+      Thread t = new Thread(r);
+      t.setDaemon(false);
+      t.setPriority(Thread.NORM_PRIORITY);
+      t.setName(CONNECTOR_TYPE + "-worker-thread-" + threadCounter.incrementAndGet());
+      return t;
+    }
+  });
+
+  /**
+   * This Oracle Connector class is the main implementation of the Connector
+   * interface for the Oracle TriggerBased Connector
+   *
+   * The Connector Class implements the onAssignmentChange function which
+   * gets run every time there is a new DatastreamTask that got assigned
+   * to this instance of the Connector. At that point, the Connector will
+   * instantiate a new OracleTaskHandler.
+   *
+   * Each task Handler has an OracleConsumer and a MessageHandler. The OracleConsumer
+   * is responsible for query changed rows form the Datastream source and The
+   * Message Handler is responsible pushing data into the Transport Provider.
+   *
+   * There is one OracleTaskHandler per DatastreamTask. This is so that tasks with the same
+   * source but different destinations never interfere with each other.
+   * It also means that datastreams with the same source but at different times
+   * are independent (imagine deleting a datastreamTask and then
+   * re-created with the same source)
+   *
+   ┌──────────────────────┐
+   │                      │                                ┌───────────────────┐
+   │ ┌──────────────────┐ │                                │OracleTaskHandler 1│
+   │ │ DatastreamTask 1 │ │                             ┌─▶│                   │
+   │ │                  │ │    ┌─────────────────────┐  │  └───────────────────┘
+   │ └──────────────────┘ │    │                     │  │
+   │                      │    │                     │  │  ┌───────────────────┐
+   │ ┌──────────────────┐ │    │  OracleTBConnector  │  │  │OracleTaskHandler 2│
+   │ │ DatastreamTask 2 │ │───▶│                     │──┼─▶│                   │
+   │ │                  │ │    │                     │  │  └───────────────────┘
+   │ └──────────────────┘ │    │                     │  │
+   │                      │    └─────────────────────┘  │  ┌───────────────────┐
+   │ ┌──────────────────┐ │                             │  │OracleTaskHandler 3│
+   │ │ DatastreamTask 3 │ │                             └─▶│                   │
+   │ │                  │ │                                └───────────────────┘
+   │ └──────────────────┘ │
+   └──────────────────────┘
+   *
+   */
+  public OracleConnector(Properties properties) throws DatastreamException {
+    _config = new OracleConnectorConfig(properties);
+    _schemaRegistry = createSchemaRegistryClient(properties, _config);
+    // TODO implement
+  }
+
+  public void start() {
+    LOG.info("Oracle TriggerBased Connector start Requested");
+    // TODO implement
+  }
+
+  public void stop() {
+    LOG.info("Oracle TriggerBased connector stop requested.");
+    // TODO implement
+  }
+
+  public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
+    if (tasks == null) {
+      LOG.error("onAssignmentChange with null tasks");
+      return;
+    }
+
+    LOG.info("onAssignmentChange called with {}", tasks);
+    // TODO implement
+  }
+
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams) throws DatastreamValidationException {
+    LOG.info("initializeDatastream called for %s", stream);
+  }
+
+  @Override
+  public List<BrooklinMetricInfo> getMetricInfos() {
+    List<BrooklinMetricInfo> metrics = new ArrayList<>();
+    // metrics.addAll(OracleTaskHandler.getMetricInfos());
+    return Collections.unmodifiableList(metrics);
+  }
+
+  /**
+   * Initialize a SchemaRegistryClient implementation instance.
+   *
+   * This function first uses ReflectionUtils to create a
+   * schemaRegistryFactory instance based on Properties. We then
+   * instantiate certain schemaRegistry based on Connector
+   * Properties
+   *
+   * @param properties - SchemaRegistryFactory className
+   * @param config - SchemaRegistry configs such as `mode` and `uri`
+   * @return SchemaRegistryClient
+   */
+  private SchemaRegistryClient createSchemaRegistryClient(Properties properties, OracleConnectorConfig config) {
+    // instantiate a schemaRegistryFactory implementation instance based on the
+    // class name given in the configs
+    String className = properties.getProperty(SCHEMA_REGISTRY_FACTORY_KEY);
+    if (StringUtils.isBlank(className)) {
+      String errorMessage = "Factory className is empty for SchemaRegistryClientFactory";
+      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, null);
+    }
+
+    SchemaRegistryClientFactory schemaRegistryFactory = ReflectionUtils.createInstance(className);
+    if (schemaRegistryFactory == null) {
+      String msg = "Invalid class name or no parameter-less constructor, class=" + className;
+      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, msg, null);
+    }
+
+    // use factory to instantiate SchemaRegistry
+    return schemaRegistryFactory.createSchemaRegistryClient(config.getLiKafkaSchemaRegistryConfig());
+  }
+}

--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connector/oracle/triggerbased/OracleConnectorConfig.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connector/oracle/triggerbased/OracleConnectorConfig.java
@@ -1,0 +1,58 @@
+package com.linkedin.datastream.connector.oracle.triggerbased;
+
+import java.util.Properties;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.common.VerifiableProperties;
+import com.linkedin.datastream.connector.oracle.triggerbased.consumer.OracleConsumerConfig;
+
+
+public class OracleConnectorConfig {
+  private static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
+  private static final int DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS = 300;
+
+  private static final String ORACLE_CONSUMER_CONFIG = "oracleConsumer.%s";
+  private static final String KAFKA_SCHEMA_REGISTRY_CONFIG = "kafkaSchemaRegistry";
+
+  private static final Map<String, OracleConsumerConfig> CONSUMER_CONFIG_CACHE  = new ConcurrentHashMap<>();
+
+  private final VerifiableProperties _verifiableProperties;
+
+  // How often the DatastreamTaskManager checks to see ensure the EventReaders are running
+  private final int _daemonThreadIntervalSeconds;
+
+  // configs for Kafka Schema Registry
+  private final Properties _kafkaSchemaRegistryConfig;
+
+  public OracleConnectorConfig(Properties properties) throws DatastreamException {
+    _verifiableProperties = new VerifiableProperties(properties);
+
+    _daemonThreadIntervalSeconds = _verifiableProperties.getInt(DAEMON_THREAD_INTERVAL_SECONDS, DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS);
+
+    _kafkaSchemaRegistryConfig = _verifiableProperties.getDomainProperties(KAFKA_SCHEMA_REGISTRY_CONFIG);
+
+    _verifiableProperties.verify();
+  }
+
+  public Properties getLiKafkaSchemaRegistryConfig() {
+    return _kafkaSchemaRegistryConfig;
+  }
+
+  public int getDaemonThreadIntervalSeconds() {
+    return _daemonThreadIntervalSeconds;
+  }
+
+  public OracleConsumerConfig getOracleConsumerConfig(String dbName) {
+    if (CONSUMER_CONFIG_CACHE.containsKey(dbName)) {
+      return CONSUMER_CONFIG_CACHE.get(dbName);
+    }
+
+    OracleConsumerConfig config =
+        new OracleConsumerConfig(_verifiableProperties.getDomainProperties(String.format(ORACLE_CONSUMER_CONFIG, dbName)));
+
+    CONSUMER_CONFIG_CACHE.put(dbName, config);
+    return config;
+  }
+}

--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connector/oracle/triggerbased/consumer/OracleConsumerConfig.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connector/oracle/triggerbased/consumer/OracleConsumerConfig.java
@@ -1,0 +1,65 @@
+package com.linkedin.datastream.connector.oracle.triggerbased.consumer;
+
+import java.util.Properties;
+
+import com.linkedin.datastream.common.VerifiableProperties;
+
+
+/**
+ * OracleConsumerConfig is a config class that holds information about the
+ * Oracle Database and any additional configs intended for the consumer logic
+ *
+ * The idea is to have all the credential information of the Oracle Databases
+ * stored as configs, namespaced under their DB name.
+ */
+public class OracleConsumerConfig {
+  private static final String DB_URI = "dbUri";
+
+  private static final String DATA_SOURCE_FACTORY_MODE = "dataSourceFactoryMode";
+  private static final String DEFAULT_DATA_SOURCE_FACTORY_MODE = "dynamic";
+
+  private static final String QUERY_HINT = "queryHint";
+  private static final String DEFAULT_EVENT_QUERY_HINTS = "/*+ first_rows LEADING(tx) +*/";
+
+  // If the resultSet is 1000 rows, with fetchSize set to 100, it would take 10 network
+  // calls to process the entire resultSet. The default fetchSize is 10, which is way to small
+  // since we expect to be seeing at least 100 rows per query in a Production Environment
+  private static final String FETCH_SIZE = "fetchSize";
+  private static final int DEFAULT_FETCH_SIZE = 100;
+
+  private final String _queryHint;
+  private final String _dataSourceFactoryMode;
+
+  private final int _fetchSize;
+
+  private final String _dbUri;
+
+  public OracleConsumerConfig(Properties properties) {
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+
+    _dataSourceFactoryMode = verifiableProperties.getString(DATA_SOURCE_FACTORY_MODE, DEFAULT_DATA_SOURCE_FACTORY_MODE);
+    _queryHint = verifiableProperties.getString(QUERY_HINT, DEFAULT_EVENT_QUERY_HINTS);
+
+    _fetchSize = verifiableProperties.getInt(FETCH_SIZE, DEFAULT_FETCH_SIZE);
+
+    _dbUri = verifiableProperties.getString(DB_URI);
+
+    verifiableProperties.verify();
+  }
+
+  public String getQueryHint() {
+    return _queryHint;
+  }
+
+  public String getDataSourceFactoryMode() {
+    return _dataSourceFactoryMode;
+  }
+
+  public int getFetchSize() {
+    return _fetchSize;
+  }
+
+  public String getDbUri() {
+    return _dbUri;
+  }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -162,6 +162,17 @@ project(':datastream-mysql-connector') {
   }
 }
 
+project(':brooklin-oracle-tb-connector') {
+  dependencies {
+    compile project(':datastream-server-api')
+    compile "org.apache.avro:avro:$avroVersion"
+    testCompile 'org.mockito:mockito-core:1.+'
+    test {
+      workingDir(project.projectDir.toString() + "/..")
+    }
+  }
+}
+
 project(':datastream-kafka') {
   dependencies {
     compile "org.apache.kafka:kafka_2.10:$kafkaVersion"

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/SchemaRegistryClient.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/SchemaRegistryClient.java
@@ -1,0 +1,15 @@
+package com.linkedin.datastream.common;
+
+import org.apache.avro.Schema;
+
+
+public interface SchemaRegistryClient {
+
+  /**
+   * Fetch schema by ID. Here is the ID is the hex string of the MD5 hash of the schema string
+   *
+   * @param id - MD5 hash of the schema id
+   * @return The schema object
+   */
+  public Schema getSchemaByID(String id);
+}

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/SchemaRegistryClientFactory.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/SchemaRegistryClientFactory.java
@@ -1,0 +1,18 @@
+package com.linkedin.datastream.common;
+
+import java.util.Properties;
+
+
+/**
+ * Interface for the schema registry factory
+ */
+public interface SchemaRegistryClientFactory {
+
+  /**
+   * Create an instance of a Schema Registry Client
+   *
+   * @param props - properties containing information such as registry URI and mode
+   * @return SchemaRegistryClient implementation
+   */
+  public SchemaRegistryClient createSchemaRegistryClient(Properties props);
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -10,4 +10,5 @@ include 'datastream-kafka-connector'
 include 'datastream-file-connector'
 include 'datastream-mysql-connector'
 include 'datastream-tools'
+include 'brooklin-oracle-tb-connector'
 


### PR DESCRIPTION
Includes the initial implementation of the OracleConnector class along with some configs

This intitial PR is mostly fixed around the `createSchemaRegistryClient()` method in the `OracleConnector` class.