### PR TITLE
fix NPE for undefined transport provider name and improve logging

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -823,6 +823,10 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
             .put(DatastreamMetadataConstants.TASK_PREFIX,
                 existingDatastream.get().getMetadata().get(DatastreamMetadataConstants.TASK_PREFIX));
       } else {
+        if (!_transportProviderAdmins.containsKey(datastream.getTransportProviderName())) {
+          throw new DatastreamValidationException(
+              String.format("Transport provider \"%s\" is undefined", datastream.getTransportProviderName()));
+        }
         _transportProviderAdmins.get(datastream.getTransportProviderName())
             .initializeDestinationForDatastream(datastream);
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -68,7 +68,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
   public DatastreamResources(DatastreamServer datastreamServer) {
     _store = datastreamServer.getDatastreamStore();
     _coordinator = datastreamServer.getCoordinator();
-    _errorLogger = new ErrorLogger(LOG);
+    _errorLogger = new ErrorLogger(LOG, _coordinator.getInstanceName());
 
     _dynamicMetricsManager = DynamicMetricsManager.getInstance();
     _dynamicMetricsManager.registerMetric(getClass(), CREATE_CALL_LATENCY_MS_STRING, CREATE_CALL_LATENCY_MS);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -171,6 +171,17 @@ public class TestDatastreamResources {
 
     // creating existing Datastream
     checkBadRequest(() -> resource.create(allRequiredFields), HttpStatus.S_409_CONFLICT);
+
+    Datastream undefinedProvider = generateDatastream(7);
+    String undefinedProviderName = "whatsoever";
+    undefinedProvider.setTransportProviderName(undefinedProviderName);
+    try {
+      resource.create(undefinedProvider);
+      Assert.fail("Should have failed for undefined provider name");
+    } catch (RestLiServiceException e) {
+      Assert.assertNotNull(e.getMessage());
+      Assert.assertTrue(e.getMessage().contains(undefinedProviderName));
+    }
   }
 
   private Datastream createDatastream(DatastreamResources resource, String name, int seed) {


### PR DESCRIPTION
1. Fix NPE when users create a datastream with a unknown transport provider
2. Improve the ErrorLogger used by dms to include instance name. (So that we know which host to go to when trouble shooting)