### PR TITLE
Add null default to generated Avros to handle adding new column

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OracleColumn.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OracleColumn.java
@@ -74,7 +74,7 @@ public class OracleColumn {
    */
   public AvroJson toAvro() {
     AvroJson typeAvro = getFieldType().toAvro();
-
+    typeAvro.nullDefault();
     typeAvro.setName(lowerCamel(getColName()));
     typeAvro.setMeta(buildMetadata(getColName(), getColPosition(), getFieldType().getMetadata()));
 

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTable.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTable.java
@@ -43,5 +43,8 @@ public class TestOracleTable {
     Assert.assertEquals(fullSchema.getNamespace(), "com.linkedin.events.schemaname");
     Assert.assertEquals(fullSchema.getProp("meta"), "dbTableName=tableName;pk=primaryKey;");
     Assert.assertTrue(fullSchema.getType().equals(Schema.Type.RECORD));
+    for (Schema.Field field : fullSchema.getFields()) {
+      Assert.assertNotNull(field.defaultValue());
+    }
   }
 }


### PR DESCRIPTION
Schema fields need to have implicit default value (i.e. "null") so that any time a column is added, the new generated Avro will be compatible with older records.