### PR TITLE
Misc fixes related to RestClient management

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
@@ -1,0 +1,128 @@
+package com.linkedin.datastream;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.ReflectionUtils;
+import com.linkedin.datastream.common.RestliUtils;
+import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
+import com.linkedin.r2.transport.http.client.HttpClientFactory;
+import com.linkedin.restli.client.RestClient;
+
+
+/**
+ * Base class for implementing a factory for Rest.li client wrappers, eg. DatastreamRestClient.
+ * We cache R2 RestClient by (URI, HTTP_PARAMS) because they are stateless. All custom factories
+ * share the HttpClientFactory. R2 RestClient is the actual HTTP client used by wrappers to send
+ * the actual requests and receive responses.
+ *
+ * Rest.li wrappers can be created in two ways:
+ * 1) use default R2 RestClient either previously registered or created through HttpClientFactory.
+ * 2) use a cached or new RestClient created with the specified http properties through HttpClientFactory.
+ *
+ * The registered R2 RestClient is mapped with (URI, EMPTY_MAP) in the cache so it will not be used
+ * when caller specify non-empty HTTP_PARAMS.
+ *
+ * Rest.li client wrapper class is expected to provide a constructor with a R2 RestClient as the
+ * only argument.
+ *
+ * Caller can specify a custom Rest.li client wrapper instance per URI which will be used whenever
+ * wrapper is requested for such URI. This has the highest precedence and is useful for plugging
+ * in mocked wrappers for unit/integration tests.
+ *
+ * Lastly, there is no need to shutdown the factory or rest client during runtime because they are
+ * essentially singleton per (URI, HTTP_PARAMS). As such, they might be reused for future wrapper
+ * creations so we need to keep them alive. When application shuts down, all resources will be
+ * released by the JVM.
+ *
+ * @param <T> type of the specific Rest.li client wrapper (eg. DatastreamRestClient).
+ */
+public final class BaseRestClientFactory<T> {
+  private static final HttpClientFactory CLIENT_FACTORY = new HttpClientFactory();
+
+  private final Logger _logger;
+  private final Class<T> _restClientClass;
+  private final Map<String, T> _overrides = new ConcurrentHashMap<>();
+  private final Map<String, RestClient> _restClients = new ConcurrentHashMap<>();
+
+  /**
+   * @param clazz Class object of the Rest.li client wrapper
+   */
+  public BaseRestClientFactory(Class<T> clazz) {
+    _restClientClass = clazz;
+    _logger = LoggerFactory.getLogger(this.getClass());
+  }
+
+  /**
+   * Get a rest client wrapper with custom HTTP configs
+   * @param uri URI to the HTTP endpoint
+   * @param httpConfig custom config for HTTP client, please find the configs in
+   *                   {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
+   * @return
+   */
+  public synchronized T getClient(String uri, Map<String, String> httpConfig) {
+    T client = getOverride(uri);
+    if (client == null) {
+      client = createClient(getRestClient(uri, httpConfig));
+    }
+    return client;
+  }
+
+  /**
+   * Register an existing R2 RestClient already bound to {@param uri}.
+   * It is cached and reused for future Rest.li client wrapper creations without custom HTTP parameters.
+   * @param uri URI to the HTTP endpoint
+   * @param restClient custom R2 RestClient
+   * @return
+   */
+  public synchronized void registerRestClient(String uri, RestClient restClient) {
+    uri = RestliUtils.sanitizeUri(uri);
+    _restClients.put(getKey(uri, Collections.emptyMap()), restClient);
+  }
+
+  /**
+   * Used mainly for testing, to override the rest client wrapper returned for a given URI.
+   * As custom factories are used in the static context, each test case should use its own
+   * URI, to avoid conflicts in case the test are running in parallel.
+   */
+  public synchronized void addOverride(String uri, T restliClient) {
+    Validate.notNull(restliClient, "null RestClient");
+    uri = RestliUtils.sanitizeUri(uri);
+    if (_overrides.containsKey(uri)) {
+      _logger.warn("Replacing existing RestliClient override for URI: " + uri);
+    }
+    _overrides.put(uri, restliClient);
+  }
+
+  private T getOverride(String uri) {
+    uri = RestliUtils.sanitizeUri(uri);
+    return _overrides.getOrDefault(uri, null);
+  }
+
+  private static String getKey(String uri, Map<String, String> httpConfig) {
+    return String.format("%s-%d", uri, httpConfig.hashCode());
+  }
+
+  private RestClient getRestClient(String uri, Map<String, String> httpConfig) {
+    String canonicalUri = RestliUtils.sanitizeUri(uri);
+    RestClient restClient;
+    String key = getKey(uri, httpConfig);
+    restClient = _restClients.computeIfAbsent(key, (k) ->
+      new RestClient(new TransportClientAdapter(CLIENT_FACTORY.getClient(httpConfig)), canonicalUri));
+    return restClient;
+  }
+
+  private T createClient(RestClient restClient) {
+    T client = ReflectionUtils.createInstance(_restClientClass, restClient);
+    if (client == null) {
+      throw new DatastreamRuntimeException("Failed to instantiate " + _restClientClass);
+    }
+    return client;
+  }
+}

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
@@ -2,15 +2,12 @@ package com.linkedin.datastream;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.Validate;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamNotFoundException;
@@ -19,9 +16,6 @@ import com.linkedin.datastream.common.DatastreamStatus;
 import com.linkedin.datastream.common.ErrorLogger;
 import com.linkedin.datastream.server.dms.DatastreamRequestBuilders;
 import com.linkedin.r2.RemoteInvocationException;
