### PR TITLE
support update datastream

### DIFF
--- a/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
+++ b/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
@@ -9,7 +9,7 @@
       "name" : "datastreamId",
       "type" : "string"
     },
-    "supports" : [ "create", "delete", "get", "get_all", "update" ],
+    "supports" : [ "batch_update", "create", "delete", "get", "get_all", "update" ],
     "methods" : [ {
       "method" : "create"
     }, {
@@ -18,6 +18,8 @@
       "method" : "update"
     }, {
       "method" : "delete"
+    }, {
+      "method" : "batch_update"
     }, {
       "method" : "get_all"
     } ],

--- a/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
+++ b/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
@@ -99,7 +99,7 @@
         "name" : "datastreamId",
         "type" : "string"
       },
-      "supports" : [ "create", "delete", "get", "get_all", "update" ],
+      "supports" : [ "batch_update", "create", "delete", "get", "get_all", "update" ],
       "methods" : [ {
         "method" : "create"
       }, {
@@ -108,6 +108,8 @@
         "method" : "update"
       }, {
         "method" : "delete"
+      }, {
+        "method" : "batch_update"
       }, {
         "method" : "get_all"
       } ],

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -47,4 +47,17 @@ public interface Connector extends MetricsAware {
    */
   void initializeDatastream(Datastream stream, List<Datastream> allDatastreams) throws DatastreamValidationException;
 
+  /**
+   * Validate the update datastreams operation. By default this is not supported. Any connectors that want to support
+   * datastream updates should override this method to perform the validation needed.
+   * @param datastreams list of datastreams to be updated
+   * @param allDatastreams all existing datastreams in the system of connector type of the datastream that is being
+   *                       validated.
+   * @throws DatastreamValidationException when the datastreams update is not valid
+   */
+  default void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
+    throw new DatastreamValidationException("Datastream update is not supported");
+  }
+
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -136,6 +136,13 @@ public class ConnectorWrapper {
     logApiEnd("initializeDatastream");
   }
 
