### PR TITLE
Handle Oracle types with spaces in their name

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/FieldMetadata.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/FieldMetadata.java
@@ -73,7 +73,7 @@ public class FieldMetadata {
         String.format("Missing metadata %s from meta string %s", OracleColumn.COL_NAME, meta));
     int fieldPosition = Integer.valueOf(Preconditions.checkNotNull(metas.get(OracleColumn.COL_POSITION),
         String.format("Missing metadata %s from meta string %s", OracleColumn.COL_POSITION, meta)));
-    Types fieldType = Types.valueOf(Preconditions.checkNotNull(metas.get(FieldType.FIELD_TYPE_NAME),
+    Types fieldType = Types.fromString(Preconditions.checkNotNull(metas.get(FieldType.FIELD_TYPE_NAME),
         String.format("Missing metadata %s from meta string %s", FieldType.FIELD_TYPE_NAME, meta)));
 
     Optional<Integer> numberPrecision =

--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OraclePrimitiveType.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OraclePrimitiveType.java
@@ -35,7 +35,7 @@ public class OraclePrimitiveType implements FieldType {
       fieldTypeName = fieldTypeName.substring(4);
     }
 
-    _type = Types.valueOf(fieldTypeName);
+    _type = Types.fromString(fieldTypeName);
   }
 
   @Override

--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/Types.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/Types.java
@@ -37,4 +37,16 @@ public enum Types {
     return _avroType;
   }
 
+  /**
+   * Use instead of Types.valueOf(String) because this properly handles spaces in the String.
+   */
+  public static Types fromString(String str) {
+    return Types.valueOf(str.replace(" ", "_"));
+  }
+
+  @Override
+  public String toString() {
+    return this.name().replace("_", " ");
+  }
+
 }

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestFieldMetadata.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestFieldMetadata.java
@@ -32,6 +32,10 @@ public class TestFieldMetadata {
     Assert.assertEquals(fieldMetadata.getDbFieldType(), Types.FLOAT, "Incorrectly parsed dbFieldType");
     Assert.assertEquals(fieldMetadata.getNumberPrecision(), Optional.of(3), "Incorrectly parsed numberPrecision");
     Assert.assertEquals(fieldMetadata.getNumberScale(), Optional.of(2), "Incorrectly parsed numberScale");
+
+    meta = "dbFieldName=ARTICLE;dbFieldPosition=1;dbFieldType=LONG RAW;";
+    fieldMetadata = FieldMetadata.fromString(meta);
+    Assert.assertEquals(fieldMetadata.getDbFieldType(), Types.LONG_RAW, "Incorrectly parsed dbFieldType");
   }
 
   public void testFromStringNegative() throws Exception {


### PR DESCRIPTION
Some Oracle column types (i.e. "LONG RAW") have spaces in them. Add methods to help with parsing between the enum and its string representation, which is used in OracleMetadataEvent as well as the schema metadata.