-import com.linkedin.r2.transport.common.Client;
-import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
-import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.restli.client.BatchUpdateRequest;
 import com.linkedin.restli.client.ActionRequest;
 import com.linkedin.restli.client.CreateIdRequest;
@@ -47,32 +41,9 @@ import com.linkedin.restli.common.UpdateStatus;
  */
 public class DatastreamRestClient {
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamRestClient.class);
+
   private final DatastreamRequestBuilders _builders;
   private final RestClient _restClient;
-
-  /**
-   * @deprecated Please use factory {@link DatastreamRestClientFactory}
-   * @param dmsUri URI to DMS endpoint
-   * @param httpConfig custom config for HTTP client, please find the configs in {@link HttpClientFactory}
-   */
-  @Deprecated
-  public DatastreamRestClient(String dmsUri, Map<String, String> httpConfig) {
-    this(dmsUri, new TransportClientAdapter(new HttpClientFactory().getClient(httpConfig)));
-  }
-
-  /**
-   * @deprecated Please use factory {@link DatastreamRestClientFactory}
-   * @param dmsUri URI to DMS endpoint
-   * @param r2Client pre-created R2Client
-   */
-  @Deprecated
-  public DatastreamRestClient(String dmsUri, Client r2Client) {
-    Validate.notEmpty(dmsUri, "invalid DSM URI");
-    Validate.notNull(r2Client, "null R2 client");
-    dmsUri = StringUtils.appendIfMissing(dmsUri, "/");
-    _builders = new DatastreamRequestBuilders();
-    _restClient = new RestClient(r2Client, dmsUri);
-  }
 
   /**
    * @deprecated Please use factory {@link DatastreamRestClientFactory}
@@ -311,13 +282,6 @@ public class DatastreamRestClient {
       }
     }
     return false;
-  }
-
-  /**
-   * Shutdown the DatastreamRestClient
-   */
-  public void shutdown() {
-    _restClient.shutdown(new FutureCallback<>());
   }
 
   /**

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
@@ -2,25 +2,20 @@ package com.linkedin.datastream;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-import com.linkedin.datastream.common.RestliUtils;
-import com.linkedin.r2.transport.common.Client;
 import com.linkedin.restli.client.RestClient;
 
 
 /**
- * Factory class for creating  {@link DatastreamRestClient} objects.
- * This factory is needed to allow mocking the DatastreamRestClient during test.
+ * Factory class for obtaining {@link DatastreamRestClient} objects.
  *
  * The reason is that currently we inject the dmsUri as part of the configuration
  * but we don't have a dependency injection framework that allows us to inject mock
  * DatastreamRestClient, without doing a major refactoring of the code.
  */
