### PR TITLE
Checking for missing task prefix.

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -674,10 +674,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     Map<String, List<Datastream>> streamsByTaskPrefix =
         allStreams.stream().collect(Collectors.groupingBy(DatastreamUtils::getTaskPrefix, Collectors.toList()));
 
-    List<DatastreamGroup> datastreamGroups = streamsByTaskPrefix.keySet()
-        .stream()
-        .map(x -> new DatastreamGroup(streamsByTaskPrefix.get(x)))
-        .collect(Collectors.toList());
+    List<DatastreamGroup> datastreamGroups =
+        streamsByTaskPrefix.values().stream().map(DatastreamGroup::new).collect(Collectors.toList());
 
     _log.debug("handleLeaderDoAssignment: final datastreams for task assignment: %s", datastreamGroups);
 

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/DatastreamUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/DatastreamUtils.java
@@ -69,6 +69,11 @@ public final class DatastreamUtils {
   }
 
   public static String getTaskPrefix(Datastream datastream) {
+    if (!datastream.getMetadata().containsKey(DatastreamMetadataConstants.TASK_PREFIX)) {
+      // Missing task prefix, generate one.
+      return DatastreamUtils.getTaskPrefix(datastream);
+    }
+
     return datastream.getMetadata().get(DatastreamMetadataConstants.TASK_PREFIX);
   }
 }


### PR DESCRIPTION
Make code robust to missing task prefix in the metadata.

