### PR TITLE
Remove support for FiveMinuteRate and FifteenMinuteRate

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/BrooklinMeterInfo.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/BrooklinMeterInfo.java
@@ -15,11 +15,9 @@ public class BrooklinMeterInfo extends BrooklinMetricInfo {
   public static final String COUNT = "Count";
   public static final String MEAN_RATE = "MeanRate";
   public static final String ONE_MINUTE_RATE = "OneMinuteRate";
-  public static final String FIVE_MINUTE_RATE = "FiveMinuteRate";
-  public static final String FIFTEEN_MINUTE_RATE = "FifteenMinuteRate";
 
   public static final Set<String> SUPPORTED_ATTRIBUTES =
-      Stream.of(COUNT, MEAN_RATE, ONE_MINUTE_RATE, FIVE_MINUTE_RATE, FIFTEEN_MINUTE_RATE).collect(Collectors.toSet());
+      Stream.of(COUNT, MEAN_RATE, ONE_MINUTE_RATE).collect(Collectors.toSet());
 
   public BrooklinMeterInfo(String nameOrRegex) {
     this(nameOrRegex, Optional.empty());


### PR DESCRIPTION
Since the "FiveMInuteRate" and "FifteenMinuteRate" are purely windows for calculating per-second rate and not being used in Brooklin, we can remove support for these altogether.