-public class DatastreamRestClientFactory {
-
-  private static Map<String, DatastreamRestClient> overrides = new ConcurrentHashMap<>();
-
+public final class DatastreamRestClientFactory {
+  private static final BaseRestClientFactory<DatastreamRestClient> FACTORY =
+      new BaseRestClientFactory<>(DatastreamRestClient.class);
 
   /**
    * Get a DatastreamRestClient with default HTTP client
@@ -28,65 +23,32 @@ public class DatastreamRestClientFactory {
    * @return
    */
   public static DatastreamRestClient getClient(String dmsUri) {
-    return getClient(dmsUri, Collections.<String, String>emptyMap());
+    return FACTORY.getClient(dmsUri, Collections.emptyMap());
   }
 
   /**
-   * Get a DatastreamRestClient with default HTTP client and custom HTTP configs
+   * Get a DatastreamRestClient with custom HTTP configs
+   * @see BaseRestClientFactory#getClient(String, Map)
    * @param dmsUri URI to DMS endpoint
-   * @param httpConfig custom config for HTTP client, please find the configs in {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
+   * @param httpConfig custom config for HTTP client, please find the configs in
+   *                   {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
    * @return
    */
   public static DatastreamRestClient getClient(String dmsUri, Map<String, String> httpConfig) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    if (overrides.containsKey(dmsUri)) {
-      return overrides.get(dmsUri);
-    }
-    return new DatastreamRestClient(dmsUri, httpConfig);
+    return FACTORY.getClient(dmsUri, httpConfig);
   }
 
   /**
-   * Get a DatastreamRestClient with an existing Rest.li R2Client
-   * @param dmsUri URI to DMS endpoint
-   * @param r2Client Rest.li R2Client
-   * @return
-   */
-  public static DatastreamRestClient getClient(String dmsUri, Client r2Client) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    if (overrides.containsKey(dmsUri)) {
-      return overrides.get(dmsUri);
-    }
-    return new DatastreamRestClient(dmsUri, r2Client);
-  }
-
-  /**
-   * Get a DatastreamRestClient with an existing Rest.li RestClient (must bound to the same dmsUri).
-   * @param dmsUri URI to DMS endpoint
-   * @param restClient Rest.li RestClient
-   * @return
-   */
-  public static DatastreamRestClient getClient(String dmsUri, RestClient restClient) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    if (overrides.containsKey(dmsUri)) {
-      return overrides.get(dmsUri);
-    }
-    return new DatastreamRestClient(restClient);
-  }
-
-  /**
-   * Used mainly for testing, to override the DatastreamRestClient returned for a given dmsUri.
-   * Note that this is an static method, each test case should use its own dmsUri, to avoid conflicts
-   * in case the test are running in parallel.
+   * @see BaseRestClientFactory#addOverride(String, Object)
    */
   public static void addOverride(String dmsUri, DatastreamRestClient restClient) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    overrides.put(dmsUri, restClient);
+    FACTORY.addOverride(dmsUri, restClient);
   }
 
   /**
-   * @return the current RestClient override mappings
+   * @see BaseRestClientFactory#registerRestClient(String, RestClient)
    */
-  public static Map<String, DatastreamRestClient> getOverrides() {
-    return Collections.unmodifiableMap(overrides);
+  public static void registerRestClient(String dmsUri, RestClient restClient) {
+    FACTORY.registerRestClient(dmsUri, restClient);
   }
 }

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClient.java
@@ -1,21 +1,14 @@
 package com.linkedin.diagnostics;
 
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
 
 import org.apache.commons.lang.Validate;
-import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.common.callback.FutureCallback;
 import com.linkedin.datastream.diagnostics.ServerComponentHealth;
 import com.linkedin.datastream.server.diagnostics.DiagRequestBuilders;
 import com.linkedin.r2.RemoteInvocationException;
