### PR TITLE
Adding Logic to Pause a Datastream.

### DIFF
--- a/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
+++ b/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
@@ -22,7 +22,14 @@
       "method" : "get_all"
     } ],
     "entity" : {
-      "path" : "/datastream/{datastreamId}"
+      "path" : "/datastream/{datastreamId}",
+      "actions" : [ {
+        "name" : "pause",
+        "returns" : "boolean"
+      }, {
+        "name" : "resume",
+        "returns" : "boolean"
+      } ]
     }
   }
 }

--- a/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc
+++ b/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdsc
@@ -51,6 +51,12 @@
       "symbolDocs" : { "INITIALIZING":"Datastream is created, but not initialized yet.", "READY": "Datastream destination is created, datastream is split into tasks and assigned and ready for producing and consumption."}
     },
     {
+      "name": "paused",
+      "doc" : "When true, the servers stop processing events for this datastream.",
+      "type" : "boolean",
+      "default": false
+    },
+    {
       "name": "destination",
       "doc": "Datastream destination string that the transport provider will use to send the events",
       "type": {

--- a/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
+++ b/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
@@ -74,6 +74,11 @@
         "INITIALIZING" : "Datastream is created, but not initialized yet."
       }
     }, {
+      "name" : "paused",
+      "type" : "boolean",
+      "doc" : "When true, the servers stop processing events for this datastream.",
+      "default" : false
+    }, {
       "name" : "destination",
       "type" : "DatastreamDestination",
       "doc" : "Datastream destination string that the transport provider will use to send the events",
@@ -112,7 +117,14 @@
         "method" : "get_all"
       } ],
       "entity" : {
-        "path" : "/datastream/{datastreamId}"
+        "path" : "/datastream/{datastreamId}",
+        "actions" : [ {
+          "name" : "pause",
+          "returns" : "boolean"
+        }, {
+          "name" : "resume",
+          "returns" : "boolean"
+        } ]
       }
     }
   }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamGroup.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamGroup.java
