### PR TITLE
Add shutdown() API for RestClient factories

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
@@ -1,13 +1,18 @@
 package com.linkedin.datastream;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.callback.FutureCallback;
+import com.linkedin.common.util.None;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.ReflectionUtils;
 import com.linkedin.datastream.common.RestliUtils;
@@ -44,19 +49,20 @@ import com.linkedin.restli.client.RestClient;
  * @param <T> type of the specific Rest.li client wrapper (eg. DatastreamRestClient).
  */
 public final class BaseRestClientFactory<T> {
-  private static final HttpClientFactory CLIENT_FACTORY = new HttpClientFactory();
+  private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(10);
 
   private final Logger _logger;
   private final Class<T> _restClientClass;
   private final Map<String, T> _overrides = new ConcurrentHashMap<>();
   private final Map<String, RestClient> _restClients = new ConcurrentHashMap<>();
+  private HttpClientFactory _httpClientFactory = new HttpClientFactory();
 
   /**
    * @param clazz Class object of the Rest.li client wrapper
    */
-  public BaseRestClientFactory(Class<T> clazz) {
+  public BaseRestClientFactory(Class<T> clazz, Logger logger) {
     _restClientClass = clazz;
-    _logger = LoggerFactory.getLogger(this.getClass());
+    _logger = logger;
   }
 
   /**
@@ -100,6 +106,68 @@ public final class BaseRestClientFactory<T> {
     _overrides.put(uri, restliClient);
   }
 
+  /**
+   * This must be called to allow JVM to shutdown cleanly. This is necessary because
+   * R2 HttpClientFactory creates non-daemon threads for RestClient. Default shutdown
+   * timeout is 5000ms (see: {@link HttpClientFactory#DEFAULT_SHUTDOWN_TIMEOUT}. For
+   * HttpClientFactory shutdown, we use @param timeout.
+   * @param callback callback to receive shutdown status
+   * @param timeout timeout wait for two times of this duration before giving up
+   */
+  public synchronized void shutdown(Callback<None> callback, Duration timeout) {
+    if (_httpClientFactory == null) {
+      return;
+    }
+
+    if (!_restClients.isEmpty()) {
+      // We are not interested in individual client shutdown status
+      // given R2 client already has sufficient logging for such.
+      FutureCallback<None> noopCallback = new FutureCallback<>();
+
+      _logger.info("Initiating asynchronous shutdown of all RestClients ...");
+      for (RestClient restClient : _restClients.values()) {
+        restClient.shutdown(noopCallback);
+      }
+      _restClients.clear();
+      _logger.info("All RestClients are shutdown successfully ...");
+    }
+
+    final CountDownLatch shutdownLatch = new CountDownLatch(1);
+
+    // HttpClientFactory actually reference counts all RestClients managed by itself.
+    // Once the count reaches zero, the factory self shuts down as such below code is
+    // most likely be an noop unless some RestClients failed to shutdown above.
+    _httpClientFactory.shutdown(new Callback<None>() {
+      @Override
+      public void onSuccess(None none) {
+        shutdownLatch.countDown();
+        _logger.info("Shutdown complete");
+        if (callback != null) {
+          callback.onSuccess(none);
+        }
+      }
+
+      @Override
+      public void onError(Throwable e) {
+        shutdownLatch.countDown();
+        _logger.error("Error during shutdown", e);
+        if (callback != null) {
+          callback.onError(e);
+        }
+      }
+    }, timeout.toMillis(), TimeUnit.MILLISECONDS);
+
+    try {
+      shutdownLatch.await(timeout.toMillis() * 2, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      _logger.error("HttpClientFactory failed to shutdown properly.", e);
+    } finally {
+      // Always nullify the factory as we do not know the state of the
+      // factory in case if fails to properly shutdown.
+      _httpClientFactory = null;
+    }
+  }
+
   private T getOverride(String uri) {
     uri = RestliUtils.sanitizeUri(uri);
     return _overrides.getOrDefault(uri, null);
@@ -114,7 +182,7 @@ public final class BaseRestClientFactory<T> {
     RestClient restClient;
     String key = getKey(uri, httpConfig);
     restClient = _restClients.computeIfAbsent(key, (k) ->
-      new RestClient(new TransportClientAdapter(CLIENT_FACTORY.getClient(httpConfig)), canonicalUri));
+      new RestClient(new TransportClientAdapter(_httpClientFactory.getClient(httpConfig)), canonicalUri));
     return restClient;
   }
 

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
@@ -1,8 +1,14 @@
 package com.linkedin.datastream;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.util.None;
 import com.linkedin.restli.client.RestClient;
 
 
@@ -14,8 +20,9 @@ import com.linkedin.restli.client.RestClient;
  * DatastreamRestClient, without doing a major refactoring of the code.
  */
 public final class DatastreamRestClientFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(DatastreamRestClientFactory.class);
   private static final BaseRestClientFactory<DatastreamRestClient> FACTORY =
-      new BaseRestClientFactory<>(DatastreamRestClient.class);
+      new BaseRestClientFactory<>(DatastreamRestClient.class, LOG);
 
   /**
    * Get a DatastreamRestClient with default HTTP client
@@ -50,5 +57,12 @@ public final class DatastreamRestClientFactory {
    */
   public static void registerRestClient(String dmsUri, RestClient restClient) {
     FACTORY.registerRestClient(dmsUri, restClient);
+  }
+
+  /**
+   * @see BaseRestClientFactory#shutdown(Callback, Duration)
+   */
+  public static void shutdown(Callback<None> callback, Duration timeout) {
+    FACTORY.shutdown(callback, timeout);
   }
 }

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
@@ -1,9 +1,16 @@
 package com.linkedin.diagnostics;
 
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.common.callback.Callback;
+import com.linkedin.common.util.None;
 import com.linkedin.datastream.BaseRestClientFactory;
+import com.linkedin.datastream.DatastreamRestClientFactory;
 import com.linkedin.restli.client.RestClient;
 
 
@@ -11,8 +18,9 @@ import com.linkedin.restli.client.RestClient;
  * Factory class for obtaining {@link ServerComponentHealthRestClient} objects.
  */
 public final class ServerComponentHealthRestClientFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(DatastreamRestClientFactory.class);
   private static final BaseRestClientFactory<ServerComponentHealthRestClient> FACTORY =
-      new BaseRestClientFactory<>(ServerComponentHealthRestClient.class);
+      new BaseRestClientFactory<>(ServerComponentHealthRestClient.class, LOG);
 
   /**
    * Get a ServerComponentHealthRestClient with default HTTP client
@@ -40,5 +48,12 @@ public final class ServerComponentHealthRestClientFactory {
    */
   public static void registerRestClient(String dmsUri, RestClient restClient) {
     FACTORY.registerRestClient(dmsUri, restClient);
+  }
+
+  /**
+   * @see BaseRestClientFactory#shutdown(Callback, Duration)
+   */
+  public static void shutdown(Callback<None> callback, Duration timeout) {
+    FACTORY.shutdown(callback, timeout);
   }
 }

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
@@ -158,24 +158,23 @@ public class DatastreamRestClientCli {
     DatastreamRestClient datastreamRestClient = null;
     try {
       datastreamRestClient = DatastreamRestClientFactory.getClient(dmsUri);
+      String datastreamName;
       switch (op) {
-        case READ: {
-          String datastreamName = getOptionValue(cmd, OptionConstants.OPT_SHORT_DATASTREAM_NAME, options);
+        case READ:
+          datastreamName = getOptionValue(cmd, OptionConstants.OPT_SHORT_DATASTREAM_NAME, options);
           Datastream stream = datastreamRestClient.getDatastream(datastreamName);
           printDatastreams(noformat, Collections.singletonList(stream));
-          return;
-        }
+          break;
         case READALL:
           printDatastreams(noformat, datastreamRestClient.getAllDatastreams());
-          return;
-        case DELETE: {
-          String datastreamName = getOptionValue(cmd, OptionConstants.OPT_SHORT_DATASTREAM_NAME, options);
+          break;
+        case DELETE:
+          datastreamName = getOptionValue(cmd, OptionConstants.OPT_SHORT_DATASTREAM_NAME, options);
           datastreamRestClient.deleteDatastream(datastreamName);
           System.out.println("Success");
-          return;
-        }
-        case CREATE: {
-          String datastreamName = getOptionValue(cmd, OptionConstants.OPT_SHORT_DATASTREAM_NAME, options);
+          break;
+        case CREATE:
+          datastreamName = getOptionValue(cmd, OptionConstants.OPT_SHORT_DATASTREAM_NAME, options);
           String sourceUri = getOptionValue(cmd, OptionConstants.OPT_SHORT_SOURCE_URI, options);
           String connectorName = getOptionValue(cmd, OptionConstants.OPT_SHORT_CONNECTOR_NAME, options);
 
@@ -234,14 +233,13 @@ public class DatastreamRestClientCli {
               datastreamRestClient.waitTillDatastreamIsInitialized(datastreamName, (int) timeout.toMillis());
           System.out.printf("Initialized %s datastream: %s\n", connectorName, completeDatastream);
           break;
-        }
         default:
           // do nothing
       }
     } catch (Exception e) {
       System.out.println(e.toString());
     } finally {
-      System.exit(0);
+      DatastreamRestClientFactory.shutdown(null, Duration.ofSeconds(30));
     }
   }
 


### PR DESCRIPTION
HttpClientFactory by default creates non-deamon threads for each
RestClient it produces. Given we are reusing all RestClients and
disables explicit shutdown of the high level RestClient classes, eg.
DatastreamRestClient, we need to provide a way for upper code to
inform us about the final shutdown when we must call shutdown on each
RestClient to release the non-daemon threads, otherwise JVM will fail to
shutdown cleanly.

This change add such API to the individual factories which can be called
during application shutdown with support of callback and timeout.