### PR TITLE
Restli implement for server component health status framework

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -305,6 +305,7 @@ project(':datastream-server') {
     compile project(':datastream-server-api')
     compile project(':datastream-common')
     compile project(':datastream-utils')
+    compile project(':datastream-client')
 
     testCompile project(':datastream-kafka')
     testCompile "org.apache.kafka:kafka_2.10:$kafkaVersion"

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
@@ -1,11 +1,12 @@
 package com.linkedin.datastream;
 
-import com.linkedin.r2.transport.common.Client;
-import com.linkedin.restli.client.RestClient;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import org.apache.commons.lang3.StringUtils;
+
+import com.linkedin.datastream.common.RestliUtils;
+import com.linkedin.r2.transport.common.Client;
+import com.linkedin.restli.client.RestClient;
 
 
 /**
@@ -17,13 +18,9 @@ import org.apache.commons.lang3.StringUtils;
  * DatastreamRestClient, without doing a major refactoring of the code.
  */
 public class DatastreamRestClientFactory {
-  private static final String DEFAULT_URI_SCHEME = "http://";
 
   private static Map<String, DatastreamRestClient> overrides = new ConcurrentHashMap<>();
 
-  private static String sanitizeUri(String dmsUri) {
-    return StringUtils.prependIfMissing(StringUtils.appendIfMissing(dmsUri, "/"), DEFAULT_URI_SCHEME);
-  }
 
   /**
    * Get a DatastreamRestClient with default HTTP client
@@ -41,7 +38,7 @@ public class DatastreamRestClientFactory {
    * @return
    */
   public static DatastreamRestClient getClient(String dmsUri, Map<String, String> httpConfig) {
-    dmsUri = sanitizeUri(dmsUri);
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
     if (overrides.containsKey(dmsUri)) {
       return overrides.get(dmsUri);
     }
@@ -55,7 +52,7 @@ public class DatastreamRestClientFactory {
    * @return
    */
   public static DatastreamRestClient getClient(String dmsUri, Client r2Client) {
-    dmsUri = sanitizeUri(dmsUri);
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
     if (overrides.containsKey(dmsUri)) {
       return overrides.get(dmsUri);
     }
@@ -69,7 +66,7 @@ public class DatastreamRestClientFactory {
    * @return
    */
   public static DatastreamRestClient getClient(String dmsUri, RestClient restClient) {
-    dmsUri = sanitizeUri(dmsUri);
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
     if (overrides.containsKey(dmsUri)) {
       return overrides.get(dmsUri);
     }
@@ -82,7 +79,7 @@ public class DatastreamRestClientFactory {
    * in case the test are running in parallel.
    */
   public static void addOverride(String dmsUri, DatastreamRestClient restClient) {
-    dmsUri = sanitizeUri(dmsUri);
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
     overrides.put(dmsUri, restClient);
   }
 

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClient.java
@@ -1,0 +1,123 @@
+package com.linkedin.diagnostics;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang.Validate;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.common.callback.FutureCallback;
+import com.linkedin.datastream.diagnostics.ServerComponentHealth;
+import com.linkedin.datastream.server.diagnostics.DiagRequestBuilders;
+import com.linkedin.r2.RemoteInvocationException;
+import com.linkedin.r2.transport.common.Client;
+import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
+import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.restli.client.FindRequest;
+import com.linkedin.restli.client.RestClient;
+
+/**
+ * Restli Client to call the ServerComponentHealth Find request to get the server status.
+ */
+
+public class ServerComponentHealthRestClient {
+  private static final Logger LOG = LoggerFactory.getLogger(ServerComponentHealthRestClient.class);
+  private final DiagRequestBuilders _builders;
+  private final RestClient _restClient;
+
+  public ServerComponentHealthRestClient(String dsmUri) {
+    this(dsmUri, new TransportClientAdapter(new HttpClientFactory().getClient(Collections.<String, String>emptyMap())));
+  }
+
+  public ServerComponentHealthRestClient(String dmsUri, Map<String, String> httpConfig) {
+    this(dmsUri, new TransportClientAdapter(new HttpClientFactory().getClient(httpConfig)));
+  }
+
+  public ServerComponentHealthRestClient(String dsmUri, Client r2Client) {
+    Validate.notEmpty(dsmUri, "invalid DSM URI");
+    Validate.notNull(r2Client, "null R2 client");
+    dsmUri = StringUtils.appendIfMissing(dsmUri, "/");
+    _builders = new DiagRequestBuilders();
+    _restClient = new RestClient(r2Client, dsmUri);
+  }
+
+  public ServerComponentHealthRestClient(RestClient restClient) {
+    Validate.notNull(restClient, "null restClient");
+    _builders = new DiagRequestBuilders();
+    _restClient = restClient;
+  }
+
+  /**
+   * Get the ServerComponentHealth status from one server instance. This method makes a FIND rest call
+   * to the ServerComponentHealth management service which in turn fetches this status from the component.
+   * @param type
+   *    Type of the component such as connector.
+   * @param scope
+   *    Scope of the component such as Espresso and Kafka.
+   * @param content
+   *    Request content should be passed to the component.
+   * @return
+   *    List of ServerComponentHealth object corresponding to the component.
+   */
+  public ServerComponentHealth getStatus(String type, String scope, String content) {
+    List<ServerComponentHealth> response = getServerComponentHealthStatues(type, scope, content);
+    if (response != null && !response.isEmpty()) {
+      return response.get(0);
+    } else {
+      LOG.error("ServerComponentHealth getStatus {%s} {%s} failed with empty response.", type, scope);
+      return null;
+    }
+  }
+
+  public List<ServerComponentHealth> getServerComponentHealthStatues(String type, String scope, String content) {
+    try {
+      FindRequest<ServerComponentHealth> request = _builders.findByStatus().typeParam(type).scopeParam(scope).contentParam(content).build();
+      return _restClient.sendRequest(request).getResponse().getEntity().getElements();
+    } catch (RemoteInvocationException e) {
+      LOG.error("Get serverComponentHealthStatus {%s} {%s} failed with error.", type, scope);
+      return null;
+    }
+  }
+
+  /**
+   * Get the ServerComponentHealth statuses from all server instances. This method makes a FIND rest call
+   * to the ServerComponentHealth management service which in turn fetches this status from the component.
+   * @param type
+   *    Type of the component such as connector.
+   * @param scope
+   *    Scope of the component such as Espresso and Kafka.
+   * @param content
+   *    Request content should be passed to the component.
+   * @return
+   *    List of ServerComponentHealth object corresponding to the component.
+   */
+  public ServerComponentHealth getAllStatus(String type, String scope, String content) {
+    List<ServerComponentHealth> response = getServerComponentHealthAllStatus(type, scope, content);
+    if (response != null && !response.isEmpty()) {
+      return response.get(0);
+    } else {
+      LOG.error("ServerComponentHealth getAllStatus {%s} {%s} failed with empty response.", type, scope);
+      return null;
+    }
+  }
+
+  public List<ServerComponentHealth> getServerComponentHealthAllStatus(String type, String scope, String content) {
+    try {
+      FindRequest<ServerComponentHealth> request = _builders.findByAllStatus().typeParam(type).scopeParam(scope).contentParam(content).build();
+      return _restClient.sendRequest(request).getResponse().getEntity().getElements();
+    } catch (RemoteInvocationException e) {
+      LOG.error("Get serverComponentHealthAllStatus {%s} {%s} failed with error.", type, scope);
+      return null;
+    }
+  }
+
+  /**
+   * Shutdown the ServerComponentHealthRestClient
+   */
+  public void shutdown() {
+    _restClient.shutdown(new FutureCallback<>());
+  }
+}

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
@@ -1,0 +1,70 @@
+package com.linkedin.diagnostics;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import com.linkedin.datastream.common.RestliUtils;
+import com.linkedin.restli.client.RestClient;
+
+
+/**
+ * ServerComponentHealth Resource Factory that is used to create the ServerComponentHealth restli resources.
+ */
+public class ServerComponentHealthRestClientFactory {
+
+  private static Map<String, ServerComponentHealthRestClient> overrides = new ConcurrentHashMap<>();
+
+  public static ServerComponentHealthRestClient getClient(String dmsUri) {
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
+    if (overrides.containsKey(dmsUri)) {
+      return overrides.get(dmsUri);
+    }
+    return new ServerComponentHealthRestClient(dmsUri);
+  }
+
+  /**
+   * Get a ServerComponentHealthRestClient with default HTTP client and custom HTTP configs
+   * @param dmsUri URI to DMS endpoint
+   * @param httpConfig custom config for HTTP client, please find the configs in {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
+   * @return
+   */
+  public static ServerComponentHealthRestClient getClient(String dmsUri, Map<String, String> httpConfig) {
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
+    if (overrides.containsKey(dmsUri)) {
+      return overrides.get(dmsUri);
+    }
+    return new ServerComponentHealthRestClient(dmsUri, httpConfig);
+  }
+
+  /**
+   * Get a ServerComponentHealthRestClient with an existing Rest.li RestClient (must bound to the same dmsUri).
+   * @param dmsUri URI to DMS endpoint
+   * @param restClient Rest.li RestClient
+   * @return
+   */
+  public static ServerComponentHealthRestClient getClient(String dmsUri, RestClient restClient) {
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
+    if (overrides.containsKey(dmsUri)) {
+      return overrides.get(dmsUri);
+    }
+    return new ServerComponentHealthRestClient(restClient);
+  }
+
+  /**
+   * Used mainly for testing, to override the ServerComponentHealthRestClient returned for a given dmsUri.
+   * Note that this is an static method, each test case should use its own dmsUri, to avoid conflicts
+   * in case the test are running in parallel.
+   */
+  public static void addOverride(String dmsUri, ServerComponentHealthRestClient restClient) {
+    dmsUri = RestliUtils.sanitizeUri(dmsUri);
+    overrides.put(dmsUri, restClient);
+  }
+
+  /**
+   * @return the current RestClient override mappings
+   */
+  public static Map<String, ServerComponentHealthRestClient> getOverrides() {
+    return Collections.unmodifiableMap(overrides);
+  }
+}

--- a/datastream-client/src/test/java/com/linkedin/TestRestliClientBase.java
+++ b/datastream-client/src/test/java/com/linkedin/TestRestliClientBase.java
@@ -1,0 +1,37 @@
+package com.linkedin;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.Properties;
+
+import com.linkedin.datastream.common.DatastreamException;
+import com.linkedin.datastream.connectors.DummyConnector;
+import com.linkedin.datastream.connectors.DummyConnectorFactory;
+import com.linkedin.datastream.server.DatastreamServer;
+import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
+import com.linkedin.datastream.server.assignment.BroadcastStrategyFactory;
+
+
+public class TestRestliClientBase {
+
+  public static final String TRANSPORT_NAME = "default";
+  public static final long WAIT_TIMEOUT_MS = Duration.ofMinutes(3).toMillis();
+  public EmbeddedDatastreamCluster _datastreamCluster;
+
+  public void setupDatastreamCluster(int numServers) throws IOException, DatastreamException {
+    Properties connectorProps = new Properties();
+    connectorProps.put(DatastreamServer.CONFIG_FACTORY_CLASS_NAME, DummyConnectorFactory.class.getCanonicalName());
+    connectorProps.put(DatastreamServer.CONFIG_CONNECTOR_ASSIGNMENT_STRATEGY_FACTORY,
+        BroadcastStrategyFactory.class.getTypeName());
+    connectorProps.put("dummyProperty", "dummyValue");
+
+    _datastreamCluster = EmbeddedDatastreamCluster.newTestDatastreamCluster(
+        Collections.singletonMap(DummyConnector.CONNECTOR_TYPE, connectorProps), null, numServers);
+
+    // NOTE: Only start the first instance by default
+    // Test case needing the 2nd one should start the 2nd instance
+    _datastreamCluster.startupServer(0);
+  }
+
+}

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -1,13 +1,11 @@
 package com.linkedin.datastream;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Properties;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -19,33 +17,23 @@ import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
+import com.linkedin.TestRestliClientBase;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamDestination;
-import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamNotFoundException;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.connectors.DummyConnector;
-import com.linkedin.datastream.connectors.DummyConnectorFactory;
-import com.linkedin.datastream.server.DatastreamServer;
-import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
-import com.linkedin.datastream.server.assignment.BroadcastStrategyFactory;
 import com.linkedin.restli.client.RestLiResponseException;
 
 
 @Test(singleThreaded = true)
-public class TestDatastreamRestClient {
-  private static final String TRANSPORT_NAME = "default";
-
+public class TestDatastreamRestClient extends TestRestliClientBase {
   private static final Logger LOG = LoggerFactory.getLogger(TestDatastreamRestClient.class);
-
-  private static final long WAIT_TIMEOUT_MS = Duration.ofMinutes(3).toMillis();
-
-  private EmbeddedDatastreamCluster _datastreamCluster;
 
   @BeforeTest
   public void setUp() throws Exception {
@@ -58,21 +46,6 @@ public class TestDatastreamRestClient {
   @AfterTest
   public void tearDown() throws Exception {
     _datastreamCluster.shutdown();
-  }
-
-  private void setupDatastreamCluster(int numServers) throws IOException, DatastreamException {
-    Properties connectorProps = new Properties();
-    connectorProps.put(DatastreamServer.CONFIG_FACTORY_CLASS_NAME, DummyConnectorFactory.class.getCanonicalName());
-    connectorProps.put(DatastreamServer.CONFIG_CONNECTOR_ASSIGNMENT_STRATEGY_FACTORY,
-        BroadcastStrategyFactory.class.getTypeName());
-    connectorProps.put("dummyProperty", "dummyValue");
-
-    _datastreamCluster = EmbeddedDatastreamCluster.newTestDatastreamCluster(
-        Collections.singletonMap(DummyConnector.CONNECTOR_TYPE, connectorProps), null, numServers);
-
-    // NOTE: Only start the first instance by default
-    // Test case needing the 2nd one should start the 2nd instance
-    _datastreamCluster.startupServer(0);
   }
 
   public static Datastream generateDatastream(int seed) {

--- a/datastream-client/src/test/java/com/linkedin/diagnostics/TestServerComponentHealthRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/diagnostics/TestServerComponentHealthRestClient.java
@@ -1,0 +1,87 @@
+package com.linkedin.diagnostics;
+
+import org.apache.log4j.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.linkedin.TestRestliClientBase;
+import com.linkedin.datastream.diagnostics.ServerComponentHealth;
+
+
+@Test(singleThreaded = true)
+public class TestServerComponentHealthRestClient extends TestRestliClientBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestServerComponentHealthRestClient.class);
+
+  @BeforeTest
+  public void setUp() throws Exception {
+    org.apache.log4j.Logger.getRootLogger().setLevel(Level.INFO);
+
+    // Create a cluster with maximum 2 DMS instances
+    setupDatastreamCluster(2);
+  }
+
+  @AfterTest
+  public void tearDown() throws Exception {
+    _datastreamCluster.shutdown();
+  }
+
+  /**
+   * Create a rest client with the default/leader DMS instance
+   * @return
+   */
+  private ServerComponentHealthRestClient createRestClient() {
+    String dmsUri = String.format("http://localhost:%d", _datastreamCluster.getDatastreamPorts().get(0));
+    return ServerComponentHealthRestClientFactory.getClient(dmsUri);
+  }
+
+  @Test
+  public void testGetStatus() throws Exception {
+    // happy path test case
+    String name = "Connector";
+    String type = "DummyConnector";
+    String content = "topic=datastream";
+    String expectedStatus = "HEALTHY";
+    ServerComponentHealthRestClient restClient = createRestClient();
+    ServerComponentHealth response =  restClient.getStatus(name, type, content);
+
+    Assert.assertEquals(response.getStatus(), expectedStatus);
+
+    // invalid name, null response.
+    name = "NonExistComponent";
+    response = restClient.getStatus(name, type, content);
+    Assert.assertEquals(response, null);
+
+    // invalid type, null response.
+    type = "NonExistConnector";
+    response = restClient.getStatus(name, type, content);
+    Assert.assertEquals(response, null);
+  }
+
+  @Test
+  public void testGetAllStatus() throws Exception {
+    // happy path test case
+    String name = "Connector";
+    String type = "DummyConnector";
+    String content = "topic=datastream";
+    String expectedStatus = "DummyStatus";
+    ServerComponentHealthRestClient restClient = createRestClient();
+    ServerComponentHealth response =  restClient.getAllStatus(name, type, content);
+
+    Assert.assertEquals(response.getStatus(), expectedStatus);
+
+    // invalid name, null response.
+    name = "NonExistComponent";
+    response = restClient.getStatus(name, type, content);
+    Assert.assertEquals(response, null);
+
+    // invalid type, null response.
+    type = "NonExistConnector";
+    response = restClient.getStatus(name, type, content);
+    Assert.assertEquals(response, null);
+  }
+}

--- a/datastream-common/src/main/idl/com.linkedin.datastream.server.diagnostics.diag.restspec.json
+++ b/datastream-common/src/main/idl/com.linkedin.datastream.server.diagnostics.diag.restspec.json
@@ -1,0 +1,46 @@
+{
+  "name" : "diag",
+  "namespace" : "com.linkedin.datastream.server.diagnostics",
+  "path" : "/diag",
+  "schema" : "com.linkedin.datastream.diagnostics.ServerComponentHealth",
+  "doc" : "Resources classes are used by rest.li to process corresponding http request.\n Note that rest.li will instantiate an object each time it processes a request.\n So do make it thread-safe when implementing the resources.\n\n The format of the restli request for the health status of all server instance\n /diag?q=allStatus&type=connector&scope=espresso&content=componentParameters\n where type and scope are used by the framework to decide which component to send the request,\n and content is the parameter passed to the component which should implement the DiagnosticsAware interface.\n\n There is an extra restli call to get the status of a single server:\n /diag?q=status&type=connector&scope=espresso&content=componentParameters\n It is not intended to be exposed to other team such as Espresso, but it can be used internally for testing purpose.\n\ngenerated from: com.linkedin.datastream.server.diagnostics.ServerComponentHealthResources",
+  "collection" : {
+    "identifier" : {
+      "name" : "diagId",
+      "type" : "string"
+    },
+    "supports" : [ ],
+    "finders" : [ {
+      "name" : "allStatus",
+      "doc" : "Finder Reqeust to get the status of all server instances.\n   You can access this FINDER method via /diag?q=status&type=connector&scope=espresso&content=...",
+      "parameters" : [ {
+        "name" : "type",
+        "type" : "string"
+      }, {
+        "name" : "scope",
+        "type" : "string"
+      }, {
+        "name" : "content",
+        "type" : "string",
+        "optional" : true
+      } ]
+    }, {
+      "name" : "status",
+      "doc" : "Finder Reqeust to get the status from one server  instance.\n   You can access this FINDER method via /diag?q=stat&type=connector&scope=espresso&content=...",
+      "parameters" : [ {
+        "name" : "type",
+        "type" : "string"
+      }, {
+        "name" : "scope",
+        "type" : "string"
+      }, {
+        "name" : "content",
+        "type" : "string",
+        "optional" : true
+      } ]
+    } ],
+    "entity" : {
+      "path" : "/diag/{diagId}"
+    }
+  }
+}

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DiagnosticsAware.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DiagnosticsAware.java
@@ -1,0 +1,23 @@
+package com.linkedin.datastream.common;
+
+import java.util.Map;
+
+
+/**
+ * Classes that implement DiagnosticsAware should return the status or any information of a host/instance,
+ * and be able to reduce all the responses across different hosts/instances.
+ * The Restli request will call process on each host/instances, then aggregate all
+ * the responses by calling reduce to return a merged response.
+ */
+
+public interface DiagnosticsAware {
+  /**
+   * @return process the query of a single host/instance, return response such as the status of the host
+   */
+  String process(String query);
+
+  /**
+   * @return reduce/merge the responses of a collection of host/instance into one response
+   */
+  String reduce(String query, Map<String, String> responses);
+}

--- a/datastream-common/src/main/pegasus/com/linkedin/datastream/diagnostics/ServerComponentHealth.pdsc
+++ b/datastream-common/src/main/pegasus/com/linkedin/datastream/diagnostics/ServerComponentHealth.pdsc
@@ -1,0 +1,13 @@
+{
+  "type": "record",
+  "name": "ServerComponentHealth",
+  "namespace": "com.linkedin.datastream.diagnostics",
+  "doc": "Datastream server component health",
+  "fields": [
+    {
+      "name" : "status",
+      "doc" : "Status of the datastream server component",
+      "type": "string"
+    }
+  ]
+}

--- a/datastream-common/src/main/snapshot/com.linkedin.datastream.server.diagnostics.diag.snapshot.json
+++ b/datastream-common/src/main/snapshot/com.linkedin.datastream.server.diagnostics.diag.snapshot.json
@@ -1,0 +1,59 @@
+{
+  "models" : [ {
+    "type" : "record",
+    "name" : "ServerComponentHealth",
+    "namespace" : "com.linkedin.datastream.diagnostics",
+    "doc" : "Datastream server component health",
+    "fields" : [ {
+      "name" : "status",
+      "type" : "string",
+      "doc" : "Status of the datastream server component"
+    } ]
+  } ],
+  "schema" : {
+    "name" : "diag",
+    "namespace" : "com.linkedin.datastream.server.diagnostics",
+    "path" : "/diag",
+    "schema" : "com.linkedin.datastream.diagnostics.ServerComponentHealth",
+    "doc" : "Resources classes are used by rest.li to process corresponding http request.\n Note that rest.li will instantiate an object each time it processes a request.\n So do make it thread-safe when implementing the resources.\n\n The format of the restli request for the health status of all server instance\n /diag?q=allStatus&type=connector&scope=espresso&content=componentParameters\n where type and scope are used by the framework to decide which component to send the request,\n and content is the parameter passed to the component which should implement the DiagnosticsAware interface.\n\n There is an extra restli call to get the status of a single server:\n /diag?q=status&type=connector&scope=espresso&content=componentParameters\n It is not intended to be exposed to other team such as Espresso, but it can be used internally for testing purpose.\n\ngenerated from: com.linkedin.datastream.server.diagnostics.ServerComponentHealthResources",
+    "collection" : {
+      "identifier" : {
+        "name" : "diagId",
+        "type" : "string"
+      },
+      "supports" : [ ],
+      "finders" : [ {
+        "name" : "allStatus",
+        "doc" : "Finder Reqeust to get the status of all server instances.\n   You can access this FINDER method via /diag?q=status&type=connector&scope=espresso&content=...",
+        "parameters" : [ {
+          "name" : "type",
+          "type" : "string"
+        }, {
+          "name" : "scope",
+          "type" : "string"
+        }, {
+          "name" : "content",
+          "type" : "string",
+          "optional" : true
+        } ]
+      }, {
+        "name" : "status",
+        "doc" : "Finder Reqeust to get the status from one server  instance.\n   You can access this FINDER method via /diag?q=stat&type=connector&scope=espresso&content=...",
+        "parameters" : [ {
+          "name" : "type",
+          "type" : "string"
+        }, {
+          "name" : "scope",
+          "type" : "string"
+        }, {
+          "name" : "content",
+          "type" : "string",
+          "optional" : true
+        } ]
+      } ],
+      "entity" : {
+        "path" : "/diag/{diagId}"
+      }
+    }
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -95,6 +95,10 @@ public class ConnectorWrapper {
     logApiEnd("stop");
   }
 
+  public Connector  getConnectorInstance() {
+    return _connector;
+  }
+
   public String getConnectorType() {
     return _connectorType;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1045,4 +1045,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     String result = sb.toString();
     return result.substring(0, result.length() - 1);
   }
+
+  public Connector getConnector(String name) {
+    if (!_connectors.containsKey(name)) {
+      return null;
+    }
+    return _connectors.get(name).getConnector().getConnectorInstance();
+  }
+
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ErrorLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ErrorLogger.java
@@ -1,4 +1,4 @@
-package com.linkedin.datastream.server.dms;
+package com.linkedin.datastream.server;
 
 import java.util.UUID;
 
@@ -14,7 +14,7 @@ import com.linkedin.restli.server.RestLiServiceException;
  * A shortened random UUID, as well as the server instance name,
  * is attached to each error message to facilitate the trouble shooting
  */
-final class ErrorLogger {
+public final class ErrorLogger {
   private final Logger _logger;
   private final String _instance;
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerComponentHealthAggregator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerComponentHealthAggregator.java
@@ -1,0 +1,121 @@
+package com.linkedin.datastream.server.diagnostics;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.DiagnosticsAware;
+import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.diagnostics.ServerComponentHealth;
+import com.linkedin.datastream.server.zk.KeyBuilder;
+import com.linkedin.diagnostics.ServerComponentHealthRestClient;
+import com.linkedin.diagnostics.ServerComponentHealthRestClientFactory;
+import com.linkedin.r2.transport.http.client.HttpClientFactory;
+
+
+/**
+ * Server Component Health reader is to get the restli response from all  server instances, do the merge and return
+ * the overall status of the server.
+ */
+public class ServerComponentHealthAggregator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ServerComponentHealthAggregator.class.getName());
+
+  private static final String HTTP_REQUEST_TIMEOUT = "http.requestTimeout";
+  private static final String HTTP_TIMEOUT = String.valueOf(Duration.ofMinutes(2).toMillis());
+
+  private final ZkClient _zkClient;
+  private final String _cluster;
+  private int _restEndPointPort;
+  private final String _restEndPointPath;
+
+  public ServerComponentHealthAggregator(ZkClient zkClient, String cluster, int endPointPort, String endPointPath) {
+    assert zkClient != null;
+    assert cluster != null;
+
+    _zkClient = zkClient;
+    _cluster = cluster;
+    _restEndPointPort = endPointPort;
+    _restEndPointPath = endPointPath;
+  }
+
+  public List<ServerComponentHealth> getResponses(String componentType, String componentScope,
+      String componentInputs, DiagnosticsAware component) {
+    List<String> hosts = getLiveInstances();
+    ConcurrentMap<String, String> responses = new ConcurrentHashMap<>();
+
+    hosts.parallelStream().forEach(hostName ->
+    {
+      ServerComponentHealthRestClient restClient = null;
+      try {
+        // Send requests to all the server live instances
+        String dmsUri = getDmsUri(hostName);
+        LOG.info("Send restli status request to " + dmsUri);
+        restClient = ServerComponentHealthRestClientFactory.getClient(dmsUri, Collections.singletonMap(
+            HttpClientFactory.HTTP_REQUEST_TIMEOUT, HTTP_TIMEOUT));
+
+        ServerComponentHealth response =
+            restClient.getStatus(componentType, componentScope, componentInputs);
+
+        // No response received from a host, set error message
+        if (response == null) {
+          String errorMessage = "No restli response from the host: " + dmsUri;
+          LOG.error(errorMessage);
+          responses.put(hostName, errorMessage);
+        } else {
+          String message = "Get restli response from the host: " + dmsUri + " with status: " + response.getStatus();
+          LOG.info(message);
+          responses.put(hostName, response.getStatus());
+        }
+      } finally {
+        if (restClient != null) {
+          restClient.shutdown();
+        }
+      }
+    });
+
+    ServerComponentHealth serverComponentHealth = new ServerComponentHealth();
+    serverComponentHealth.setStatus(component.reduce(componentInputs, responses));
+
+    return Arrays.asList(serverComponentHealth);
+  }
+
+  private List<String> getLiveInstances() {
+    List<String> instances = new ArrayList<>();
+    List<String> nodes = _zkClient.getChildren(KeyBuilder.liveInstances(_cluster));
+    for (String node : nodes) {
+      instances.add(_zkClient.readData(KeyBuilder.liveInstance(_cluster, node)));
+    }
+    return instances;
+  }
+
+  private String getDmsUri(String hostName) {
+    String dmsUri = "";
+    if (!hostName.startsWith("http")) {
+      dmsUri += "http://";
+    }
+    if (hostName.split(":").length == 1) { // hostName does not include port number
+      dmsUri += hostName + ":" + _restEndPointPort;
+    } else {
+      dmsUri += hostName;
+    }
+    if (!_restEndPointPath.isEmpty()) {
+      dmsUri += "/" + _restEndPointPath;
+    }
+    return dmsUri;
+  }
+
+  public void setPort(int port) {
+    if (_restEndPointPort == 0) {
+      _restEndPointPort = port;
+    }
+  }
+
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerComponentHealthResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerComponentHealthResources.java
@@ -1,0 +1,116 @@
+package com.linkedin.datastream.server.diagnostics;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.DiagnosticsAware;
+import com.linkedin.datastream.diagnostics.ServerComponentHealth;
+import com.linkedin.datastream.server.Coordinator;
+import com.linkedin.datastream.server.DatastreamServer;
+import com.linkedin.datastream.server.ErrorLogger;
+import com.linkedin.datastream.server.api.connector.Connector;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.PagingContext;
+import com.linkedin.restli.server.annotations.Finder;
+import com.linkedin.restli.server.annotations.Optional;
+import com.linkedin.restli.server.annotations.PagingContextParam;
+import com.linkedin.restli.server.annotations.QueryParam;
+import com.linkedin.restli.server.annotations.RestLiCollection;
+import com.linkedin.restli.server.resources.CollectionResourceTemplate;
+
+
+/**
+ * Resources classes are used by rest.li to process corresponding http request.
+ * Note that rest.li will instantiate an object each time it processes a request.
+ * So do make it thread-safe when implementing the resources.
+
+ * The format of the restli request for the health status of all server instance
+ * /diag?q=allStatus&type=connector&scope=espresso&content=componentParameters
+ * where type and scope are used by the framework to decide which component to send the request,
+ * and content is the parameter passed to the component which should implement the DiagnosticsAware interface.
+
+ * There is an extra restli call to get the status of a single server:
+ * /diag?q=status&type=connector&scope=espresso&content=componentParameters
+ * It is not intended to be exposed to other team such as Espresso, but it can be used internally for testing purpose.
+ */
+
+@RestLiCollection(name = "diag", namespace = "com.linkedin.datastream.server.diagnostics")
+public class ServerComponentHealthResources extends CollectionResourceTemplate<String, ServerComponentHealth> {
+
+  public static final String CONNECTOR_NAME = "connector";
+  private static final Logger LOG = LoggerFactory.getLogger(ServerComponentHealthResources.class);
+  private final ServerComponentHealthAggregator _aggregator;
+  private final DatastreamServer _server;
+  private final Coordinator _coordinator;
+  private final ErrorLogger _errorLogger;
+
+  public ServerComponentHealthResources(DatastreamServer datastreamServer) {
+    _aggregator = datastreamServer.getServerComponentHealthAggregator();
+    _server = datastreamServer;
+    _coordinator = datastreamServer.getCoordinator();
+    _errorLogger = new ErrorLogger(LOG, _coordinator.getInstanceName());
+  }
+
+  /**
+   Finder Reqeust to get the status of all server instances.
+   You can access this FINDER method via /diag?q=status&type=connector&scope=espresso&content=...
+   */
+  @Finder("allStatus")
+  public List<ServerComponentHealth> getAllStatus(@PagingContextParam PagingContext context,
+      @QueryParam("type") String componentType,  // Connector or Transport provider
+      @QueryParam("scope") String componentScope,  // Espresso, EspressoBootstrap and etc.
+      @QueryParam("content") @Optional String componentInputs) {
+
+    LOG.info("Restli getAllStatus request with name: %s, type: %s and content: %s.", componentType, componentScope,
+        componentInputs);
+    DiagnosticsAware component = getComponent(componentType, componentScope);
+    if (component != null) {
+      return _aggregator.getResponses(componentType, componentScope, componentInputs, component);
+    } else {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Unknown component name and type");
+      return Collections.emptyList();
+    }
+  }
+
+  /**
+   Finder Reqeust to get the status from one server  instance.
+   You can access this FINDER method via /diag?q=stat&type=connector&scope=espresso&content=...
+   */
+  @Finder("status")
+  public List<ServerComponentHealth> getStatus(@PagingContextParam PagingContext context,
+      @QueryParam("type") String componentType,
+      @QueryParam("scope") String componentScope,
+      @QueryParam("content") @Optional String componentInputs) {
+
+    LOG.info("Restli getStatus request with name: %s, type: %s and content: %s.", componentType, componentScope,
+        componentInputs);
+
+    ServerComponentHealth serverComponentHealth = new ServerComponentHealth();
+
+    DiagnosticsAware component = getComponent(componentType, componentScope);
+    if (component != null) {
+      serverComponentHealth.setStatus(component.process(componentInputs));
+      List<ServerComponentHealth> response = Arrays.asList(serverComponentHealth);
+      return response;
+    } else {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Unknown component name and type");
+      return Collections.emptyList();
+    }
+  }
+
+  // Get the component object
+  private DiagnosticsAware getComponent(String componentType, String componentScope) {
+    String componentTypeLowercase = componentType.toLowerCase();
+    if (componentTypeLowercase.equals(CONNECTOR_NAME)) {
+      Connector connector = _coordinator.getConnector(componentScope);
+      if (connector != null && connector instanceof DiagnosticsAware) {
+        return (DiagnosticsAware) connector;
+      }
+    }
+    return null;
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -25,6 +25,7 @@ import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.Coordinator;
 import com.linkedin.datastream.server.DatastreamServer;
+import com.linkedin.datastream.server.ErrorLogger;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.CreateResponse;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.server.dms;
 
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.commons.lang.Validate;
@@ -36,6 +37,10 @@ public class ZookeeperBackedDatastreamStore implements DatastreamStore {
 
   private String getZnodePath(String key) {
     return KeyBuilder.datastream(_cluster, key);
+  }
+
+  private List<String> getInstances() {
+    return _zkClient.getChildren(KeyBuilder.liveInstances(_cluster));
   }
 
   @Override

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/diagnostics/TestServerComponentHealthResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/diagnostics/TestServerComponentHealthResources.java
@@ -1,0 +1,56 @@
+package com.linkedin.datastream.server.diagnostics;
+
+import java.util.List;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.linkedin.datastream.diagnostics.ServerComponentHealth;
+import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
+import com.linkedin.datastream.server.TestDatastreamServer;
+import com.linkedin.restli.server.PagingContext;
+
+
+/**
+ * Test ServerComponentHealthResources with zookeeper backed DatastreamStore
+ */
+@Test(singleThreaded = true)
+public class TestServerComponentHealthResources {
+
+  private static final PagingContext NO_PAGING = new PagingContext(0, 0, false, false);
+
+  private EmbeddedDatastreamCluster _datastreamKafkaCluster;
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    _datastreamKafkaCluster = TestDatastreamServer.initializeTestDatastreamServerWithDummyConnector(null);
+    _datastreamKafkaCluster.startup();
+  }
+
+  @AfterMethod
+  public void cleanup() {
+    _datastreamKafkaCluster.shutdown();
+  }
+
+  @Test
+  public void testGetStatus() {
+    ServerComponentHealthResources resource =
+        new ServerComponentHealthResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+
+    String name = "Connector";
+    String type = "DummyConnector";
+    String content = "topic=datastream";
+    String expectedStatus = "HEALTHY";
+
+    List<ServerComponentHealth> response = resource.getStatus(NO_PAGING, name, type, content);
+    for (ServerComponentHealth sch : response) {
+      //Assert.assertEquals(sch.getName(), type + name);
+      Assert.assertEquals(sch.getStatus(), expectedStatus);
+      //Assert.assertEquals(sch.getStatusDetail().get(0), content);
+    }
+
+  }
+}

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
@@ -1,9 +1,11 @@
 package com.linkedin.datastream.connectors;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DiagnosticsAware;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.api.connector.Connector;
@@ -13,7 +15,7 @@ import com.linkedin.datastream.server.api.connector.DatastreamValidationExceptio
 /**
  * A trivial implementation of connector interface
  */
-public class DummyConnector implements Connector {
+public class DummyConnector implements Connector, DiagnosticsAware {
 
   public static final String VALID_DUMMY_SOURCE = "DummyConnector://DummySource";
   public static final String CONNECTOR_TYPE = "DummyConnector";
@@ -55,5 +57,15 @@ public class DummyConnector implements Connector {
   @Override
   public List<BrooklinMetricInfo> getMetricInfos() {
     return null;
+  }
+
+  @Override
+  public String process(String query) {
+    return "HEALTHY";
+  }
+
+  @Override
+  public String reduce(String query, Map<String, String> responses) {
+    return "DummyStatus";
   }
 }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/RestliUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/RestliUtils.java
@@ -4,10 +4,19 @@ import com.linkedin.restli.server.PagingContext;
 
 import java.util.stream.Stream;
 
+import org.apache.commons.lang3.StringUtils;
+
+
 /**
  * Utility class to simplify usage of Restli.
  */
 public final class RestliUtils {
+
+  private static final String DEFAULT_URI_SCHEME = "http://";
+
+  public static String sanitizeUri(String dmsUri) {
+    return StringUtils.prependIfMissing(StringUtils.appendIfMissing(dmsUri, "/"), DEFAULT_URI_SCHEME);
+  }
 
   /**
    * Applies a Paging Context to a Stream.


### PR DESCRIPTION
The format of the restli request for the health status of all server instance
/diag?q=allStatus&type=connector&scope=espresso&content=componentParameters
where type and scope are used by the framework to decide which component to send the request, and content is the parameter passed to the component which should implement the DiagnosticsAware interface.

There is an extra restli call to get the status of a single server:
/diag?q=status&type=connector&scope=espresso&content=componentParameters
It is not intended to be exposed to other team such as Espresso, but it can be used internally for testing purpose.