### PR TITLE
Register metric for SKIPPED_BAD_MESSAGES meter

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -364,6 +364,7 @@ public class KafkaConnectorTask implements Runnable {
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + EVENTS_PROCESSED_RATE));
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + EVENTS_BYTE_PROCESSED_RATE));
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + ERROR_RATE));
+    metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + SKIPPED_BAD_MESSAGES_RATE));
 
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + REBALANCE_RATE));
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX_REGEX + NUM_KAFKA_POLLS));


### PR DESCRIPTION
This is to fix a bug, that the metric does not show up in InGraph