### PR TITLE
Add heartbeat to detect coordinator lockup

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.server;
 import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.common.zk.ZkClient;
 
+import java.time.Duration;
 import java.util.Properties;
 
 
@@ -13,7 +14,8 @@ public final class CoordinatorConfig {
   private final int _zkConnectionTimeout;
   private final Properties _config;
   private final VerifiableProperties _properties;
-  private final int _retryIntervalMS;
+  private final int _retryIntervalMs;
+  private final long _heartbeatPeriodMs;
 
   private static final String PREFIX = "brooklin.server.coordinator.";
   public static final String CONFIG_DEFAULT_TRANSPORT_PROVIDER = PREFIX + "defaultTransportProviderName";
@@ -21,7 +23,9 @@ public final class CoordinatorConfig {
   public static final String CONFIG_ZK_ADDRESS = PREFIX + "zkAddress";
   public static final String CONFIG_ZK_SESSION_TIMEOUT = PREFIX + "zkSessionTimeout";
   public static final String CONFIG_ZK_CONNECTION_TIMEOUT = PREFIX + "zkConnectionTimeout";
-  public static final String CONFIG_RETRY_INTERVAL = PREFIX + "retryIntervalMS";
+  public static final String CONFIG_RETRY_INTERVAL = PREFIX + "retryIntervalMs";
+  public static final String CONFIG_HEARTBEAT_PERIOD_MS = PREFIX + "heartbeatPeriodMs";
+
   private final String _defaultTransportProviderName;
   private int _assignmentChangeThreadPoolThreadCount = 3;
 
@@ -32,7 +36,8 @@ public final class CoordinatorConfig {
     _zkAddress = _properties.getString(CONFIG_ZK_ADDRESS);
     _zkSessionTimeout = _properties.getInt(CONFIG_ZK_SESSION_TIMEOUT, ZkClient.DEFAULT_SESSION_TIMEOUT);
     _zkConnectionTimeout = _properties.getInt(CONFIG_ZK_CONNECTION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
-    _retryIntervalMS = _properties.getInt(CONFIG_RETRY_INTERVAL, 1000 /* 1 second */);
+    _retryIntervalMs = _properties.getInt(CONFIG_RETRY_INTERVAL, 1000 /* 1 second */);
+    _heartbeatPeriodMs = _properties.getLong(CONFIG_HEARTBEAT_PERIOD_MS, Duration.ofMinutes(1).toMillis());
     _defaultTransportProviderName = _properties.getString(CONFIG_DEFAULT_TRANSPORT_PROVIDER, "");
   }
 
@@ -56,8 +61,8 @@ public final class CoordinatorConfig {
     return _zkConnectionTimeout;
   }
 
-  public int getRetryIntervalMS() {
-    return _retryIntervalMS;
+  public int getRetryIntervalMs() {
+    return _retryIntervalMs;
   }
 
   public void setAssignmentChangeThreadPoolThreadCount(int count) {
@@ -70,5 +75,9 @@ public final class CoordinatorConfig {
 
   public String getDefaultTransportProviderName() {
     return _defaultTransportProviderName;
+  }
+
+  public long getHeartbeatPeriodMs() {
+    return _heartbeatPeriodMs;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -6,12 +6,14 @@ public class CoordinatorEvent {
     LEADER_DO_ASSIGNMENT,
     HANDLE_ASSIGNMENT_CHANGE,
     HANDLE_ADD_OR_DELETE_DATASTREAM,
-    HANDLE_INSTANCE_ERROR
+    HANDLE_INSTANCE_ERROR,
+    HEARTBEAT
   }
 
   public static final CoordinatorEvent LEADER_DO_ASSIGNMENT_EVENT = new CoordinatorEvent(EventType.LEADER_DO_ASSIGNMENT);
   public static final CoordinatorEvent HANDLE_ASSIGNMENT_CHANGE_EVENT = new CoordinatorEvent(EventType.HANDLE_ASSIGNMENT_CHANGE);
   public static final CoordinatorEvent HANDLE_ADD_OR_DELETE_DATASTREAM_EVENT = new CoordinatorEvent(EventType.HANDLE_ADD_OR_DELETE_DATASTREAM);
+  public static final CoordinatorEvent HEARTBEAT_EVENT = new CoordinatorEvent(EventType.HEARTBEAT);
 
   protected final EventType _eventType;
 


### PR DESCRIPTION
Coordinator, as the name suggests, coordinates the operation of all
server components, eg. connecters, transport providers. In addition, it
make calls to ZK and othe external services. All of these internal and
external dependencies can misbehave and hang. Given coordinator event
handlers are all synchronized, when they hang, the whole coordinator
event handling is halted. Given the connectors run indepdently from
coordinator event loop, they can still producing events fine, this can
mask such lockup issues until we realize no new datastreams are handled
or other symptoms showing up much later in time.

To proatively detect such event-loop lockup, this change adds a
heartbeat mechanism through a counter metric. By default, every minute
coordinator queues up a heartbeat event which increments the counter.
When lockup happens, no events get processed in the queue, thus counter
will not be incremented until the lockup is broken out. This metric can
be used to set up alerts.