### PR TITLE
Update events processed rate in Kafka Connector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -193,6 +193,7 @@ public class KafkaConnectorTask implements Runnable {
             _consumerMetrics.updateNumPolls(1);
             _consumerMetrics.updateEventCountsPerPoll(records.count());
             if (!records.isEmpty()) {
+              _consumerMetrics.updateEventsProcessedRate(records.count());
               _consumerMetrics.updateLastEventReceivedTime(Instant.now());
             }
           } catch (NoOffsetForPartitionException e) {


### PR DESCRIPTION
The event rate is not being updated right now and always shows up as zero. Update with the events read.