### PR TITLE
NoOpDeduper for connectors to have the option to disable any de-duping

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/NoOpDeduper.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/NoOpDeduper.java
@@ -1,0 +1,17 @@
+package com.linkedin.datastream.server.api.connector;
+
+import java.util.List;
+import java.util.Optional;
+
+import com.linkedin.datastream.common.Datastream;
+
+
+/**
+ * Dummy deduper for connector not needing de-dup or handles de-dups themselves.
+ */
+public class NoOpDeduper implements DatastreamDeduper {
+  @Override
+  public Optional<Datastream> findExistingDatastream(Datastream newDatastream, List<Datastream> allDatastream) {
+    return Optional.empty();
+  }
+}

--- a/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestSourceBasedDeduper.java
+++ b/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestSourceBasedDeduper.java
@@ -83,8 +83,8 @@ public class TestSourceBasedDeduper {
   @Test
   public void testDatastreamWithSameSourceButNoTopicReuse() {
     Datastream datastream = generateDatastream(0, false);
-    Datastream datastream1 = generateDatastream(0, true);
-    Datastream datastream2 = generateDatastream(1, true);
+    Datastream datastream1 = generateDatastream(1, true);
+    Datastream datastream2 = generateDatastream(2, true);
     datastream1.getMetadata().put(DatastreamMetadataConstants.REUSE_EXISTING_DESTINATION_KEY, "false");
     SourceBasedDeduper deduper = new SourceBasedDeduper();
     Optional<Datastream> foundDatastream =

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -90,6 +90,7 @@ public class DatastreamTestUtils {
     StringMap metadata = new StringMap();
     metadata.put(DatastreamMetadataConstants.OWNER_KEY, "dummy_owner");
     metadata.put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(Instant.now().toEpochMilli()));
+    metadata.put(DatastreamMetadataConstants.TASK_PREFIX, datastreamName);
     ds.setMetadata(metadata);
     return ds;
   }


### PR DESCRIPTION
Some connectors might not need de-duper functionality or has more
complex de-dup logic which must be handled internally by themselves.
Currently, empty de-duper factory is not acceptable as server throws.
One way to solve the problem is to add an NoOpDeduper so existing code
requires no changes. Another option requires adding checks where the
deduper is used and allow empty deduper factory.

This change implements the first option.