### PR TITLE
Add datastream TTL and cleanup when it expires

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -56,4 +56,10 @@ public class DatastreamMetadataConstants {
    * to identity the datastream/topic name to prevent duplications.
    */
    public static final String UID = "uid";
+
+  /**
+   * Connector can use this for datastreams with finite set of events such that
+   * can be deleted after TTL expires. The TTL is expressed as miliseconds.
+   */
+  public static final String TTL_MS = "system.ttl.ms";
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamGroup.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamGroup.java
@@ -77,4 +77,10 @@ public class DatastreamGroup {
   public boolean belongsTo(DatastreamTask task) {
     return  task.getTaskPrefix().equals(getTaskPrefix());
   }
+
+  @Override
+  public String toString() {
+    String streamNames = _datastreams.stream().map(Datastream::getName).collect(Collectors.joining(","));
+    return "DatastreamGroup{" + "taskPrefix='" + _taskPrefix + '\'' + ", datastreams=" + streamNames + '}';
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AbstractDatastreamDeduper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AbstractDatastreamDeduper.java
@@ -24,6 +24,10 @@ import static com.linkedin.datastream.common.DatastreamUtils.getPayloadSerDe;
  *
  * Deduper subclasses should override {@link AbstractDatastreamDeduper#dedupStreams}
  * to apply any additional dedup logic.
+ *
+ * Note that {@link com.linkedin.datastream.common.DatastreamMetadataConstants#TTL_MS}
+ * is not considered by the base deduper such that it is up to the sub deduper to
+ * choose the most appropriate action for duping streams with different TTLs.
  */
 public abstract class AbstractDatastreamDeduper implements DatastreamDeduper {
   @Override

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -5,13 +5,16 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.I0Itec.zkclient.IZkChildListener;
+import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.annotations.VisibleForTesting;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamUtils;
@@ -22,10 +25,12 @@ import com.linkedin.datastream.server.zk.KeyBuilder;
 /**
  * Class that maintains the cache of all the datastreams in the datastream cluster.
  *
- * List of all the datastream names are always kept up-to date. But the complete datastream objects are lazily read
- * from the zookeeper when they are requested.
+ * List of all the datastream names are always kept up-to date (barring ZK watcher delay).
+ * But the complete datastream objects are lazily read from the zookeeper when they are
+ * requested.
  *
- * Note : This layer assumes that the datastreams are not updated once they are created.
+ * Note: Caller of this class is expected to call invalidateAllCache for any datastream
+ * update events such that any future datastream accesses will update the cached copies.
  */
 public class CachedDatastreamReader {
   private static final Logger LOG = LoggerFactory.getLogger(CachedDatastreamReader.class);
@@ -47,27 +52,27 @@ public class CachedDatastreamReader {
 
     // Be notified of changes to the children list in order to cache it. The listener creates a copy of the list
     // because other listeners could potentially get access to it and modify its contents.
-    _zkclient.subscribeChildChanges(path, new IZkChildListener() {
-      @Override
-      public void handleChildChange(String parentPath, List<String> currentChildren) throws Exception {
-        synchronized (CachedDatastreamReader.this) {
-          LOG.debug(
-              String.format("Received datastream add or delete notification. parentPath %s, children %s", parentPath,
-                  currentChildren));
-          _datastreamNames = new ArrayList<>(currentChildren);
-          Set<String> datastreamsRemoved = new HashSet<>(_datastreams.keySet());
-          datastreamsRemoved.removeAll(_datastreamNames);
-          if (!datastreamsRemoved.isEmpty()) {
-            LOG.info(String.format("Removing the deleted datastreams {%s} from cache", datastreamsRemoved));
-            _datastreams.keySet().removeAll(datastreamsRemoved);
-          }
-
-          LOG.debug("New datastream list in the cache: %s", _datastreamNames);
+    _zkclient.subscribeChildChanges(path, (parentPath, currentChildren) -> {
+      synchronized (CachedDatastreamReader.this) {
+        LOG.debug(
+            String.format("Received datastream add or delete notification. parentPath %s, children %s", parentPath,
+                currentChildren));
+        _datastreamNames = new ArrayList<>(currentChildren);
+        Set<String> datastreamsRemoved = new HashSet<>(_datastreams.keySet());
+        datastreamsRemoved.removeAll(_datastreamNames);
+        if (!datastreamsRemoved.isEmpty()) {
+          LOG.info(String.format("Removing the deleted datastreams {%s} from cache", datastreamsRemoved));
+          _datastreams.keySet().removeAll(datastreamsRemoved);
         }
+
+        LOG.debug("New datastream list in the cache: %s", _datastreamNames);
       }
     });
   }
 
+  /**
+   * Get the current datastream groups in the cache (no calls to ZK).
+   */
   public synchronized List<DatastreamGroup> getDatastreamGroups() {
     List<Datastream> allStreams = getAllDatastreams(false);
 
@@ -81,55 +86,100 @@ public class CachedDatastreamReader {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Get the current list of datastream names in the cache (no calls to ZK).
+   */
   public synchronized List<String> getAllDatastreamNames() {
     return Collections.unmodifiableList(_datastreamNames);
   }
 
+  /**
+   * Get the current list of datastreams in the cache (no calls to ZK).
+   */
   public synchronized List<Datastream> getAllDatastreams() {
     return getAllDatastreams(false);
   }
 
+  /**
+   * Get the current list of datastreams in the cache. Caveat: if flushCache
+   * is false, there could be a very short window (ZK watcher latency) that
+   * the returned list is out-of-sync with ZK. Caller should be aware of this.
+   * @param flushCache if true, all datastreams should be refetched from ZK
+   */
   public synchronized List<Datastream> getAllDatastreams(boolean flushCache) {
     if (flushCache) {
       _datastreamNames = fetchAllDatastreamNamesFromZk();
     }
 
-    return _datastreamNames.stream().map(x -> this.getDatastream(x, flushCache)).collect(Collectors.toList());
+    return _datastreamNames.stream()
+        .map(x -> this.getDatastream(x, flushCache))
+        .filter(Objects::nonNull) // getDatastream can return null when the stream is just deleted in ZK
+        .collect(Collectors.toList());
   }
 
   /**
    * Invalidate all cache entries to force the reader to get fresh copy of the data from zk.
-   * While the list of datastreams is always up-to-date, there is no guarantee that the CacheDatastreamReader
-   * is keeping a fresh copy of the actual content. Calling this function would effectively make
-   * sure any following getDatastream calls get a newer copy of data.
+   * While the list of datastreams is mostly up-to-date (zk watcher delay), there is no guarantee
+   * that the CacheDatastreamReader is keeping a fresh copy of the actual content. Calling this
+   * function would effectively make sure any following getDatastream calls get a newer copy of data.
    */
   public synchronized void invalidateAllCache() {
     LOG.info("About to invalidate all cache entries...");
     _datastreams.clear();
   }
 
+  /**
+   * Lookup the cached datastream based on its name with the option to access ZK for latest copy.
+   * @param datastreamName name of the datastream
+   * @param flushCache whether zk should be accessed regardless of cache hits
+   * @return the datastream object if exists; or null not exists in either cache or ZK
+   */
+  @VisibleForTesting
   Datastream getDatastream(String datastreamName, boolean flushCache) {
     Datastream ds = _datastreams.get(datastreamName);
     if (ds == null || flushCache) {
       ds = getDatastreamFromZk(datastreamName);
 
-      // If it has destination connection string populated then it is a complete datastream, cache it.
-      if (ds.hasDestination() && ds.getDestination().hasConnectionString()) {
+      if (ds == null) {
+        LOG.info("Datastream {} does not exist in cache/ZK.", datastreamName);
+      } else if (!DatastreamUtils.hasValidDestination(ds)) {
+        LOG.info("Datastream {} does have a valid destination yet and not ready for use.", datastreamName);
+      } else {
         _datastreams.put(datastreamName, ds);
       }
     }
     return ds;
   }
 
+  /**
+   * Lookup the datastream based on its name from ZK.
+   * @param datastreamName name of the datastream
+   * @return the datastream object if exists; or null not exists in ZK
+   */
   private Datastream getDatastreamFromZk(String datastreamName) {
     String path = KeyBuilder.datastream(_cluster, datastreamName);
-    String content = _zkclient.ensureReadData(path);
-    return DatastreamUtils.fromJSON(content);
+    if (_zkclient.exists(path)) {
+      try {
+        String content = _zkclient.ensureReadData(path);
+        if (content != null) {
+          return DatastreamUtils.fromJSON(content);
+        }
+      } catch (ZkNoNodeException e) {
+        // This can happen when the path still exists but later deleted
+        // during ensureReadData
+        LOG.warn("Datastream {} is just deleted from ZK.", datastreamName);
+      }
+    }
+    return null;
   }
 
   private List<String> fetchAllDatastreamNamesFromZk() {
     String path = KeyBuilder.datastreams(_cluster);
-    _zkclient.ensurePath(path);
-    return _zkclient.getChildren(path, true);
+    if (_zkclient.exists(path)) {
+      return _zkclient.getChildren(path, true);
+    } else {
+      LOG.warn("Brooklin cluster '{}' is not initialize yet.", _cluster);
+      return Collections.emptyList();
+    }
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/KafkaTestUtils.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/KafkaTestUtils.java
@@ -18,7 +18,7 @@ import java.util.concurrent.TimeoutException;
  * Helper class for writing unit tests with EmbeddedKafka.
  */
 public final class KafkaTestUtils {
-  private static final int DEFAULT_TIMEOUT_MS = 30000;
+  private static final int DEFAULT_TIMEOUT_MS = 60000;
 
   public interface ReaderCallback {
     boolean onMessage(byte[] key, byte[] value) throws IOException;


### PR DESCRIPTION
For some connectors, their datastream events can be finite and has
limited usefulness within a certain time period. After that they should
not be kept around, otherwise it can pollutes the ZK space unnecessily.
To support cleanup of such streams, this change defines a TTL metadata
which can be leveraged by connector if it desires stream cleanup. TTL is
enforced for three events, datastream add, datastream drop, and leader
election. Note that rebalancing due to instance up/down does not trigger
TTL processing for now. this is okay because there is no pressure to
delete streams if there are no new streams anyway. If this turns out to
be an issue in the future, we can do cleanup in leaderDoAssignment too.

We also exclude expired tasks from getting assigned so even when there
is none of the three events occurs, expired streams do not get assigned
to any instances.