### PR TITLE
Fixes for the Datastream rest client tool

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -2,11 +2,14 @@ package com.linkedin.datastream.common;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
+
+import org.apache.commons.lang.Validate;
 
 
 public class BrooklinEnvelope {
 
-  private Object _previousValue;
+  private Optional<Object> _previousValue;
 
   private Object _key;
 
@@ -14,10 +17,17 @@ public class BrooklinEnvelope {
 
   private Map<String, String> _metadata;
 
+  public BrooklinEnvelope(Object key, Object value, Map<String, String> metadata) {
+    this(key, value, null, metadata);
+  }
+
   public BrooklinEnvelope(Object key, Object value, Object previousValue, Map<String, String> metadata) {
+    Validate.notNull(key, "key cannot be null");
+    Validate.notNull(key, "value cannot be null");
+    Validate.notNull(metadata, "metadata cannot be null");
     _key = key;
     _value = value;
-    _previousValue = previousValue;
+    _previousValue = Optional.ofNullable(previousValue);
     _metadata = metadata;
   }
 
@@ -26,14 +36,16 @@ public class BrooklinEnvelope {
   }
 
   public void setPreviousValue(Object previousValue) {
-    _previousValue = previousValue;
+    _previousValue = Optional.ofNullable(previousValue);
   }
 
   public void setKey(Object key) {
+    Validate.notNull(key, "key cannot be null");
     _key = key;
   }
 
   public void setValue(Object value) {
+    Validate.notNull(value, "value cannot be null");
     _value = value;
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -276,6 +276,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
     _zkAdapter.setDatastreamTaskStateForKey(this, key, value);
   }
 
+  @JsonIgnore
   @Override
   public SerDeSet getDestinationSerDes() {
     return _destinationSerDes;

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
@@ -27,6 +27,11 @@ public class OptionConstants {
   public static final String OPT_ARG_DESTINATION_URI = "DESTINATION_URI";
   public static final String OPT_DESC_DESTINATION_URI = "Datastream destination uri";
 
+  public static final String OPT_SHORT_UNFORMATTED = "nf";
+  public static final String OPT_LONG_UNFORMATTED = "noformat";
+  public static final String OPT_ARG_UNFORMATTED = "NO_FORMAT";
+  public static final String OPT_DESC_UNFORMATTED = "Print without formatting";
+
   public static final String OPT_SHORT_DESTINATION_PARTITIONS = "dp";
   public static final String OPT_LONG_DESTINATION_PARTITIONS = "destinationpartitions";
   public static final String OPT_ARG_DESTINATION_PARTITIONS = "DESTINATION_PARTITIONS";


### PR DESCRIPTION
Fixes to the Datastream rest client tool to serialize datastreams where some of the properties are not set. 
Added a validation in the kafka connector.
Make the BrooklinEnvelope.previousValue optional
Avoid serializing the SerDeSet into the datastream task json.