### PR TITLE
Fix stuck partition metric sensor type to be Gauge and not Meter

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
@@ -316,7 +316,7 @@ public class CommonConnectorMetrics {
     // TODO: Remove the override once a choice has been made between COUNT and ONE_MINUTE_RATE
     metrics.add(new BrooklinMeterInfo(prefix + REBALANCE_RATE,
         Optional.of(Arrays.asList(BrooklinMeterInfo.COUNT, BrooklinMeterInfo.ONE_MINUTE_RATE))));
-    metrics.add(new BrooklinMeterInfo(prefix + STUCK_PARTITIONS));
+    metrics.add(new BrooklinGaugeInfo(prefix + STUCK_PARTITIONS));
     return Collections.unmodifiableList(metrics);
   }
 }


### PR DESCRIPTION
Previous change to move connector metrics to a common class introduced a bug where
the stuck partition metric was registered as a BrooklinMeterInfo sensor instead of
BrooklinGaugeInfo. But since the actual metric is a Gauge, there will be no matching
metric for the sensor. Fix the sensor type.