### PR TITLE
Make HttpClientFactory create daemon threads

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
@@ -1,14 +1,11 @@
 package com.linkedin.datastream;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.common.callback.Callback;
-import com.linkedin.common.util.None;
 import com.linkedin.restli.client.RestClient;
 
 
@@ -57,12 +54,5 @@ public final class DatastreamRestClientFactory {
    */
   public static void registerRestClient(String dmsUri, RestClient restClient) {
     FACTORY.registerRestClient(dmsUri, restClient);
-  }
-
-  /**
-   * @see BaseRestClientFactory#shutdown(Callback, Duration)
-   */
-  public static void shutdown(Callback<None> callback, Duration timeout) {
-    FACTORY.shutdown(callback, timeout);
   }
 }

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
@@ -1,14 +1,11 @@
 package com.linkedin.diagnostics;
 
-import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.linkedin.common.callback.Callback;
-import com.linkedin.common.util.None;
 import com.linkedin.datastream.BaseRestClientFactory;
 import com.linkedin.datastream.DatastreamRestClientFactory;
 import com.linkedin.restli.client.RestClient;
@@ -48,12 +45,5 @@ public final class ServerComponentHealthRestClientFactory {
    */
   public static void registerRestClient(String dmsUri, RestClient restClient) {
     FACTORY.registerRestClient(dmsUri, restClient);
-  }
-
-  /**
-   * @see BaseRestClientFactory#shutdown(Callback, Duration)
-   */
-  public static void shutdown(Callback<None> callback, Duration timeout) {
-    FACTORY.shutdown(callback, timeout);
   }
 }

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
@@ -238,8 +238,6 @@ public class DatastreamRestClientCli {
       }
     } catch (Exception e) {
       System.out.println(e.toString());
-    } finally {
-      DatastreamRestClientFactory.shutdown(null, Duration.ofSeconds(30));
     }
   }
 


### PR DESCRIPTION
This essentially revert the change introduced in:
  Add shutdown() API for RestClient factories

Because in practice, we have seen the shutdown still leaves remnant
non-daemon R2 threads alive for no obivous reasons. Debugging this
wasn't fruitful. Given we do not have a use case to accessing DMS during
shutdown, we do not have to use daemon threads for our RestClient
factories.

This change removes the non-working shutdown() method and provides a
custom thread factory to create daemon threads for HttpClientFactory.

This has been verified to resolve the lingering R2 threads issue.