-import com.linkedin.r2.transport.common.Client;
-import com.linkedin.r2.transport.common.bridge.client.TransportClientAdapter;
-import com.linkedin.r2.transport.http.client.HttpClientFactory;
 import com.linkedin.restli.client.FindRequest;
 import com.linkedin.restli.client.RestClient;
 
@@ -27,22 +20,6 @@ public class ServerComponentHealthRestClient {
   private static final Logger LOG = LoggerFactory.getLogger(ServerComponentHealthRestClient.class);
   private final DiagRequestBuilders _builders;
   private final RestClient _restClient;
-
-  public ServerComponentHealthRestClient(String dsmUri) {
-    this(dsmUri, new TransportClientAdapter(new HttpClientFactory().getClient(Collections.<String, String>emptyMap())));
-  }
-
-  public ServerComponentHealthRestClient(String dmsUri, Map<String, String> httpConfig) {
-    this(dmsUri, new TransportClientAdapter(new HttpClientFactory().getClient(httpConfig)));
-  }
-
-  public ServerComponentHealthRestClient(String dsmUri, Client r2Client) {
-    Validate.notEmpty(dsmUri, "invalid DSM URI");
-    Validate.notNull(r2Client, "null R2 client");
-    dsmUri = StringUtils.appendIfMissing(dsmUri, "/");
-    _builders = new DiagRequestBuilders();
-    _restClient = new RestClient(r2Client, dsmUri);
-  }
 
   public ServerComponentHealthRestClient(RestClient restClient) {
     Validate.notNull(restClient, "null restClient");
@@ -112,12 +89,5 @@ public class ServerComponentHealthRestClient {
       LOG.error("Get serverComponentHealthAllStatus {%s} {%s} failed with error.", type, scope);
       return null;
     }
-  }
-
-  /**
-   * Shutdown the ServerComponentHealthRestClient
-   */
-  public void shutdown() {
-    _restClient.shutdown(new FutureCallback<>());
   }
 }

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
@@ -2,69 +2,43 @@ package com.linkedin.diagnostics;
 
 import java.util.Collections;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 
-import com.linkedin.datastream.common.RestliUtils;
+import com.linkedin.datastream.BaseRestClientFactory;
 import com.linkedin.restli.client.RestClient;
 
 
 /**
- * ServerComponentHealth Resource Factory that is used to create the ServerComponentHealth restli resources.
+ * Factory class for obtaining {@link ServerComponentHealthRestClient} objects.
  */
-public class ServerComponentHealthRestClientFactory {
+public final class ServerComponentHealthRestClientFactory {
+  private static final BaseRestClientFactory<ServerComponentHealthRestClient> FACTORY =
+      new BaseRestClientFactory<>(ServerComponentHealthRestClient.class);
 
-  private static Map<String, ServerComponentHealthRestClient> overrides = new ConcurrentHashMap<>();
-
+  /**
+   * Get a ServerComponentHealthRestClient with default HTTP client
+   * @param dmsUri URI to DMS endpoint
+   * @return
+   */
   public static ServerComponentHealthRestClient getClient(String dmsUri) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    if (overrides.containsKey(dmsUri)) {
-      return overrides.get(dmsUri);
-    }
-    return new ServerComponentHealthRestClient(dmsUri);
+    return FACTORY.getClient(dmsUri, Collections.emptyMap());
   }
 
   /**
-   * Get a ServerComponentHealthRestClient with default HTTP client and custom HTTP configs
+   * Get a ServerComponentHealthRestClient with custom HTTP configs
+   * @see BaseRestClientFactory#getClient(String, Map)
    * @param dmsUri URI to DMS endpoint
-   * @param httpConfig custom config for HTTP client, please find the configs in {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
+   * @param httpConfig custom config for HTTP client, please find the configs in
+   *                   {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
    * @return
    */
   public static ServerComponentHealthRestClient getClient(String dmsUri, Map<String, String> httpConfig) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    if (overrides.containsKey(dmsUri)) {
-      return overrides.get(dmsUri);
-    }
-    return new ServerComponentHealthRestClient(dmsUri, httpConfig);
+    return FACTORY.getClient(dmsUri, httpConfig);
   }
 
   /**
-   * Get a ServerComponentHealthRestClient with an existing Rest.li RestClient (must bound to the same dmsUri).
-   * @param dmsUri URI to DMS endpoint
-   * @param restClient Rest.li RestClient
-   * @return
+   * @see BaseRestClientFactory#registerRestClient(String, RestClient)
    */
