### PR TITLE
Limiting the number of tasks created for broadcast strategy.

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -702,7 +702,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
    * If #2 occurs, it also invalidates the datastream cache for the next assignment.
    *
    * This means TTL is enforced only for below events:
-   *  1) new learder is elected
+   *  1) new leader is elected
    *  2) a new stream is added
    *  3) an existing stream is deleted
    *

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -4,6 +4,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -14,10 +15,24 @@ import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.server.api.strategy.AssignmentStrategy;
 
+import static com.linkedin.datastream.server.assignment.BroadcastStrategyFactory.CFG_MAX_TASKS;
 
+/**
+ * The number of tasks created for datastream is min(numberOfInstances, maxTasks),
+ * unless maxTasks is less than 1, in that case it create one task for each instance.
+ *
+ * All the tasks are redistributed across all the instances equally.
+ */
 public class BroadcastStrategy implements AssignmentStrategy {
 
   private static final Logger LOG = LoggerFactory.getLogger(BroadcastStrategy.class.getName());
+
+  private final int _maxTasks;
+
+  public BroadcastStrategy(int maxTasks) {
+    // If maxTasks is less than one, then just create one task for each instance.
+    _maxTasks = maxTasks < 1 ? Integer.MAX_VALUE : maxTasks;
+  }
 
   @Override
   public Map<String, Set<DatastreamTask>> assign(List<DatastreamGroup> datastreams, List<String> instances,
@@ -29,21 +44,44 @@ public class BroadcastStrategy implements AssignmentStrategy {
     Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
 
     for (String instance : instances) {
-      Set<DatastreamTask> newAssignmentForInstance = assignment.computeIfAbsent(instance, (x) -> new HashSet<>());
-      Set<DatastreamTask> currentAssignmentForInstance =
-          currentAssignment.computeIfAbsent(instance, (x) -> new HashSet<>());
+      assignment.put(instance, new HashSet<>());
+      currentAssignment.computeIfAbsent(instance, (x) -> new HashSet<>());
+    }
 
-      for (DatastreamGroup dg : datastreams) {
-        DatastreamTask foundDatastreamTask = currentAssignmentForInstance.stream()
+    int instancePos = 0;
+    for (DatastreamGroup dg : datastreams) {
+      int numTask = getNumTasks(dg, instances.size());
+      for (int taskPos = 0; taskPos < numTask; taskPos++) {
+        String instance = instances.get(instancePos);
+
+        DatastreamTask foundDatastreamTask = currentAssignment.get(instance)
+            .stream()
             .filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()))
             .findFirst()
             .orElse(new DatastreamTaskImpl(dg.getDatastreams()));
-        newAssignmentForInstance.add(foundDatastreamTask);
+        assignment.get(instance).add(foundDatastreamTask);
+
+        // Move to the next instance
+        instancePos = (instancePos + 1) % instances.size();
       }
     }
 
     LOG.info(String.format("New assignment is {%s}", assignment));
 
     return assignment;
+  }
+
+  private int getNumTasks(DatastreamGroup dg, int numInstances) {
+    // Look for an override in any of the datastream.
+    // In case of multiple overrides, select the largest.
+    // If not override is present then use the default "_maxTasks"
+    int maxTasks = dg.getDatastreams().stream()
+        .map(ds -> ds.getMetadata().get(CFG_MAX_TASKS))
+        .filter(Objects::nonNull)
+        .mapToInt(Integer::valueOf)
+        .map(x -> x < 1 ? Integer.MAX_VALUE : x)
+        .max()
+        .orElse(_maxTasks);
+    return  Math.min(maxTasks, numInstances);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategyFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategyFactory.java
@@ -2,14 +2,19 @@ package com.linkedin.datastream.server.assignment;
 
 import java.util.Properties;
 
+import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.server.api.strategy.AssignmentStrategy;
 import com.linkedin.datastream.server.api.strategy.AssignmentStrategyFactory;
 
 
 public class BroadcastStrategyFactory implements AssignmentStrategyFactory {
+  public static final String CFG_MAX_TASKS = "maxTasks";
+  public static final int DEFAULT_MAX_TASKS = 6;
 
   @Override
   public AssignmentStrategy createStrategy(Properties assignmentStrategyProperties) {
-    return new BroadcastStrategy();
+    VerifiableProperties props = new VerifiableProperties(assignmentStrategyProperties);
+    int maxTasks = props.getInt(CFG_MAX_TASKS, DEFAULT_MAX_TASKS);
+    return new BroadcastStrategy(maxTasks);
   }
 }


### PR DESCRIPTION
Currently we create one task per server, but for larger clusters at
smaller number of tasks per datastream is better.

Introduce a parameter (with default 6) to the number of tasks per
datastream in broadcast. Also adding logic to override this parameter
for a specific datastream using metadata.