### PR TITLE
misc clean ups regarding oracle tb connector

### DIFF
--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/OracleConnector.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/OracleConnector.java
@@ -246,7 +246,7 @@ public class OracleConnector implements Connector {
     // class name given in the configs
     String className = properties.getProperty(SCHEMA_REGISTRY_FACTORY_KEY);
     if (StringUtils.isBlank(className)) {
-      String errorMessage = "Factory className is empty for SchemaRegistryClientFactory";
+      String errorMessage = "Missing property " + SCHEMA_REGISTRY_FACTORY_KEY;
       ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, null);
     }
 


### PR DESCRIPTION
1. handle `oracle.sql.TIMESTAMP` and `java.sql.Timestamp` differently. same with `java.sql.Date` and `oracle.sql.DATE`

2. update an error message so its more accurate to property names

3. refactor `isPrimitive()` function in `OracleDatabaseClient` to use the hard coded `Types`class. 