### PR TITLE
Kafka Connector Retry Logic

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,7 +121,7 @@ project(':datastream-common') {
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "com.intellij:annotations:$intellijAnnotations"
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
-    testCompile 'org.mockito:mockito-core:1.+'
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 }
 
@@ -148,7 +148,7 @@ project(':datastream-file-connector') {
     compile project(':datastream-utils')
     testCompile project(':datastream-server')
     testCompile project(':datastream-testcommon')
-    testCompile 'org.mockito:mockito-core:1.+'
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 }
 
@@ -157,7 +157,7 @@ project(':datastream-mysql-connector') {
     compile project(':datastream-server-api')
     compile "org.apache.avro:avro:$avroVersion"
     compile "com.zendesk:open-replicator:1.4.2"
-    testCompile 'org.mockito:mockito-core:1.+'
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile project(':datastream-testcommon')
   }
   test {
@@ -169,7 +169,7 @@ project(':brooklin-oracle-tb-connector') {
   dependencies {
     compile project(':datastream-server-api')
     compile "org.apache.avro:avro:$avroVersion"
-    testCompile 'org.mockito:mockito-core:1.+'
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
     testCompile project(':datastream-testcommon')
     test {
       workingDir(project.projectDir.toString() + "/..")
@@ -214,6 +214,7 @@ project(':datastream-kafka-connector') {
     compile "commons-validator:commons-validator:1.5.1"
 
     testCompile project(':datastream-kafka')
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 }
 
@@ -312,7 +313,7 @@ project(':datastream-server') {
     testCompile project(':datastream-client')
     testCompile project(':datastream-file-connector')
     testCompile project(':datastream-testcommon')
-    testCompile "org.mockito:mockito-core:1.+"
+    testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 
   tasks.create(name: "copyDependantLibs", type: Copy) {

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -16,4 +16,5 @@ ext {
     metricsCoreVersion = "3.1.2"
     eventHubVersion = "0.9.0"
     samzaVersion = "0.11.0"
+    mockitoVersion = "1.+"
 }


### PR DESCRIPTION
Adding Retry Logic (with sleep between retry) to the kafka connector.

The idea is to avoid overwhelming with retry a server in case the
pipeline get stuck in a single message.

Also adding a new Option to datastream, to skip bad messages after 5
retries.