### PR TITLE
Add Kafak topic checks to KafakTestUtils and use it in tests

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -232,6 +232,7 @@ project(':datastream-testcommon') {
     compile "commons-cli:commons-cli:$commonsCliVersion"
     compile "org.apache.avro:avro:$avroVersion"
     compile "org.apache.zookeeper:zookeeper:$zookeeperVersion"
+    compile "org.apache.kafka:kafka_2.10:$kafkaVersion"
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamServer.java
@@ -45,6 +45,7 @@ import com.linkedin.datastream.server.assignment.BroadcastStrategyFactory;
 import com.linkedin.datastream.server.assignment.LoadbalancingStrategyFactory;
 import com.linkedin.datastream.server.zk.KeyBuilder;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
+import com.linkedin.datastream.testutil.KafkaTestUtils;
 import com.linkedin.datastream.testutil.TestUtils;
 
 import static com.linkedin.datastream.server.DatastreamServer.*;
@@ -204,6 +205,7 @@ public class TestDatastreamServer {
     ZkConnection zkConnection = new ZkConnection(_datastreamCluster.getZkConnection());
     ZkUtils zkUtils = new ZkUtils(zkClient, zkConnection, false);
     AdminUtils.createTopic(zkUtils, destinationTopic, numberOfPartitions, 1, new Properties(), RackAwareMode.Disabled$.MODULE$);
+    KafkaTestUtils.ensureTopicIsReady(_datastreamCluster.getKafkaCluster().getBrokers(), destinationTopic, numberOfPartitions);
 
     Datastream fileDatastream1 = createFileDatastream(fileName1, destinationTopic, 2);
     Assert.assertEquals((int) fileDatastream1.getDestination().getPartitions(), 2);


### PR DESCRIPTION
AdminUtils.createTopic creates topic asynchrnously so it is not
guaranteed the topic exists and ready for use right after it returns. We
have seen test flakiness due to immediately producing to just created
topics.

This change add a topic readiness check helper to KafakTestUtils which
is called by related tests. It also moves KafakTestUtils to testcommon
module such that other modules can use it.

Repeated runs of gradlew build prove the flakiness is fixed.