### PR TITLE
Add UID field to DatastreamMetadataConstants

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -14,7 +14,7 @@ public class DatastreamMetadataConstants {
    * Whether the datastream should reuse existing datastream's destination if it is available.
    */
   public static final String REUSE_EXISTING_DESTINATION_KEY = "system.reuseExistingDestination";
-  
+
   /**
    * Prefix any event metadata with this if transport supports sending metadata with events.
    */
@@ -50,4 +50,10 @@ public class DatastreamMetadataConstants {
    * Position at which the ingestion should start for the datastream.
    */
   public static final String START_POSITION = "system.start.position";
+
+  /**
+   * UID is added and reserved for the future usage. If set, it could be used
+   * to identity the datastream/topic name to prevent duplications.
+   */
+   public static final String UID = "uid";
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1085,7 +1085,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       throw e;
     }
 
-    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(Instant.now().toEpochMilli()));
+    datastream.getMetadata().putIfAbsent(DatastreamMetadataConstants.CREATION_MS, String.valueOf(Instant.now().toEpochMilli()));
   }
 
   private void populateDatastreamDestinationFromExistingDatastream(Datastream datastream, Datastream existingStream) {


### PR DESCRIPTION
For now, CREATION_MS is appended to the topic name to identify the topic uniquely.
UID is added and reserved for the future usage. If UID is set, it will be appended
to the KAC topic name to replace CREATION_MS.

Another change is to not override the creation time metadata if it's already set.