### PR TITLE
making the oracle connection j2ee13 compliant

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DynamicDataSourceFactoryImpl.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DynamicDataSourceFactoryImpl.java
@@ -43,6 +43,10 @@ public class DynamicDataSourceFactoryImpl implements OracleDataSourceFactory {
         prop = new Properties();
       }
 
+      // This ensures that when we call {@code ResultSet.getObject()} it returns
+      // java.sql.Timestamp for the TIMESTAMP SQL type (instead of oracle.sql.TIMESTAMP)
+      prop.put("oracle.jdbc.J2EE13Compliant", "true");
+
       if (queryTimeoutSec > 0) {
         // read timeout should be slightly more than query timeout
         int readTimeoutMS = 1000 * queryTimeoutSec + 100;


### PR DESCRIPTION
a normal call to `ResultSet.getObject()` will return a `oracle.sql.TIMESTAMP` for TIMESTAMP SQL types. This is an issue in open source since we don't have access to the `oracle.sql.TIMESTAMP` class.

We can fix this by setting a property during the oracle connection to make it J2EE13 compliant

http://docs.oracle.com/database/121/JJDBC/datacc.htm#JJDBC28363