### PR TITLE
Allows sub dedupers to throw ValidationException

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AbstractDatastreamDeduper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AbstractDatastreamDeduper.java
@@ -64,5 +64,6 @@ public abstract class AbstractDatastreamDeduper implements DatastreamDeduper {
    * @param candidates existings streams meeting basic requirements for reuse
    * @return optional wrapper of the reusable stream
    */
-  protected abstract Optional<Datastream> dedupStreams(Datastream stream, List<Datastream> candidates);
+  protected abstract Optional<Datastream> dedupStreams(Datastream stream, List<Datastream> candidates)
+      throws DatastreamValidationException;
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 
 
 /**
@@ -17,7 +18,8 @@ public class SourceBasedDeduper extends AbstractDatastreamDeduper {
   private static final Logger LOG = LoggerFactory.getLogger(SourceBasedDeduper.class);
 
   @Override
-  public Optional<Datastream> dedupStreams(Datastream stream, List<Datastream> candidates) {
+  public Optional<Datastream> dedupStreams(Datastream stream, List<Datastream> candidates)
+      throws DatastreamValidationException {
     List<Datastream> duplicateDatastreams = candidates.stream()
         .filter(d -> d.getSource().equals(stream.getSource()))
         .collect(Collectors.toList());


### PR DESCRIPTION
Deduper implementations subclassing from AbstractDatastreamDeduper needs
to be able to throw DatastreamValidationException per DatastreamDeduper
interface. This change adds the throws statement to the abstract
dedupStream() for that. Last PR forgot to include it when introducing
the abstract class between the interface and actual implementations.