### PR TITLE
Added skipping of bad messages to event producer, so that all connect…

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/transport/NoOpTransportProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/transport/NoOpTransportProvider.java
@@ -1,0 +1,25 @@
+package com.linkedin.datastream.server.transport;
+
+import com.linkedin.datastream.server.DatastreamProducerRecord;
+import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
+import com.linkedin.datastream.server.api.transport.SendCallback;
+import com.linkedin.datastream.server.api.transport.TransportProvider;
+
+
+public class NoOpTransportProvider implements TransportProvider {
+
+  @Override
+  public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+    DatastreamRecordMetadata metadata =  new DatastreamRecordMetadata(
+        record.getCheckpoint(), null, record.getPartition().orElse(null));
+    onComplete.onCompletion(metadata, null);
+  }
+
+  @Override
+  public void close() {
+  }
+
+  @Override
+  public void flush() {
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -1,0 +1,134 @@
+package com.linkedin.datastream.server;
+
+import java.lang.reflect.Field;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.BrooklinEnvelope;
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.connectors.DummyConnector;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.server.api.transport.SendCallback;
+import com.linkedin.datastream.server.api.transport.TransportProvider;
+import com.linkedin.datastream.server.providers.NoOpCheckpointProvider;
+import com.linkedin.datastream.server.transport.NoOpTransportProvider;
+import com.linkedin.datastream.testutil.DatastreamTestUtils;
+
+
+public class TestEventProducer {
+
+  @BeforeMethod
+  public void setUp() throws Exception {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    // A hack to force clean up DynamicMetricsManager
+    Field field = DynamicMetricsManager.class.getDeclaredField("_instance");
+    try {
+      field.setAccessible(true);
+      field.set(null, null);
+    } finally {
+      field.setAccessible(false);
+    }
+  }
+
+  @Test
+  public void testSendBasic() {
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "test-ds")[0];
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+
+    AtomicInteger numEventsProduced = new AtomicInteger();
+    TransportProvider transport = new NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        numEventsProduced.incrementAndGet();
+        super.send(destination, record, onComplete);
+      }
+    };
+
+    EventProducer eventProducer = new EventProducer(task, transport,
+        new NoOpCheckpointProvider(), new Properties(), false);
+    Assert.assertNull(getBadMessageRateMeter(datastream));
+
+    int eventCount = 5;
+    for (int i = 0; i < eventCount; i++) {
+      eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+    }
+    Assert.assertEquals(eventCount, numEventsProduced.get());
+  }
+
+  @Test
+  public void testSendAndSkipBadMessages() {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "test-ds")[0];
+    StringMap metadata = datastream.getMetadata();
+    metadata.put(EventProducer.CFG_SKIP_BAD_MESSAGE, "true");
+    datastream.setMetadata(metadata);
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+
+    // Create a "all-fail" transport provider
+    int failedCount = 3;
+    AtomicInteger numEventsProduced = new AtomicInteger();
+    TransportProvider transport = new NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        if (numEventsProduced.incrementAndGet() <= failedCount) {
+          throw new DatastreamRuntimeException();
+        }
+      }
+    };
+
+    EventProducer eventProducer = new EventProducer(task, transport,
+        new NoOpCheckpointProvider(), new Properties(), false);
+
+    int eventCount = 5;
+    for (int i = 0; i < eventCount; i++) {
+      eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+    }
+
+    Assert.assertEquals(eventCount, numEventsProduced.get());
+
+    // Verify bad message count equals to messages produced
+    Meter badMessageRate = getBadMessageRateMeter(datastream);
+    Assert.assertTrue(badMessageRate.getMeanRate() > 0);
+    Assert.assertEquals(failedCount, badMessageRate.getCount());
+
+  }
+
+  private Meter getBadMessageRateMeter(Datastream datastream) {
+    return DynamicMetricsManager.getInstance().getMetric(String.format("%s.%s.%s",
+        EventProducer.class.getSimpleName(),
+        datastream.getName(),
+        EventProducer.SKIPPED_BAD_MESSAGES_RATE));
+  }
+
+  private DatastreamProducerRecord createDatastreamProducerRecord() {
+    return createDatastreamProducerRecord(0, "0", 1);
+  }
+
+  private DatastreamProducerRecord createDatastreamProducerRecord(int partition, String checkpoint, int eventCount) {
+    DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
+    builder.setPartition(partition);
+    builder.setSourceCheckpoint(checkpoint);
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
+    for (int i = 0; i < eventCount; i++) {
+      builder.addEvent(new BrooklinEnvelope(new byte[0], new byte[0], null, new HashMap<>()));
+    }
+    return builder.build();
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/diagnostics/TestServerComponentHealthResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/diagnostics/TestServerComponentHealthResources.java
@@ -7,7 +7,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.MetricRegistry;
+
 import com.linkedin.datastream.diagnostics.ServerComponentHealth;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
 import com.linkedin.datastream.server.TestDatastreamServer;
 import com.linkedin.restli.server.PagingContext;
@@ -26,6 +29,7 @@ public class TestServerComponentHealthResources {
   @BeforeMethod
   public void setUp()
       throws Exception {
+    DynamicMetricsManager.createInstance(new MetricRegistry());
     _datastreamKafkaCluster = TestDatastreamServer.initializeTestDatastreamServerWithDummyConnector(null);
     _datastreamKafkaCluster.startup();
   }


### PR DESCRIPTION
Added skipping of bad messages to event producer, so that all connecters can benefit from this. This is often required when more processing of messages are involved, and there are more chances for processing to fail. If the user case can tolerate message loss, skipping failed messages will not stop the pipeline. A boolean flag skipBadMessage is introduced to datastream metadata to enable this feature and a meter skippedBadMessagesRate is added to record the rate of bad messages skipped.