### PR TITLE
Tolerate temporary race condition in assignment

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -409,14 +409,14 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     // all datastream tasks for all connector types
     Map<String, List<DatastreamTask>> currentAssignment = new HashMap<>();
     assignment.forEach(ds -> {
-
       DatastreamTask task = getDatastreamTask(ds);
-
-      String connectorType = task.getConnectorType();
-      if (!currentAssignment.containsKey(connectorType)) {
-        currentAssignment.put(connectorType, new ArrayList<>());
+      if (task != null) {
+        String connectorType = task.getConnectorType();
+        if (!currentAssignment.containsKey(connectorType)) {
+          currentAssignment.put(connectorType, new ArrayList<>());
+        }
+        currentAssignment.get(connectorType).add(task);
       }
-      currentAssignment.get(connectorType).add(task);
     });
 
     _log.info(printAssignmentByType(currentAssignment));
@@ -499,13 +499,17 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       return _assignedDatastreamTasks.get(taskName);
     } else {
       DatastreamTaskImpl task = _adapter.getAssignedDatastreamTask(_adapter.getInstanceName(), taskName);
-      DatastreamGroup dg = _datastreamCache.getDatastreamGroups()
-          .stream()
-          .filter(x -> x.getTaskPrefix().equals(task.getTaskPrefix()))
-          .findFirst()
-          .get();
 
-      task.setDatastreams(dg.getDatastreams());
+      if (task != null) {
+        DatastreamGroup dg = _datastreamCache.getDatastreamGroups()
+            .stream()
+            .filter(x -> x.getTaskPrefix().equals(task.getTaskPrefix()))
+            .findFirst()
+            .get();
+
+        task.setDatastreams(dg.getDatastreams());
+      }
+
       return task;
     }
   }


### PR DESCRIPTION
Given the nature of leader/follower structure, it can happen that when a
follower is reading the task nodes, the nodes might have been deleted in
before this but after the assignment watch has triggered. In this case,
current behavior is to throw and recover in the next immediate assignment
event queued up by coordinator. This change wraps the zk access for task
node in a try/catch so that we do not throw and increment error counter
unnecessarily causing false alarms.