### PR TITLE
Allow Key and Value to be null inside the BrooklinEnvelope

### DIFF
--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/MessageHandler.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/MessageHandler.java
@@ -234,7 +234,7 @@ public class MessageHandler implements SendCallback {
 
   private DatastreamProducerRecord buildProducerRecord(BrooklinEnvelope brooklinEnvelope) {
     DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
-    builder.setPartitionKey(new String((byte[]) brooklinEnvelope.getKey()));
+    builder.setPartitionKey(new String((byte[]) brooklinEnvelope.key().get()));
     builder.addEvent(brooklinEnvelope);
 
     long sourceTimestamp =

--- a/brooklin-oracle-tb-connector/src/test/java/com/linkedin/datastream/connectors/oracle/triggerbased/TestMessageHandler.java
+++ b/brooklin-oracle-tb-connector/src/test/java/com/linkedin/datastream/connectors/oracle/triggerbased/TestMessageHandler.java
@@ -73,7 +73,7 @@ public class TestMessageHandler {
     BrooklinEnvelope envelope = handler.generateBrooklinEnvelope(events.get(1));
 
     // validate basic encoding on key
-    byte[] keyByteArray = (byte[]) envelope.getKey();
+    byte[] keyByteArray = (byte[]) envelope.key().get();
     Assert.assertNotNull(keyByteArray);
     Assert.assertFalse(keyByteArray.length == 0);
     Assert.assertFalse(keyByteArray[0] > MAGIC_BYTE);

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 
+import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang.Validate;
 
 
@@ -21,9 +22,8 @@ public class BrooklinEnvelope {
     this(key, value, null, metadata);
   }
 
-  public BrooklinEnvelope(Object key, Object value, Object previousValue, Map<String, String> metadata) {
-    Validate.notNull(key, "key cannot be null");
-    Validate.notNull(key, "value cannot be null");
+  public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
+      Map<String, String> metadata) {
     Validate.notNull(metadata, "metadata cannot be null");
     _key = key;
     _value = value;
@@ -48,13 +48,11 @@ public class BrooklinEnvelope {
     _previousValue = previousValue;
   }
 
-  public void setKey(Object key) {
-    Validate.notNull(key, "key cannot be null");
+  public void setKey(@Nullable Object key) {
     _key = key;
   }
 
-  public void setValue(Object value) {
-    Validate.notNull(value, "value cannot be null");
+  public void setValue(@Nullable Object value) {
     _value = value;
   }
 
@@ -62,12 +60,24 @@ public class BrooklinEnvelope {
     _metadata = metadata;
   }
 
+  @Nullable
+  @Deprecated
   public Object getKey() {
     return _key;
   }
 
+  public Optional<Object> key() {
+    return Optional.ofNullable(_key);
+  }
+
+  @Nullable
+  @Deprecated
   public Object getValue() {
     return _value;
+  }
+
+  public Optional<Object> value() {
+    return Optional.ofNullable(_value);
   }
 
   public Map<String, String> getMetadata() {

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -78,12 +78,12 @@ public class KafkaTransportProvider implements TransportProvider {
     byte[] payloadValue = new byte[0];
     if (event instanceof BrooklinEnvelope) {
       BrooklinEnvelope envelope = (BrooklinEnvelope) event;
-      if (envelope.getKey() instanceof byte[]) {
-        keyValue = (byte[]) envelope.getKey();
+      if (envelope.key().isPresent() && envelope.key().get() instanceof byte[]) {
+        keyValue = (byte[]) envelope.key().get();
       }
 
-      if (envelope.getValue() instanceof byte[]) {
-        payloadValue = (byte[]) envelope.getValue();
+      if (envelope.value().isPresent() && envelope.value().get() instanceof byte[]) {
+        payloadValue = (byte[]) envelope.value().get();
       }
     } else if (event instanceof byte[]) {
       payloadValue = (byte[]) event;

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
@@ -41,8 +41,8 @@ public class DatastreamProducerRecord {
   }
 
   private void serializeEvent(BrooklinEnvelope event, SerDeSet serDes) {
-    serDes.getKeySerDe().ifPresent(x -> event.setKey(x.serialize(event.getKey())));
-    serDes.getValueSerDe().ifPresent(x -> event.setValue(x.serialize(event.getValue())));
+    serDes.getKeySerDe().ifPresent(x -> event.key().ifPresent(k -> event.setKey(x.serialize(k))));
+    serDes.getValueSerDe().ifPresent(x -> event.value().ifPresent(v -> event.setValue(x.serialize(v))));
 
     if (event.getPreviousValue().isPresent() && serDes.getValueSerDe().isPresent()) {
       event.setPreviousValue(serDes.getValueSerDe().get().serialize(event.getPreviousValue()));

--- a/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestDatastreamProducerRecordBuilder.java
+++ b/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestDatastreamProducerRecordBuilder.java
@@ -28,8 +28,8 @@ public class TestDatastreamProducerRecordBuilder {
 
     DatastreamProducerRecord record = builder.build();
     Assert.assertEquals(record.getEvents().size(), 2);
-    Assert.assertEquals(record.getEvents().get(0).getValue(), event1.getValue());
-    Assert.assertEquals(record.getEvents().get(1).getValue(), event2.getValue());
+    Assert.assertEquals(record.getEvents().get(0).value().get(), event1.value().get());
+    Assert.assertEquals(record.getEvents().get(1).value().get(), event2.value().get());
     Assert.assertEquals(record.getPartition().get().intValue(), partition);
     Assert.assertEquals(record.getCheckpoint(), sourceCheckpoint);
     Assert.assertEquals(record.getEventsSourceTimestamp(), timestamp);
@@ -78,7 +78,7 @@ public class TestDatastreamProducerRecordBuilder {
     DatastreamProducerRecord record = builder.build();
 
     Assert.assertEquals(record.getEvents().size(), 1);
-    Assert.assertEquals(record.getEvents().get(0).getKey(), key);
-    Assert.assertEquals(record.getEvents().get(0).getValue(), payload);
+    Assert.assertEquals(record.getEvents().get(0).key().get(), key);
+    Assert.assertEquals(record.getEvents().get(0).value().get(), payload);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -146,8 +146,6 @@ public class EventProducer implements DatastreamEventProducer {
     for (Object event : record.getEvents()) {
       BrooklinEnvelope envelope = (BrooklinEnvelope) event;
       Validate.notNull(envelope, "null event");
-      Validate.notNull(envelope.getKey(), "null key");
-      Validate.notNull(envelope.getValue(), "null value");
     }
   }
 


### PR DESCRIPTION
Some events in  kafka in cert has null keys.
This is creating problem in the pipeline.

This is the first pull request in a series of pull request going all the way to brooklin-server.