-  public static ServerComponentHealthRestClient getClient(String dmsUri, RestClient restClient) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    if (overrides.containsKey(dmsUri)) {
-      return overrides.get(dmsUri);
-    }
-    return new ServerComponentHealthRestClient(restClient);
-  }
-
-  /**
-   * Used mainly for testing, to override the ServerComponentHealthRestClient returned for a given dmsUri.
-   * Note that this is an static method, each test case should use its own dmsUri, to avoid conflicts
-   * in case the test are running in parallel.
-   */
-  public static void addOverride(String dmsUri, ServerComponentHealthRestClient restClient) {
-    dmsUri = RestliUtils.sanitizeUri(dmsUri);
-    overrides.put(dmsUri, restClient);
-  }
-
-  /**
-   * @return the current RestClient override mappings
-   */
-  public static Map<String, ServerComponentHealthRestClient> getOverrides() {
-    return Collections.unmodifiableMap(overrides);
+  public static void registerRestClient(String dmsUri, RestClient restClient) {
+    FACTORY.registerRestClient(dmsUri, restClient);
   }
 }

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -279,7 +279,6 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
         .getMetadata()
         .get("key")
         .equals("testDatastreamUpdate2"), 100, 10000));
-    restClient.shutdown();
   }
 
   @Test

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
@@ -241,9 +241,6 @@ public class DatastreamRestClientCli {
     } catch (Exception e) {
       System.out.println(e.toString());
     } finally {
-      if (datastreamRestClient != null) {
-        datastreamRestClient.shutdown();
-      }
       System.exit(0);
     }
   }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
@@ -19,19 +19,39 @@ public class ReflectionUtils {
   /**
    * Create an instance of the specified class with constuctor
    * matching the argument array.
+   * @param className name of the class
+   * @param args argument array
+   * @param <T> type fo the class
+   * @return instance of the class, or null if anything went wrong
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> T createInstance(String className, Object... args) {
+    Validate.notNull(className, "null class name");
+    Class<T> clazz;
+    try {
+      clazz = (Class<T>) Class.forName(className);
+    } catch (Exception e) {
+      LOG.warn("Failed to find class with name: " + className, e);
+      return null;
+    }
+    return createInstance(clazz, args);
+  }
+
+  /**
+   * Create an instance of the specified class with constuctor
+   * matching the argument array.
    * @param clazz name of the class
    * @param args argument array
    * @param <T> type fo the class
    * @return instance of the class, or null if anything went wrong
    */
   @SuppressWarnings("unchecked")
-  public static <T> T createInstance(String clazz, Object... args) {
+  public static <T> T createInstance(Class<T> clazz, Object... args) {
     Validate.notNull(clazz, "null class name");
     try {
-      Class<T> classObj = (Class<T>) Class.forName(clazz);
       Class<?>[] argTypes = new Class<?>[args.length];
       IntStream.range(0, args.length).forEach(i -> argTypes[i] = args[i].getClass());
-      Constructor<T> ctor = classObj.getDeclaredConstructor(argTypes);
+      Constructor<T> ctor = clazz.getDeclaredConstructor(argTypes);
       return ctor.newInstance(args);
     } catch (Exception e) {
       LOG.warn("Failed to create instance for: " + clazz, e);

--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/TestReflectionUtils.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/TestReflectionUtils.java
@@ -50,7 +50,7 @@ public class TestReflectionUtils {
 
     boolean exception = false;
     try {
-      ReflectionUtils.createInstance(null);
+      ReflectionUtils.createInstance((String) null);
     } catch (Exception e) {
       exception = true;
     }


### PR DESCRIPTION
- added a base class for custom Restli client factories
- reuse R2 RestClient as much as possible
- use a single HttpClientFactory to avoid leaking file handles
- remove unnecessary ctors in restli clients
- remove the shutdown method() due to reuse