### PR TITLE
Move schema gen tests from brooklin-li-common to Datastream

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,7 @@ project(':datastream-common') {
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "com.intellij:annotations:$intellijAnnotations"
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
+    testCompile 'org.mockito:mockito-core:1.+'
   }
 }
 

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestFieldMetadata.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestFieldMetadata.java
@@ -1,0 +1,86 @@
+package com.linkedin.datastream.avrogenerator;
+
+import java.util.Optional;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit tests for FieldMetadata
+ */
+@Test
+public class TestFieldMetadata {
+
+  @Test
+  public void testFromStringPositive() throws Exception {
+    String meta = "dbFieldName=AUTHOR;dbFieldPosition=26;dbFieldType=NVARCHAR2;";
+
+    FieldMetadata fieldMetadata = FieldMetadata.fromString(meta);
+
+    Assert.assertEquals(fieldMetadata.getDbFieldName(), "AUTHOR", "Incorrectly parsed dbFieldName");
+    Assert.assertEquals(fieldMetadata.getDbFieldPosition(), 26, "Incorrectly parsed dbFieldPosition");
+    Assert.assertEquals(fieldMetadata.getDbFieldType(), Types.NVARCHAR2, "Incorrectly parsed dbFieldType");
+    Assert.assertEquals(fieldMetadata.getNumberPrecision(), Optional.empty());
+    Assert.assertEquals(fieldMetadata.getNumberScale(), Optional.empty());
+
+    // with precision and scale
+    meta = "dbFieldName=WEIGHT;dbFieldPosition=1;dbFieldType=FLOAT;numberScale=2;numberPrecision=3;";
+    fieldMetadata = FieldMetadata.fromString(meta);
+
+    Assert.assertEquals(fieldMetadata.getDbFieldName(), "WEIGHT", "Incorrectly parsed dbFieldName");
+    Assert.assertEquals(fieldMetadata.getDbFieldPosition(), 1, "Incorrectly parsed dbFieldPosition");
+    Assert.assertEquals(fieldMetadata.getDbFieldType(), Types.FLOAT, "Incorrectly parsed dbFieldType");
+    Assert.assertEquals(fieldMetadata.getNumberPrecision(), Optional.of(3), "Incorrectly parsed numberPrecision");
+    Assert.assertEquals(fieldMetadata.getNumberScale(), Optional.of(2), "Incorrectly parsed numberScale");
+  }
+
+  public void testFromStringNegative() throws Exception {
+    String meta;
+    FieldMetadata fieldMetadata;
+
+    // missing field name
+    try {
+      meta = "dbFieldPosition=1;dbFieldType=FLOAT;numberScale=2;numberPrecision=3;";
+      fieldMetadata = FieldMetadata.fromString(meta);
+      Assert.fail("Parsing field metadata from string should have failed due to missing field name");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof NullPointerException);
+    }
+
+    // missing field position
+    try {
+      meta = "dbFieldName=AUTHOR;dbFieldType=FLOAT;numberScale=2;numberPrecision=3;";
+      fieldMetadata = FieldMetadata.fromString(meta);
+      Assert.fail("Parsing field metadata from string should have failed due to missing field position");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof NullPointerException);
+    }
+
+    // missing field type
+    try {
+      meta = "dbFieldName=AUTHOR;dbFieldPosition=26;";
+      fieldMetadata = FieldMetadata.fromString(meta);
+      Assert.fail("Parsing field metadata from string should have failed due to missing field type");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof NullPointerException);
+    }
+
+    // invalid delimiter
+    try {
+      meta = "dbFieldName=AUTHOR,dbFieldPosition=26,dbFieldType=NVARCHAR2;";
+      fieldMetadata = FieldMetadata.fromString(meta);
+      Assert.fail("Parsing field metadata from string should have failed due to invalid delimiter");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof IllegalArgumentException);
+    }
+
+    try {
+      meta = "dbFieldName:AUTHOR;dbFieldPosition:26;dbFieldType:NVARCHAR2;";
+      fieldMetadata = FieldMetadata.fromString(meta);
+      Assert.fail("Parsing field metadata from string should have failed due to invalid delimiter");
+    } catch (Exception e) {
+      Assert.assertTrue(e instanceof IllegalArgumentException);
+    }
+
+  }
+}

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleDatabaseClient.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleDatabaseClient.java
@@ -1,0 +1,45 @@
+package com.linkedin.datastream.avrogenerator;
+
+import java.sql.SQLException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class TestOracleDatabaseClient {
+  private static final String JOBS_SCHEMA = "JOBS";
+  private static final String JOBS_TABLE = "JOBS";
+
+  @Test(enabled = false)
+  public void testBasic() throws SQLException {
+    String conUri = "jdbc:oracle:thin:jobs/jobs8uat@//lca1-eitm-jobs.stg.linkedin.com:1521/EI_EITM_JOBS";
+    OracleDatabaseClient client = new OracleDatabaseClient(conUri);
+    client.initializeConnection();
+
+    boolean b = client.isTable(JOBS_SCHEMA, JOBS_TABLE);
+    Assert.assertEquals(b, true);
+
+    b = client.isPrimitive("VARCHAR2");
+    Assert.assertEquals(b, true);
+
+    b = client.isPrimitive("NUMBER");
+    Assert.assertEquals(b, true);
+
+    b = client.isPrimitive("DATABUS_GEO_T");
+    Assert.assertEquals(b, false);
+
+    b = client.isStruct(JOBS_SCHEMA, "DATABUS_GEO_T");
+    Assert.assertEquals(b, true);
+
+    b = client.isCollection(JOBS_SCHEMA, "DATABUS_COMPANY_ARRAY_T");
+    Assert.assertEquals(b, true);
+
+    OracleDatabaseClient.CollectionMetadata metadata = client.getCollectionMetadata(JOBS_SCHEMA, "DATABUS_COMPANY_ARRAY_T");
+    Assert.assertEquals("DATABUS_COMPANY_T", metadata.getElementFieldTypeName());
+    Assert.assertEquals(metadata.getElementPrecision(), 0);
+    Assert.assertEquals(metadata.getElementScale(), 0);
+    Assert.assertEquals(metadata.getElementSchemaName(), "JOBS");
+
+    client.closeConnection();
+  }
+}

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
@@ -1,0 +1,76 @@
+package com.linkedin.datastream.avrogenerator;
+
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class TestOraclePrimitive {
+
+  @Test
+  public void testConstructor() {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "string");
+    Assert.assertEquals(primitive.getFieldTypeName(), "VARCHAR2");
+    Assert.assertEquals(primitive.getSchemaName(), null);
+
+    primitive = new OraclePrimitiveType("CLOB", 0, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "string");
+
+    primitive = new OraclePrimitiveType("DATE", 0, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "long");
+
+    primitive = new OraclePrimitiveType("BLOB", 0, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "bytes");
+
+    primitive = new OraclePrimitiveType("NUMBER", 1, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "float");
+
+    primitive = new OraclePrimitiveType("NUMBER", 7, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "double");
+
+    primitive = new OraclePrimitiveType("NUMBER", 0, 10);
+    Assert.assertEquals(primitive.getAvroFieldName(), "long");
+
+    primitive = new OraclePrimitiveType("NUMBER", 0, 1);
+    Assert.assertEquals(primitive.getAvroFieldName(), "int");
+
+    primitive = new OraclePrimitiveType("NUMBER", -127, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "string");
+
+    primitive = new OraclePrimitiveType("NUMBER", 0, 0);
+    Assert.assertEquals(primitive.getAvroFieldName(), "string");
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testInvalidScale() {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("NUMBER", 18, 0);
+  }
+
+  @Test
+  public void testGetMetadata() {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=VARCHAR2;");
+
+    primitive = new OraclePrimitiveType("NUMBER", 10, 10);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=DOUBLE;numberScale=10;numberPrecision=10;");
+
+    primitive = new OraclePrimitiveType("NUMBER", -127, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;numberScale=-127;numberPrecision=0;");
+
+    primitive = new OraclePrimitiveType("TIMESTAMP", -127, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=TIMESTAMP;");
+  }
+
+  @Test
+  public void testToAvro() {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("NUMBER", 0, 10);
+    Map<String, Object> info = primitive.toAvro().info();
+    String[] types = (String[]) info.get("type");
+
+
+    Assert.assertEquals(types[0], "null");
+    Assert.assertEquals(types[1], "long");
+  }
+}

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleStruct.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleStruct.java
@@ -1,0 +1,52 @@
+package com.linkedin.datastream.avrogenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class TestOracleStruct {
+
+  @Test
+  public void testConstructorBasic() {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
+    OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
+
+    List<OracleColumn> list = new ArrayList<>();
+    list.add(col1);
+    list.add(col2);
+
+    OracleStructType struct = new OracleStructType("JOBS", "fieldName", list);
+
+    Assert.assertNotNull(struct);
+    Assert.assertEquals(struct.getAvroFieldName(), "record");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testToAvro() throws Exception {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
+    OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
+
+    List<OracleColumn> list = new ArrayList<>();
+    list.add(col1);
+    list.add(col2);
+
+    OracleStructType struct = new OracleStructType("JOBS", "fieldName", list);
+
+    Map<String, Object> info = struct.toAvro().info();
+    List<Object> types = (List<Object>) info.get("type");
+    Map<String, Object> recordType = (Map<String, Object>) types.get(0);
+
+
+    Assert.assertEquals((String) types.get(1), "null");
+    Assert.assertEquals((String) recordType.get("type"), "record");
+    Assert.assertEquals((String) recordType.get("name"), "fieldName");
+    Assert.assertNotNull(recordType.get("fields"));
+  }
+}

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTable.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTable.java
@@ -1,0 +1,47 @@
+package com.linkedin.datastream.avrogenerator;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.avro.Schema;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class TestOracleTable {
+
+  @Test
+  public void testConstructorBasic() {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
+    OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
+
+    List<OracleColumn> list = new ArrayList<>();
+    list.add(col1);
+    list.add(col2);
+
+    // should nto throw error
+    OracleTable table = new OracleTable("tableName", "schemaName", list, "primaryKey");
+
+    Assert.assertNotNull(table);
+  }
+
+  @Test
+  public void testToAvro() throws Exception {
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
+    OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
+
+    List<OracleColumn> list = new ArrayList<>();
+    list.add(col1);
+    list.add(col2);
+
+    OracleTable table = new OracleTable("tableName", "schemaName", list, "primaryKey");
+
+    Schema fullSchema = table.toAvro().toSchema();
+
+    Assert.assertEquals(fullSchema.getNamespace(), "com.linkedin.events.schemaname");
+    Assert.assertEquals(fullSchema.getProp("meta"), "dbTableName=tableName;pk=primaryKey;");
+    Assert.assertTrue(fullSchema.getType().equals(Schema.Type.RECORD));
+  }
+}

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTableFactory.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTableFactory.java
@@ -1,0 +1,38 @@
+package com.linkedin.datastream.avrogenerator;
+
+import java.util.Collections;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class TestOracleTableFactory {
+  @Test
+  public void testE2EBuildFieldTypeFactory() throws Exception {
+    OracleDatabaseClient client = Mockito.mock(OracleDatabaseClient.class);
+    DatabaseSource.TableMetadata meta = new DatabaseSource.TableMetadata("CHAR", "name", 0, 0);
+
+    Mockito.when(client.getTableMetadata("schema", "view")).thenReturn(Collections.singletonList(meta));
+    Mockito.when(client.isPrimitive("CHAR")).thenReturn(true);
+
+    OracleTableFactory factory = new OracleTableFactory(client);
+
+    OracleTable table = factory.buildOracleTable("schema", "view", "key");
+  }
+
+  @Test
+  public void testAbsentPrimaryKey() throws Exception {
+    OracleDatabaseClient client = Mockito.mock(OracleDatabaseClient.class);
+    DatabaseSource.TableMetadata meta = new DatabaseSource.TableMetadata("CHAR", "name", 0, 0);
+
+    Mockito.when(client.getTableMetadata("schema", "view")).thenReturn(Collections.singletonList(meta));
+    Mockito.when(client.isPrimitive("CHAR")).thenReturn(true);
+    Mockito.when(client.getPrimaryKeyFields("view")).thenReturn(Collections.singletonList("pk_field"));
+
+    OracleTableFactory factory = new OracleTableFactory(client);
+    OracleTable table = factory.buildOracleTable("schema", "view", null);
+
+    Assert.assertEquals(table.getPrimaryKey(), "pkField");
+  }
+}


### PR DESCRIPTION
Sadman was working on moving the schema generator code from li-common to Datastream. However he didn't move the unit tests over. This PR moves the open-source avro schema generator unit tests over.