### PR TITLE
Added skipping of bad messages to event producer, so that all connect…

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -15,7 +15,10 @@ import org.apache.commons.lang.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Meter;
+
 import com.linkedin.datastream.common.BrooklinEnvelope;
+import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.ErrorLogger;
 import com.linkedin.datastream.metrics.BrooklinCounterInfo;
@@ -82,11 +85,18 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String AGGREGATE = "aggregate";
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_SLA_MS = "60000"; // 1 minute
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS = "180000"; // 3 minutes
+
+  public static final String CFG_SKIP_BAD_MESSAGE = "skipBadMessage";
+  public static final String SKIPPED_BAD_MESSAGES_RATE = "skippedBadMessagesRate";
+
+  private final String _datastreamName;
   private final int _availabilityThresholdSlaMs;
   // Alternate SLA for comparision with the main
   private final int _availabilityThresholdAlternateSlaMs;
   private Instant _lastFlushTime = Instant.now();
   private final Duration _flushInterval;
+  private final boolean _skipBadMessagesEnabled;
+  private final Meter _skippedBadMessagesRate = new Meter();
 
   /**
    * Construct an EventProducer instance.
@@ -103,6 +113,7 @@ public class EventProducer implements DatastreamEventProducer {
     Validate.notNull(config, "null config");
 
     _datastreamTask = task;
+    _datastreamName = task.getDatastreams().get(0).getName();
     _serDeSet = task.getDestinationSerDes();
     _transportProvider = transportProvider;
     _checkpointPolicy = customCheckpointing ? CheckpointPolicy.CUSTOM : CheckpointPolicy.DATASTREAM;
@@ -132,6 +143,12 @@ public class EventProducer implements DatastreamEventProducer {
     _dynamicMetricsManager.createOrUpdateCounter(MODULE, AGGREGATE, EVENTS_PRODUCED_OUTSIDE_SLA, 0);
     _dynamicMetricsManager.createOrUpdateCounter(MODULE, _datastreamTask.getConnectorType(),
         EVENTS_PRODUCED_OUTSIDE_SLA, 0);
+
+    _skipBadMessagesEnabled = skipBadMessageEnabled(task);
+    if (_skipBadMessagesEnabled) {
+      _dynamicMetricsManager.registerMetric(getClass().getSimpleName(), _datastreamName, SKIPPED_BAD_MESSAGES_RATE,
+          _skippedBadMessagesRate);
+    }
   }
 
   public int getProducerId() {
@@ -160,23 +177,44 @@ public class EventProducer implements DatastreamEventProducer {
    */
   @Override
   public void send(DatastreamProducerRecord record, SendCallback sendCallback) {
-    validateEventRecord(record);
-
-    // Serialize
-    record.serializeEvents(_datastreamTask.getDestinationSerDes());
+    try {
+      // Validate
+      validateEventRecord(record);
+      // Serialize
+      record.serializeEvents(_datastreamTask.getDestinationSerDes());
+      // Send
+      _transportProvider.send(_datastreamTask.getDatastreamDestination().getConnectionString(), record,
+          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record));
+    } catch (Exception e) {
+      if (_skipBadMessagesEnabled) {
+      /*
+       * If flag _skipBadMessagesEnabled is set, then message are skipped after failure
+       * Example of problems:
+       * - Message is above the message size supported by the destination.
+       * - The message can not be encoded to conform to the destination format (e.g. missing a field).
+       *
+       * This flag should only be set to true for use cases that can tolerate messages lost.
+       *
+       * Unfortunately the error could be a transient network problem, and not a problem with the message itself.
+       * For this reason is strongly recommended to put alerts in the _skippedBadMessagesRate and page the oncall
+       * in case of errors.
+       *
+       * TODO: Try to define a special exception for "badMessage" so we can differenciate between a send error,
+       * or a message compliance error. Right now is very hard to do that, because  will require to refactor a lot
+       * of library and code we do not control.
+       */
+        _logger.error("Skipping Message. task: {} ; error: {}", _datastreamTask, e.toString());
+        _skippedBadMessagesRate.mark();
+      } else {
+        String errorMessage = String.format("Failed send the event %s exception %s", record, e);
+        _logger.warn(errorMessage, e);
+        throw new DatastreamRuntimeException(errorMessage, e);
+      }
+    }
 
     // It is possible that the connector is not calling flush at regular intervals, In which case we will force a periodic flush.
     if (Instant.now().isAfter(_lastFlushTime.plus(_flushInterval))) {
       flush();
-    }
-
-    try {
-      _transportProvider.send(_datastreamTask.getDatastreamDestination().getConnectionString(), record,
-          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record));
-    } catch (Exception e) {
-      String errorMessage = String.format("Failed send the event %s exception %s", record, e);
-      _logger.warn(errorMessage, e);
-      throw new DatastreamRuntimeException(errorMessage, e);
     }
   }
 
@@ -297,5 +335,18 @@ public class EventProducer implements DatastreamEventProducer {
             BrooklinHistogramInfo.PERCENTILE_99, BrooklinHistogramInfo.PERCENTILE_999))));
 
     return Collections.unmodifiableList(metrics);