+  public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
+    logApiStart("validateUpdateDatastreams");
+    _connector.validateUpdateDatastreams(datastreams, allDatastreams);
+    logApiEnd("validateUpdateDatastreams");
+  }
+
   public long getNumDatastreams() {
     return _numDatastreams.get();
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -5,14 +5,20 @@ public class CoordinatorEvent {
   public enum EventType {
     LEADER_DO_ASSIGNMENT,
     HANDLE_ASSIGNMENT_CHANGE,
+    HANDLE_DATASTREAM_CHANGE_WITH_UPDATE,
     HANDLE_ADD_OR_DELETE_DATASTREAM,
     HANDLE_INSTANCE_ERROR,
     HEARTBEAT
   }
 
-  public static final CoordinatorEvent LEADER_DO_ASSIGNMENT_EVENT = new CoordinatorEvent(EventType.LEADER_DO_ASSIGNMENT);
-  public static final CoordinatorEvent HANDLE_ASSIGNMENT_CHANGE_EVENT = new CoordinatorEvent(EventType.HANDLE_ASSIGNMENT_CHANGE);
-  public static final CoordinatorEvent HANDLE_ADD_OR_DELETE_DATASTREAM_EVENT = new CoordinatorEvent(EventType.HANDLE_ADD_OR_DELETE_DATASTREAM);
+  public static final CoordinatorEvent LEADER_DO_ASSIGNMENT_EVENT =
+      new CoordinatorEvent(EventType.LEADER_DO_ASSIGNMENT);
+  public static final CoordinatorEvent HANDLE_ASSIGNMENT_CHANGE_EVENT =
+      new CoordinatorEvent(EventType.HANDLE_ASSIGNMENT_CHANGE);
+  public static final CoordinatorEvent HANDLE_DATASTREAM_CHANGE_WITH_UPDATE_EVENT =
+      new CoordinatorEvent(EventType.HANDLE_DATASTREAM_CHANGE_WITH_UPDATE);
+  public static final CoordinatorEvent HANDLE_ADD_OR_DELETE_DATASTREAM_EVENT =
+      new CoordinatorEvent(EventType.HANDLE_ADD_OR_DELETE_DATASTREAM);
   public static final CoordinatorEvent HEARTBEAT_EVENT = new CoordinatorEvent(EventType.HEARTBEAT);
 
   protected final EventType _eventType;
@@ -36,6 +42,10 @@ public class CoordinatorEvent {
 
   public static CoordinatorEvent createHandleAssignmentChangeEvent() {
     return HANDLE_ASSIGNMENT_CHANGE_EVENT;
+  }
+
+  public static CoordinatorEvent createHandleDatastreamChangeEvent() {
+    return HANDLE_DATASTREAM_CHANGE_WITH_UPDATE_EVENT;
   }
 
   public static CoordinatorEvent createHandleDatastreamAddOrDeleteEvent() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -45,7 +45,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamTask.class.getName());
 
   private static final String STATUS = "STATUS";
-  private List<Datastream> _datastreams;
+  private volatile List<Datastream> _datastreams;
 
   private HashMap<Integer, String> _checkpoints = new HashMap<>();
 
@@ -176,6 +176,12 @@ public class DatastreamTaskImpl implements DatastreamTask {
     return _checkpoints;
   }
 
+  /**
+   * Get the list of datastreams for the datastream task. Note that the datastreams may change
+   * between onAssignmentChange (because of datastream update for example). It's connector's
+   * responsibility to re-fetch the datastream list even when it receives the exact same set
+   * of datastream tasks.
+   */
   @JsonIgnore
   @Override
   public List<Datastream> getDatastreams() {
@@ -202,6 +208,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   public void setDatastreams(List<Datastream> datastreams) {
     _datastreams = datastreams;
+    // destination and connector type should be immutable
     _transportProviderName = _datastreams.get(0).getTransportProviderName();
     _connectorType = _datastreams.get(0).getConnectorName();
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -128,6 +128,10 @@ public class EventProducer implements DatastreamEventProducer {
     _logger.info(String.format("Created event producer with customCheckpointing=%s", customCheckpointing));
 
     _dynamicMetricsManager = DynamicMetricsManager.getInstance();
+    // provision some metrics to force them to create
+    _dynamicMetricsManager.createOrUpdateCounter(MODULE, AGGREGATE, EVENTS_PRODUCED_OUTSIDE_SLA, 0);
+    _dynamicMetricsManager.createOrUpdateCounter(MODULE, _datastreamTask.getConnectorType(),
+        EVENTS_PRODUCED_OUTSIDE_SLA, 0);
   }
 
   public int getProducerId() {
@@ -197,6 +201,9 @@ public class EventProducer implements DatastreamEventProducer {
             EVENTS_PRODUCED_WITHIN_SLA, 1);
       } else {
         _dynamicMetricsManager.createOrUpdateCounter(MODULE, metadata.getTopic(), EVENTS_PRODUCED_OUTSIDE_SLA, 1);
+        _dynamicMetricsManager.createOrUpdateCounter(MODULE, AGGREGATE, EVENTS_PRODUCED_OUTSIDE_SLA, 1);
+        _dynamicMetricsManager.createOrUpdateCounter(MODULE, _datastreamTask.getConnectorType(),
+            EVENTS_PRODUCED_OUTSIDE_SLA, 1);
         _logger.debug(
             String.format("Event latency of %d for source %s, topic %s, partition %d exceeded SLA of %d milliseconds",
                 sourceToDestinationLatencyMs, _datastreamTask.getDatastreamSource().getConnectionString(),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -27,11 +27,12 @@ public interface DatastreamStore {
 
   /**
    * Updates the datastream associated with the given key with the provided one.
-   * @param key
-   * @param datastream
+   * @param key datastream name of the original datastream to be updated
+   * @param datastream content of the updated datastream
+   * @param notifyleader whether to notify leader about the update
    * @throws DatastreamException
    */
-  void updateDatastream(String key, Datastream datastream) throws DatastreamException;
+  void updateDatastream(String key, Datastream datastream, boolean notifyLeader) throws DatastreamException;
 
   /**
    * Creates a new datastream and associates it with the provided key.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
@@ -72,25 +72,17 @@ public class ZookeeperBackedDatastreamStore implements DatastreamStore {
   }
 
   @Override
-  public void updateDatastream(String key, Datastream datastream) throws DatastreamException {
-    // Updating a Datastream is still tricky for now. Changing either the
-    // the source or target may result in failure on connector.
-    // We only support changes of the "status field"
-
+  public void updateDatastream(String key, Datastream datastream, boolean notifyLeader) throws DatastreamException {
     Datastream oldDatastream = getDatastream(key);
     if (oldDatastream == null) {
       throw new DatastreamException("Datastream does not exists, can not be updated: " + key);
     }
 
-    oldDatastream.setStatus(datastream.getStatus());
-
-    if (!datastream.equals(oldDatastream)) {
-      throw new DatastreamException("Only changes to the 'status' field are supported at this time.");
-    }
-
     String json = DatastreamUtils.toJSON(datastream);
     _zkClient.writeData(getZnodePath(key), json);
-    notifyLeaderOfDataChange();
+    if (notifyLeader) {
+      notifyLeaderOfDataChange();
+    }
   }
 
   @Override

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -8,6 +8,7 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
+import java.util.stream.Stream;
 
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -29,10 +30,12 @@ import com.linkedin.datastream.server.TestDatastreamServer;
 import com.linkedin.data.template.StringMap;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.ActionResult;
+import com.linkedin.restli.server.BatchUpdateRequest;
 import com.linkedin.restli.server.CreateResponse;
 import com.linkedin.restli.server.PagingContext;
 import com.linkedin.restli.server.PathKeys;
 import com.linkedin.restli.server.RestLiServiceException;
+import com.linkedin.restli.server.UpdateResponse;
 
 
 /**
@@ -208,6 +211,73 @@ public class TestDatastreamResources {
     } catch (RestLiServiceException e) {
       Assert.assertEquals(e.getStatus(), status);
     }
+  }
+
+  private Datastream createAndWaitUntilInitialized(DatastreamResources resources, Datastream ds) {
+    resources.create(ds);
+    Assert.assertTrue(
+        PollUtils.poll(() -> resources.get(ds.getName()).getStatus().equals(DatastreamStatus.READY), 100, 10000));
+    return resources.get(ds.getName());
+  }
+
+  @Test
+  public void testUpdateDatastream() throws Exception {
+    DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+
+    Datastream originalDatastream1 = generateDatastream(1);
+    Datastream originalDatastream2 = generateDatastream(2);
+    checkBadRequest(() -> resource.update("none", originalDatastream1), HttpStatus.S_400_BAD_REQUEST);
+    checkBadRequest(() -> resource.update(originalDatastream1.getName(), originalDatastream1),
+        HttpStatus.S_404_NOT_FOUND);
+
+    Datastream datastream1 = createAndWaitUntilInitialized(resource, originalDatastream1);
+    Datastream datastream2 = createAndWaitUntilInitialized(resource, originalDatastream2);
+
+    datastream1.getMetadata().put("key", "value");
+    UpdateResponse response = resource.update(datastream1.getName(), datastream1);
+    Assert.assertEquals(response.getStatus(), HttpStatus.S_200_OK);
+    Assert.assertTrue(PollUtils.poll(() -> {
+      Datastream updatedDatastream1 = resource.get(datastream1.getName());
+      return updatedDatastream1.getMetadata().get("key").equals("value");
+    }, 100, 10000));
+
+    Datastream modifyDestination = generateDatastream(1);
+    modifyDestination.getDestination().setConnectionString("updated");
+    checkBadRequest(() -> resource.update(modifyDestination.getName(), modifyDestination),
+        HttpStatus.S_400_BAD_REQUEST);
+
+    Datastream modifyStatus = generateDatastream(1);
+    modifyStatus.setStatus(DatastreamStatus.PAUSED);
+    checkBadRequest(() -> resource.update(modifyStatus.getName(), modifyStatus), HttpStatus.S_400_BAD_REQUEST);
+
+    datastream1.getMetadata().put("key", "value2");
+    datastream2.getDestination().setConnectionString("updated");
+    BatchUpdateRequest<String, Datastream> request = new BatchUpdateRequest<>(
+        Stream.of(datastream1, datastream2).collect(Collectors.toMap(Datastream::getName, ds -> ds)));
+    try {
+      resource.batchUpdate(request);
+      Assert.fail("Should have failed");
+    } catch (RestLiServiceException e) {
+      // do nothing
+    }
+
+
+    // make sure that on a failed batch update even the valid datastream update doesn't go through
+    Thread.sleep(200);
+    Datastream updatedDatastream = resource.get(datastream1.getName());
+    // we might get false positive result because of the zk delay
+    // if we get flaky result here that means something is wrong
+    Assert.assertEquals(updatedDatastream.getMetadata().get("key"), "value");
+
+    datastream2 = resource.get(datastream2.getName());
+    request = new BatchUpdateRequest<>(
+        Stream.of(datastream1, datastream2).collect(Collectors.toMap(Datastream::getName, ds -> ds)));
+    resource.batchUpdate(request);
+
+    Assert.assertTrue(PollUtils.poll(() -> {
+      Datastream updatedDatastream1 = resource.get(datastream1.getName());
+      return updatedDatastream1.getMetadata().get("key").equals("value2");
+    }, 100, 10000));
   }
 
   @Test

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
@@ -55,6 +55,11 @@ public class DummyConnector implements Connector, DiagnosticsAware {
   }
 
   @Override
+  public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
+  }
+
+  @Override
   public List<BrooklinMetricInfo> getMetricInfos() {
     return null;
   }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -151,7 +151,7 @@ public class DatastreamTestUtils {
       zkClient.ensurePath(KeyBuilder.datastreams(cluster));
       CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, cluster);
       ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, cluster);
-      dsStore.updateDatastream(datastream.getName(), datastream);
+      dsStore.updateDatastream(datastream.getName(), datastream, true);
     }
   }
 }


### PR DESCRIPTION
Support update datastream:

1. allow update and batch_update datastream call in DatastreamResources.java
2. introduce validateUpdateDatastream in connnector to verify datastream updates (by default it won't allow datastream updates; only those connectors who implement this method can allow datastream updates)
3. dms notifies everyone the update by touching every instance's "assignments" node (e.g. cluster/instances/instance-01/assignments)
4. Coordinator to subscribe to changes on "assignments" node and process it as a "datastream update" event
5. Coordinator invalidate all the cache entries it has for datastreams to re-fetch all data from zk
6. Coordinator performs a onAssignmentChange on all connectors (even if the task lists remain the same)