@@ -54,4 +54,9 @@ public class DatastreamGroup {
   public Optional<Integer> getSourcePartitions() {
     return Optional.ofNullable(_datastreams.get(0).getSource()).map(x -> x.getPartitions(GetMode.NULL));
   }
+
+  // A Datastream Group is paused, only if ALL the datastreams in the group are in paused.
+  public boolean isPaused() {
+    return _datastreams.stream().allMatch(ds -> ds.isPaused(GetMode.DEFAULT));
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -17,22 +17,29 @@ import com.codahale.metrics.MetricRegistry;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
+import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.RestliUtils;
 import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
 import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 import com.linkedin.datastream.server.Coordinator;
 import com.linkedin.datastream.server.DatastreamServer;
-import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+import com.linkedin.data.template.GetMode;
 import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.ActionResult;
+import com.linkedin.restli.server.annotations.Action;
+import com.linkedin.restli.server.annotations.Context;
+import com.linkedin.restli.server.annotations.PathKeysParam;
+import com.linkedin.restli.server.annotations.RestLiCollection;
 import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.PagingContext;
-import com.linkedin.restli.server.UpdateResponse;
-import com.linkedin.restli.server.annotations.Context;
-import com.linkedin.restli.server.annotations.RestLiCollection;
+import com.linkedin.restli.server.PathKeys;
+import com.linkedin.restli.server.ResourceLevel;
 import com.linkedin.restli.server.resources.CollectionResourceTemplate;
+import com.linkedin.restli.server.UpdateResponse;
 
 
 /*
@@ -40,8 +47,12 @@ import com.linkedin.restli.server.resources.CollectionResourceTemplate;
  * Note that rest.li will instantiate an object each time it processes a request.
  * So do make it thread-safe when implementing the resources.
  */
-@RestLiCollection(name = "datastream", namespace = "com.linkedin.datastream.server.dms")
+@RestLiCollection(
+    name = "datastream",
+    keyName = DatastreamResources.KEY_NAME,
+    namespace = "com.linkedin.datastream.server.dms")
 public class DatastreamResources extends CollectionResourceTemplate<String, Datastream> {
+  public static final String KEY_NAME = "datastreamId";
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamResources.class);
   private static final String CLASS_NAME = DatastreamResources.class.getSimpleName();
 
@@ -81,6 +92,57 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
     // TODO: behavior of updating a datastream is not fully defined yet; block this method for now
     return new UpdateResponse(HttpStatus.S_405_METHOD_NOT_ALLOWED);
   }
+
+  @Action(name = "pause", resourceLevel = ResourceLevel.ENTITY)
+  public ActionResult<Boolean> pause(@PathKeysParam PathKeys pathKeys) {
+    String datastreamName = pathKeys.getAsString(KEY_NAME);
+    Datastream datastream = _store.getDatastream(datastreamName);
+    if (datastream == null) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_404_NOT_FOUND,
+          "Datastream to pause does not exist: " + datastreamName);
+    }
+
+    if (datastream.isPaused(GetMode.DEFAULT)) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_405_METHOD_NOT_ALLOWED,
+          "Datastream already paused: " + datastreamName);
+    }
+
+    try {
+      datastream.setPaused(true);
+      _store.updateDatastream(datastreamName, datastream);
+    } catch (DatastreamException e) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
+          "Could not update datastream to pause: " + datastreamName);
+    }
+
+    return new ActionResult<>(true);
+  }
+
+  @Action(name = "resume", resourceLevel = ResourceLevel.ENTITY)
+  public ActionResult<Boolean> resume(@PathKeysParam PathKeys pathKeys) {
+    String datastreamName = pathKeys.getAsString(KEY_NAME);
+    Datastream datastream = _store.getDatastream(datastreamName);
+    if (datastream == null) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_404_NOT_FOUND,
+          "Datastream to resume does not exist: " + datastreamName);
+    }
+
+    if (!datastream.isPaused(GetMode.DEFAULT)) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_405_METHOD_NOT_ALLOWED,
+          "Datastream is not paused, cannot resume: " + datastreamName);
+    }
+
+    try {
+      datastream.setPaused(false);
+      _store.updateDatastream(datastreamName, datastream);
+    } catch (DatastreamException e) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
+          "Could not update datastream to resume: " + datastreamName);
+    }
+
+    return new ActionResult<>(true);
+  }
+
 
   @Override
   public UpdateResponse delete(String datastreamName) {

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -130,4 +130,28 @@ public class DatastreamTestUtils {
     storeDatastreams(zkClient, cluster, datastreams);
     return datastreams;
   }
+
+  public static Datastream getDatastream(ZkClient zkClient, String cluster, String datastreamName) {
+    zkClient.ensurePath(KeyBuilder.datastreams(cluster));
+    CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, cluster);
+    ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, cluster);
+    return dsStore.getDatastream(datastreamName);
+  }
+
+  /**
+   * Update the datastreams into the appropriate locations in zookeeper.
+   * @param zkClient zookeeper client
+   * @param cluster name of the datastream cluster
+   * @param datastreams list of datastreams
+   * @throws DatastreamException the datastream exception
+   */
+  public static void updateDatastreams(ZkClient zkClient, String cluster, Datastream... datastreams)
+      throws DatastreamException {
+    for (Datastream datastream : datastreams) {
+      zkClient.ensurePath(KeyBuilder.datastreams(cluster));
+      CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, cluster);
+      ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, cluster);
+      dsStore.updateDatastream(datastream.getName(), datastream);
+    }
+  }
 }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/JsonUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/JsonUtils.java
@@ -26,6 +26,7 @@ public final class JsonUtils {
     MAPPER.configure(DeserializationConfig.Feature.FAIL_ON_UNKNOWN_PROPERTIES, false);
 
     final DeserializationConfig config = MAPPER.getDeserializationConfig();
+    config.addMixInAnnotations(Datastream.class, IgnoreDatastreamSetPausedMixIn.class);
     config.addMixInAnnotations(DatastreamSource.class, IgnoreDatastreamSourceSetPartitionsMixIn.class);
     config.addMixInAnnotations(DatastreamDestination.class, IgnoreDatastreamDestinationSetPartitionsMixIn.class);
   }
@@ -38,6 +39,11 @@ public final class JsonUtils {
   private static abstract class IgnoreDatastreamDestinationSetPartitionsMixIn {
     @JsonIgnore
     public abstract DatastreamDestination setPartitions(int value);
+  }
+
+  private abstract class IgnoreDatastreamSetPausedMixIn {
+    @JsonIgnore
+    public abstract void setPaused(Boolean value);
   }
 
   /**


### PR DESCRIPTION
Adding logic to pause a datastream.

This logic will be useful for correcting problem (e.g. pausing a datastream to manually inspect 
and/or correct checkpoints) and other maintenance operations. 

When all the datastream in a group are "Paused" their associated tasks
are removed from the active instances, and move to a "PAUSED_NODE"
entry in zookeeper. Effectively sopping processing until the group is resumed.

Added two Custom Rest Actions to the Datastream Resource: pause and
resume. These new calls modify the paused attribute of the store
datastream, and notify the Coornitator to do a task rebalance.

There are a few minor changes unrelated to the paused logic here:
  - Fixing the retry logic in the handleDatastreamAddOrDelete method
    (It was a pending TODO in the code)
  - Fixing duplicate code to method "updateAllAssignments"
  - Making some variable privates