### PR TITLE
Cleanup the checkpoint state for the unassigned tasks

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -456,6 +456,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private void uninitializeTask(DatastreamTask t) {
     TransportProviderAdmin tpAdmin = _transportProviderAdmins.get(t.getTransportProviderName());
     tpAdmin.unassignTransportProvider(t);
+    _cpProvider.unassignDatastreamTask(t);
   }
 
   private void initializeTask(DatastreamTask task) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -62,8 +62,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   private String _taskPrefix;
 
-  private String _datastreamName;
-
   // List of partitions the task covers.
   private List<Integer> _partitions;
 
@@ -252,14 +250,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   public void setTaskPrefix(String taskPrefix) {
     _taskPrefix = taskPrefix;
-  }
-
-  public String getDatastreamName() {
-    return _datastreamName;
-  }
-
-  public void setDatastreamName(String datastreamName) {
-    _datastreamName = datastreamName;
   }
 
   @JsonIgnore

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/providers/CheckpointProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/providers/CheckpointProvider.java
@@ -12,6 +12,12 @@ import com.linkedin.datastream.server.DatastreamTask;
 public interface CheckpointProvider extends MetricsAware {
 
   /**
+   * Unassign datastream task. This is called when the datastream task is being reassigned from the current instance.
+   * Any cleanup of the internal checkpoint state for the datastream task is performed here.
+   */
+  void unassignDatastreamTask(DatastreamTask task);
+
+  /**
    * update the checkpoint. This might get called every time a send succeeds. So avoid writing to durable store
    * everytime updateCheckpoint is called.
    */

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/providers/NoOpCheckpointProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/providers/NoOpCheckpointProvider.java
@@ -8,6 +8,11 @@ import com.linkedin.datastream.server.DatastreamTask;
 
 public class NoOpCheckpointProvider implements CheckpointProvider {
   @Override
+  public void unassignDatastreamTask(DatastreamTask task) {
+
+  }
+
+  @Override
   public void updateCheckpoint(DatastreamTask task, int partition, String checkpoint) {
     return;
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -225,7 +225,6 @@ public class TestZkAdapter {
     // simulate assigning one task [task1] to the connector
     //
     DatastreamTaskImpl task1 = new DatastreamTaskImpl();
-    task1.setDatastreamName("task1");
     task1.setTaskPrefix("task1");
     task1.setConnectorType(connectorType);
     tasks.add(task1);
@@ -243,7 +242,6 @@ public class TestZkAdapter {
     // simulate assigning two tasks [task1, task2] to the same instance
     //
     DatastreamTaskImpl task2 = new DatastreamTaskImpl();
-    task2.setDatastreamName("task2");
     task2.setTaskPrefix("task2");
     task2.setConnectorType(connectorType);
     tasks.add(task2);
@@ -263,7 +261,6 @@ public class TestZkAdapter {
     // simuate removing task2 and adding task3 to the assignment, now the tasks are [task1, task3]
     //
     DatastreamTaskImpl task3 = new DatastreamTaskImpl();
-    task3.setDatastreamName("task3");
     task3.setTaskPrefix("task3");
     task3.setConnectorType(connectorType);
     tasks.add(task3);
@@ -309,17 +306,14 @@ public class TestZkAdapter {
     //   to instance2: [task2, task3]
     //
     DatastreamTaskImpl task1 = new DatastreamTaskImpl();
-    task1.setDatastreamName("task1");
     task1.setTaskPrefix("task1");
     task1.setConnectorType(connectorType);
 
     DatastreamTaskImpl task2 = new DatastreamTaskImpl();
-    task2.setDatastreamName("task2");
     task2.setTaskPrefix("task2");
     task2.setConnectorType(connectorType);
 
     DatastreamTaskImpl task3 = new DatastreamTaskImpl();
-    task3.setDatastreamName("task3");
     task3.setTaskPrefix("task3");
     task3.setConnectorType(connectorType);
 
@@ -369,28 +363,24 @@ public class TestZkAdapter {
     // simulate assigning one task [task1] to the connector. task1 has 4 partitions
     //
     DatastreamTaskImpl task1_0 = new DatastreamTaskImpl();
-    task1_0.setDatastreamName("task1");
     task1_0.setTaskPrefix("task1");
     task1_0.setId("0");
     task1_0.setConnectorType(connectorType);
     tasks.add(task1_0);
 
     DatastreamTaskImpl task1_1 = new DatastreamTaskImpl();
-    task1_1.setDatastreamName("task1");
     task1_1.setId("1");
     task1_1.setTaskPrefix("task1");
     task1_1.setConnectorType(connectorType);
     tasks.add(task1_1);
 
     DatastreamTaskImpl task1_2 = new DatastreamTaskImpl();
-    task1_2.setDatastreamName("task1");
     task1_2.setTaskPrefix("task1");
     task1_2.setId("2");
     task1_2.setConnectorType(connectorType);
     tasks.add(task1_2);
 
     DatastreamTaskImpl task1_3 = new DatastreamTaskImpl();
-    task1_3.setDatastreamName("task1");
     task1_3.setTaskPrefix("task1");
     task1_3.setId("3");
     task1_3.setConnectorType(connectorType);
@@ -441,7 +431,6 @@ public class TestZkAdapter {
     adapter1.connect();
 
     DatastreamTaskImpl task = new DatastreamTaskImpl();
-    task.setDatastreamName("task1");
     task.setId("3");
     task.setConnectorType(connectorType);
     task.setZkAdapter(adapter1);
@@ -486,7 +475,6 @@ public class TestZkAdapter {
     adapter1.connect();
 
     DatastreamTaskImpl task = new DatastreamTaskImpl();
-    task.setDatastreamName("task1");
     task.setId("3");
     task.setConnectorType(connectorType);
     task.setZkAdapter(adapter1);
@@ -525,7 +513,6 @@ public class TestZkAdapter {
     adapter1.connect();
 
     DatastreamTaskImpl task = new DatastreamTaskImpl();
-    task.setDatastreamName("task1");
     task.setId("3");
     task.setConnectorType(connectorType);
     task.setZkAdapter(adapter1);

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/InMemoryCheckpointProvider.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/InMemoryCheckpointProvider.java
@@ -24,6 +24,11 @@ public class InMemoryCheckpointProvider implements CheckpointProvider {
   }
 
   @Override
+  public void unassignDatastreamTask(DatastreamTask task) {
+    _cpMap.remove(task);
+  }
+
+  @Override
   public void updateCheckpoint(DatastreamTask task, int partition, String checkpoint) {
     if (!_cpMap.containsKey(task)) {
       _cpMap.put(task, new HashMap<>());


### PR DESCRIPTION
When you delete a datastream and then shutdown the instance. The tasks for the deleted datastreams are recreated. This is because right now when the tasks are unassigned, The internal checkpoints are not cleaned up. This fix cleans up the internal state of the checkpoint provider for all the unassigned tasks.