+  }
+
+  /**
+   * Look for config {@value CFG_SKIP_BAD_MESSAGE} in the datastream metadata and returns its value.
+   * Default value is false.
+   */
+  private static boolean skipBadMessageEnabled(DatastreamTask task) {
+    return task.getDatastreams()
+        .stream()
+        .findFirst()
+        .map(Datastream::getMetadata)
+        .map(metadata -> metadata.getOrDefault(CFG_SKIP_BAD_MESSAGE, "false").toLowerCase().equals("true"))
+        .orElse(false);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/transport/NoOpTransportProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/transport/NoOpTransportProvider.java
@@ -1,0 +1,25 @@
+package com.linkedin.datastream.server.transport;
+
+import com.linkedin.datastream.server.DatastreamProducerRecord;
+import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
+import com.linkedin.datastream.server.api.transport.SendCallback;
+import com.linkedin.datastream.server.api.transport.TransportProvider;
+
+
+public class NoOpTransportProvider implements TransportProvider {
+
+  @Override
+  public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+    DatastreamRecordMetadata metadata =  new DatastreamRecordMetadata(
+        record.getCheckpoint(), null, record.getPartition().orElse(null));
+    onComplete.onCompletion(metadata, null);
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void flush() {
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -1,0 +1,132 @@
+package com.linkedin.datastream.server;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.BrooklinEnvelope;
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.connectors.DummyConnector;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.server.api.transport.SendCallback;
+import com.linkedin.datastream.server.api.transport.TransportProvider;
+import com.linkedin.datastream.server.providers.NoOpCheckpointProvider;
+import com.linkedin.datastream.server.transport.NoOpTransportProvider;
+import com.linkedin.datastream.testutil.DatastreamTestUtils;
+
+
+public class TestEventProducer {
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    // A hack to force clean up DynamicMetricsManager
+    Field field = DynamicMetricsManager.class.getDeclaredField("_instance");
+    try {
+      field.setAccessible(true);
+      field.set(null, null);
+    } finally {
+      field.setAccessible(false);
+    }
+  }
+
+  @Test
+  public void testSendBasic() {
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "test-ds")[0];
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+
+    AtomicInteger numEventsProduced = new AtomicInteger();
+    TransportProvider transport = new NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        numEventsProduced.incrementAndGet();
+        super.send(destination, record, onComplete);
+      }
+    };
+
+    EventProducer eventProducer = new EventProducer(task, transport,
+        new NoOpCheckpointProvider(), new Properties(), false);
+    Assert.assertNull(getBadMessageRateMeter(datastream));
+
+    int eventCount = 5;
+    for (int i = 0; i < eventCount; i++) {
+      eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+    }
+    Assert.assertEquals(eventCount, numEventsProduced.get());
+  }
+
+  @Test
+  public void testSendAndSkipBadMessages() {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "test-ds")[0];
+    StringMap metadata = datastream.getMetadata();
+    metadata.put(EventProducer.CFG_SKIP_BAD_MESSAGE, "true");
+    datastream.setMetadata(metadata);
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+
+    // Create a "all-fail" transport provider
+    AtomicInteger numEventsProduced = new AtomicInteger();
+    TransportProvider transport = new NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        numEventsProduced.incrementAndGet();
+        throw new DatastreamRuntimeException();
+      }
+    };
+
+    EventProducer eventProducer = new EventProducer(task, transport,
+        new NoOpCheckpointProvider(), new Properties(), false);
+
+    int eventCount = 5;
+    for (int i = 0; i < eventCount; i++) {
+      eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+    }
+
+    Assert.assertEquals(eventCount, numEventsProduced.get());
+
+    // Verify bad message count equals to messages produced
+    Meter badMessageRate = getBadMessageRateMeter(datastream);
+    Assert.assertTrue(badMessageRate.getMeanRate() > 0);
+    Assert.assertEquals(eventCount, badMessageRate.getCount());
+
+  }
+
+  private Meter getBadMessageRateMeter(Datastream datastream) {
+    return DynamicMetricsManager.getInstance().getMetric(String.format("%s.%s.%s",
+        EventProducer.class.getSimpleName(),
+        datastream.getName(),
+        EventProducer.SKIPPED_BAD_MESSAGES_RATE));
+  }
+
+  private DatastreamProducerRecord createDatastreamProducerRecord() {
+    return createDatastreamProducerRecord(0, "0", 1);
+  }
+
+  private DatastreamProducerRecord createDatastreamProducerRecord(int partition, String checkpoint, int eventCount) {
+    DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
+    builder.setPartition(partition);
+    builder.setSourceCheckpoint(checkpoint);
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
+    for (int i = 0; i < eventCount; i++) {
+      builder.addEvent(new BrooklinEnvelope(new byte[0], new byte[0], null, new HashMap<>()));
+    }
+    return builder.build();
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/diagnostics/TestServerComponentHealthResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/diagnostics/TestServerComponentHealthResources.java
@@ -7,7 +7,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.MetricRegistry;
+
 import com.linkedin.datastream.diagnostics.ServerComponentHealth;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
 import com.linkedin.datastream.server.TestDatastreamServer;
 import com.linkedin.restli.server.PagingContext;
@@ -26,6 +29,7 @@ public class TestServerComponentHealthResources {
   @BeforeMethod
   public void setUp()
       throws Exception {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
     _datastreamKafkaCluster = TestDatastreamServer.initializeTestDatastreamServerWithDummyConnector(null);
     _datastreamKafkaCluster.startup();
   }


### PR DESCRIPTION
Added skipping of bad messages to event producer, so that all connecters can benefit from this. 
This is often required when more processing of messages are involved, and there are more chances for processing to fail. If the user case can tolerate message loss, skipping failed messages will not stop the pipeline. A boolean flag skipBadMessage is introduced to enable this feature in datastream metadata and a meter skippedBadMessagesRate is added to record the rate of bad messages skipped.