### PR TITLE
Support for Multi Topic Subscription in a Kafka Connector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectionString.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectionString.java
@@ -5,39 +5,63 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.StringJoiner;
+import javax.annotation.Nullable;
 
 
 /**
  * the object representation of a kafka connection string.
  * strings are of the form:
  * kafka://[host1:port1,host2:port2...]/topicName
+ *
+ * We also support regular expressions for topicName, using the following syntax:
+ * kafka://[host1:port1,host2:port2...]/pattern:topicNameRegEx
  */
 public class KafkaConnectionString {
   private final static String PREFIX = KafkaConnector.CONNECTOR_NAME + "://";
+  public static final String PATTERN = "pattern:";
 
   private final List<KafkaBrokerAddress> _brokers;
   private final String _topicName;
+  private final String _topicPattern;
+  private final boolean _isPattern;
 
-  public KafkaConnectionString(List<KafkaBrokerAddress> brokers, String topicName) {
+  /* package */ KafkaConnectionString(List<KafkaBrokerAddress> brokers, boolean isPattern, String nameOrPattern) {
     ArrayList<KafkaBrokerAddress> brokersCopy = new ArrayList<>(brokers);
-    Collections.sort(brokersCopy, KafkaBrokerAddress.BY_URL);
-    this._brokers = Collections.unmodifiableList(brokersCopy);
-    this._topicName = topicName.trim();
+    brokersCopy.sort(KafkaBrokerAddress.BY_URL);
+    _brokers = Collections.unmodifiableList(brokersCopy);
+    _isPattern = isPattern;
+    if (isPattern) {
+      _topicName = null;
+      _topicPattern = nameOrPattern.trim();
+    } else {
+      _topicName = nameOrPattern.trim();
+      _topicPattern = null;
+    }
   }
 
   public List<KafkaBrokerAddress> getBrokers() {
     return _brokers;
   }
 
+  public boolean isPattern() {
+    return _isPattern;
+  }
+
+  @Nullable
   public String getTopicName() {
     return _topicName;
+  }
+
+  @Nullable
+  public String getTopicPattern() {
+    return _topicPattern;
   }
 
   @Override
   public String toString() {
     StringJoiner joiner = new StringJoiner(",");
     _brokers.forEach(kafkaBrokerAddress -> joiner.add(kafkaBrokerAddress.toString()));
-    return PREFIX + joiner.toString() + "/" + _topicName;
+    return PREFIX + joiner.toString() + "/" + (_isPattern ? PATTERN : "") + _topicName;
   }
 
   @Override
@@ -50,12 +74,13 @@ public class KafkaConnectionString {
     }
     KafkaConnectionString that = (KafkaConnectionString) o;
     //note this is order-sensitive
-    return Objects.equals(_brokers, that._brokers) && Objects.equals(_topicName, that._topicName);
+    return Objects.equals(_brokers, that._brokers) && Objects.equals(_topicName, that._topicName)
+        && Objects.equals(_isPattern, that._isPattern);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_brokers, _topicName);
+    return Objects.hash(_brokers, _topicName, _isPattern);
   }
 
   public static KafkaConnectionString valueOf(String connectionString) throws IllegalArgumentException {
@@ -72,13 +97,17 @@ public class KafkaConnectionString {
     if (topicIndex < 0) {
       badArg(connectionString);
     }
-    String topicName = str.substring(topicIndex + 1).trim();
-    if (topicName.isEmpty()) {
+    String topicNameOrPattern = str.substring(topicIndex + 1).trim();
+    if (topicNameOrPattern.isEmpty()) {
       badArg(connectionString);
+    }
+    boolean isPattern = topicNameOrPattern.startsWith(PATTERN);
+    if (isPattern) {
+      topicNameOrPattern = topicNameOrPattern.substring(PATTERN.length());
     }
     str = str.substring(0, topicIndex);
     List<KafkaBrokerAddress> brokers = parseBrokers(str);
-    return new KafkaConnectionString(brokers, topicName);
+    return new KafkaConnectionString(brokers, isPattern, topicNameOrPattern);
   }
 
   public static List<KafkaBrokerAddress> parseBrokers(String brokersValue) {

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectionString.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectionString.java
@@ -51,29 +51,30 @@ public class TestKafkaConnectionString {
   @Test
   public void testSimpleString() {
     Assert.assertEquals(
-        new KafkaConnectionString(Collections.singletonList(new KafkaBrokerAddress("somewhere", 666)), "topic"),
-        KafkaConnectionString.valueOf("kafka://somewhere:666/topic")
-    );
+        new KafkaConnectionString(Collections.singletonList(new KafkaBrokerAddress("somewhere", 666)), false, "topic"),
+        KafkaConnectionString.valueOf("kafka://somewhere:666/topic"));
   }
 
   @Test
   public void testMultipleBrokers() {
-    Assert.assertEquals(
-        new KafkaConnectionString(
-            Arrays.asList(
-              new KafkaBrokerAddress("somewhere", 666),
-              new KafkaBrokerAddress("somewhereElse", 667)
-            ),
-            "topic"
-        ),
-        KafkaConnectionString.valueOf("kafka://somewhere:666,somewhereElse:667/topic")
-    );
+    Assert.assertEquals(new KafkaConnectionString(
+        Arrays.asList(new KafkaBrokerAddress("somewhere", 666), new KafkaBrokerAddress("somewhereElse", 667)), false,
+        "topic"), KafkaConnectionString.valueOf("kafka://somewhere:666,somewhereElse:667/topic"));
   }
 
   @Test
   public void testBrokerListSorting() {
     KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafka://a:667,b:665,a:666/topic");
     Assert.assertEquals("kafka://a:666,a:667,b:665/topic", connectionString.toString());
+    Assert.assertFalse(connectionString.isPattern());
+    Assert.assertNull(connectionString.getTopicPattern());
+  }
+
+  @Test void testTopicPattern() {
+    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafka://a:667,b:665,a:666/pattern:topic.*");
+    Assert.assertTrue(connectionString.isPattern());
+    Assert.assertNull(connectionString.getTopicName());
+    Assert.assertEquals(connectionString.getTopicPattern(), "topic.*");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
@@ -103,6 +103,22 @@ public class TestKafkaConnector {
   }
 
   @Test
+  public void testInitializeDatastreamWithRegEx() throws UnsupportedEncodingException, DatastreamValidationException {
+    Datastream ds = createDatastream("testInitializeDatastreamWithNonexistTopic",  "pattern:startWith.*");
+    KafkaConnector connector =
+        new KafkaConnector("test", getDefaultConfig(null));
+    connector.initializeDatastream(ds, Collections.emptyList());
+  }
+
+  @Test(expectedExceptions = DatastreamValidationException.class)
+  public void testInitializeDatastreamInvalidRegEx() throws UnsupportedEncodingException, DatastreamValidationException {
+    Datastream ds = createDatastream("testInitializeDatastreamWithNonexistTopic",  "pattern:testWithInvalidRegEx[");
+    KafkaConnector connector =
+        new KafkaConnector("test", getDefaultConfig(null));
+    connector.initializeDatastream(ds, Collections.emptyList());
+  }
+
+  @Test
   public void testPopulatingDefaultSerde() throws Exception {
     String topicName = "testPopulatingDefaultSerde";
     TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName, 0, 100);


### PR DESCRIPTION
Adding support for multi topic subscription (using regular expression)
to the kafka connector. The topic of origin is recorded in the event
metadata.