### PR TITLE
Adding utility class FlushlessEventProducerHandler

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecordBuilder.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecordBuilder.java
@@ -25,6 +25,7 @@ public class DatastreamProducerRecordBuilder {
   private List<BrooklinEnvelope> _events = new ArrayList<>();
   private long _eventsSourceTimestamp;
   private Optional<String> _partitionKey = Optional.empty();
+  private Optional<String> _destination = Optional.empty();
 
   /**
    * Partition to which this DatastreamProducerRecord should be produced. if the partition is not set, TransportProvider
@@ -39,6 +40,11 @@ public class DatastreamProducerRecordBuilder {
   public void setPartitionKey(String partitionKey) {
     Validate.notEmpty(partitionKey, "partitionKey cannot be empty.");
     _partitionKey = Optional.of(partitionKey);
+  }
+
+  public void setDestination(String destination) {
+    Validate.notEmpty(destination, "destination cannot be empty.");
+    _destination = Optional.of(destination);
   }
 
   /**
@@ -72,6 +78,7 @@ public class DatastreamProducerRecordBuilder {
    *   DatastreamProducerRecord that is created.
    */
   public DatastreamProducerRecord build() {
-    return new DatastreamProducerRecord(_events, _partition, _partitionKey, _sourceCheckpoint, _eventsSourceTimestamp);
+    return new DatastreamProducerRecord(_events, _partition, _partitionKey, _destination, _sourceCheckpoint,
+        _eventsSourceTimestamp);
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
@@ -1,0 +1,158 @@
+package com.linkedin.datastream.server;
+
+import java.util.Comparator;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nullable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class for Sending events to the corresponding EventProducer and keeping track of the in flight messages,
+ * and the acknowledge checkpoints for each destination partition.
+ *
+ * The main assumption of this class is that: For each  destination/partition tuple, the send method should
+ * be called with monotonically ascending checkpoints.
+ *
+ * @param <T> Type of the checkpoint object internally used by the connector.
+ */
+
+class FlushlessEventProducerHandler<T> {
+  private static final Logger LOG = LoggerFactory.getLogger(FlushlessEventProducerHandler.class);
+  private ConcurrentHashMap<DestinationPartition, CallbackStatus> _callbackStatusMap = new ConcurrentHashMap<>();
+
+  private final DatastreamEventProducer _eventProducer;
+
+  FlushlessEventProducerHandler(DatastreamEventProducer eventProducer) {
+    _eventProducer = eventProducer;
+  }
+
+  /**
+   * Reset all the inflight status counter, and metadata stored for this eventProducer.
+   * This should be used, after calling flush and getting partition reassignments.
+   */
+  public void clear() {
+    _callbackStatusMap.clear();
+  }
+
+  /**
+   * Sends event to the transport, using the passed EventProducer.
+   *
+   * NOTE: This method should be called with monotonically increasing checkpoints for a giving DestinationPartition.
+   * @param record the event to send
+   * @param checkpoint the checkpoint associated with this event.
+   *                   Multiple events could share the same checkpoint.
+   */
+  public void send(DatastreamProducerRecord record, T checkpoint) {
+    DestinationPartition dp =
+        new DestinationPartition(record.getDestination().orElse(""), record.getPartition().orElse(0));
+    CallbackStatus status = _callbackStatusMap.computeIfAbsent(dp, d -> new CallbackStatus());
+    status.register(checkpoint);
+    _eventProducer.send(record, ((metadata, exception) -> {
+      if (exception != null) {
+        LOG.error("Failed to send datastream record: " + metadata, exception);
+      }
+      status.ack(checkpoint);
+    }));
+  }
+
+  /**
+   * @return the latest safe checkpoint acknowledge by a destination Partition. Null if not event has been acknowledged.
+   */
+  @Nullable
+  public T getAckCheckpoint(String destination, int partition) {
+    if (destination == null) {
+      destination = "";
+    }
+    CallbackStatus status = _callbackStatusMap.get(new DestinationPartition(destination, partition));
+    return status != null ? status.getAckCheckpoint() : null;
+  }
+
+  public long getInFlightCount(String destination, int partition) {
+    if (destination == null) {
+      destination = "";
+    }
+    CallbackStatus status = _callbackStatusMap.get(new DestinationPartition(destination, partition));
+    return status != null ? status.getInFlightCount() : 0;
+  }
+
+  /**
+   * @return the smallest checkpoint acknowledged by all destinations. Null if not event has been acknowledged.
+   *         If all tasks are up to date, returns the passed {@code currentCheckpoint}
+   *         NOTE: This method assume that the checkpoints are monotonically increasing across DestinationPartition.
+   *               For example, for a connector reading from a source with a global monotonic SCN (e.g. Espresso)
+   *               this function will work correctly.
+   */
+  @Nullable
+  public T getAckCheckpoint(T currentCheckpoint, Comparator<T> checkpointComparator) {
+    T lowWaterMark = null;
+
+    for (CallbackStatus status : _callbackStatusMap.values()) {
+      if (status.getInFlightCount() > 0) {
+        T checkpoint = status.getAckCheckpoint();
+        if (checkpoint == null) {
+          return null; // no events ack yet for this topic partition
+        }
+        if (lowWaterMark == null || checkpointComparator.compare(checkpoint, lowWaterMark) < 0) {
+          lowWaterMark = checkpoint;
+        }
+      }
+    }
+
+    return lowWaterMark != null ? lowWaterMark : currentCheckpoint;
+  }
+
+  /**
+   * Helper class to store the callback status of the inFlight events.
+   */
+  private class CallbackStatus {
+    private T _currentCheckpoint = null;
+    private T _prevCheckpoint = null;
+    private AtomicLong _inFlight = new AtomicLong(0);
+
+    public T getAckCheckpoint() {
+      if (_inFlight.get() > 0) {
+        // If messages are in flight, the current checkpoint could be partial in case of multiple
+        // messages for the same checkpoint. It is safer to return the previous one in this case.
+        return _prevCheckpoint;
+      }
+      return _currentCheckpoint;
+    }
+
+    public long getInFlightCount() {
+      return _inFlight.get();
+    }
+
+    public void register(T checkpoint) {
+      _inFlight.incrementAndGet();
+    }
+
+    /**
+     * The checkpoints should acknowledgement comes in order for a Given DestinationPartition
+     */
+    public synchronized void ack(T checkpoint) {
+      _inFlight.decrementAndGet();
+      if (!Objects.equals(_currentCheckpoint, checkpoint)) {
+        _prevCheckpoint = _currentCheckpoint;
+      }
+      _currentCheckpoint = checkpoint;
+    }
+  }
+
+  public static final class DestinationPartition extends Pair<String, Integer> {
+    public DestinationPartition(String destination, int partition) {
+      super(destination, partition);
+    }
+
+    public String getDestination() {
+      return getKey();
+    }
+
+    public int getPartition() {
+      return getValue();
+    }
+  }
+}

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/Pair.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/Pair.java
@@ -1,5 +1,8 @@
 package com.linkedin.datastream.server;
 
+import java.util.Objects;
+
+
 public class Pair<K, V> {
 
   private final V _value;
@@ -16,5 +19,27 @@ public class Pair<K, V> {
 
   public K getKey() {
     return _key;
+  }
+
+  public boolean equals(Object obj)
+  {
+    if (obj instanceof Pair)
+    {
+      Pair other = (Pair) obj;
+      return  Objects.equals(_key, other._key) &&
+          Objects.equals(_value, other._value);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_key, _value);
+  }
+
+  /*convenient method*/
+  public static <S, T> Pair<S, T> of(S first, T second)
+  {
+    return new Pair<S, T>(first, second);
   }
 }

--- a/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestFlushlessEventProducerHandler.java
+++ b/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestFlushlessEventProducerHandler.java
@@ -1,0 +1,153 @@
+package com.linkedin.datastream.server;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.datastream.common.BrooklinEnvelope;
+import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
+import com.linkedin.datastream.server.api.transport.SendCallback;
+
+import static com.linkedin.datastream.server.FlushlessEventProducerHandler.DestinationPartition;
+
+
+public class TestFlushlessEventProducerHandler {
+  private static final Long BIG_CHECKPOINT = Long.MAX_VALUE;
+  private static Random _rnd = new Random();
+  private static final String TOPIC = "MyTopic";
+
+  @Test
+  public void testSingleRecord() throws Exception {
+    RandomEventProducer eventProducer = new RandomEventProducer();
+    FlushlessEventProducerHandler<Long> handler = new FlushlessEventProducerHandler<>(eventProducer);
+
+    long checkpoint = 1;
+    DatastreamProducerRecord record = getDatastreamProducerRecord(checkpoint, TOPIC, 1);
+
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
+    handler.send(record, checkpoint);
+    Assert.assertNull(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()));
+    Assert.assertEquals(handler.getInFlightCount(TOPIC, 1), 1);
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, 1), null);
+    eventProducer.flush();
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
+    Assert.assertEquals(handler.getInFlightCount(TOPIC, 1), 0);
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, 1), new Long(checkpoint));
+  }
+
+  @Test
+  public void testMultipleSends() throws Exception {
+    RandomEventProducer eventProducer = new RandomEventProducer();
+    FlushlessEventProducerHandler<Long> handler = new FlushlessEventProducerHandler<>(eventProducer);
+
+    // Send 100 messages
+    for (int i = 0; i < 1000; i++) {
+      DestinationPartition tp = new DestinationPartition(TOPIC, _rnd.nextInt(10));
+      sendEvent(tp, handler, i / 2);
+    }
+
+    for (int i = 0; i < 999; i++) {
+      eventProducer.processOne();
+      long minOffsetPending = eventProducer.minCheckpoint();
+      Long checkpoint = handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder());
+      long ackOffset = checkpoint == null ? -1 : checkpoint;
+
+      Assert.assertTrue(ackOffset < minOffsetPending,
+          "Not true that " + ackOffset + " is less than " + minOffsetPending);
+    }
+    eventProducer.processOne();
+
+    for (int par=0; par < 10; par++) {
+      Assert.assertEquals(handler.getInFlightCount(TOPIC, par), 0);
+    }
+
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
+
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
+  }
+
+  private void sendEvent(DestinationPartition tp, FlushlessEventProducerHandler<Long> handler, long checkpoint) {
+    DatastreamProducerRecord record = getDatastreamProducerRecord(checkpoint, tp.getKey(), tp.getValue());
+    handler.send(record, checkpoint);
+  }
+
+  private DatastreamProducerRecord getDatastreamProducerRecord(Long checkpoint, String topic, int partition) {
+    BrooklinEnvelope emptyEnvelope = new BrooklinEnvelope("1", "value", new HashMap<>());
+    DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
+    builder.addEvent(emptyEnvelope);
+    builder.setPartition(partition);
+    builder.setSourceCheckpoint(checkpoint.toString());
+    builder.setEventsSourceTimestamp(System.currentTimeMillis());
+    builder.setDestination(topic);
+    return builder.build();
+  }
+
+  private static class RandomEventProducer implements DatastreamEventProducer {
+    Map<DestinationPartition, List<Pair<DatastreamProducerRecord, SendCallback>>> _queue = new HashMap<>();
+    List<DestinationPartition> tps = new ArrayList<>();
+    private double _exceptionProb;
+
+    public RandomEventProducer() {
+      this(0.0);
+    }
+
+    public RandomEventProducer(double exceptionProb) {
+      _exceptionProb = exceptionProb;
+    }
+
+    @Override
+    public synchronized void send(DatastreamProducerRecord record, SendCallback callback) {
+      DestinationPartition tp = new DestinationPartition(TOPIC, record.getPartition().orElse(0));
+      if (!tps.contains(tp)) {
+        tps.add(tp);
+      }
+      _queue.computeIfAbsent(tp, x -> new ArrayList<>()).add(Pair.of(record, callback));
+    }
+
+    public synchronized void processOne() {
+      int start = _rnd.nextInt(tps.size());
+      for (int i = 0; i < tps.size(); i++) {
+        DestinationPartition tp = tps.get((i + start) % tps.size());
+        if (!_queue.get(tp).isEmpty()) {
+          Pair<DatastreamProducerRecord, SendCallback> pair = _queue.get(tp).remove(0);
+          DatastreamProducerRecord record = pair.getKey();
+          SendCallback callback = pair.getValue();
+
+          DatastreamRecordMetadata metadata =
+              new DatastreamRecordMetadata(record.getCheckpoint(), TOPIC, record.getPartition().orElse(0));
+          Exception exception = null;
+          if (_rnd.nextDouble() < _exceptionProb) {
+            exception = new RuntimeException("Simulating Flakiness sending messages");
+          }
+          callback.onCompletion(metadata, exception);
+          return;
+        }
+      }
+    }
+
+    @Override
+    public synchronized void flush() {
+      while (_queue.values().stream().anyMatch(l -> !l.isEmpty())) {
+        processOne();
+      }
+    }
+
+    public long minCheckpoint() {
+      return _queue.values()
+          .stream()
+          .flatMap(Collection::stream)
+          .map(Pair::getKey)
+          .map(DatastreamProducerRecord::getCheckpoint)
+          .mapToLong(Long::valueOf)
+          .min()
+          .getAsLong();
+    }
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -185,7 +185,9 @@ public class EventProducer implements DatastreamEventProducer {
       // Serialize
       record.serializeEvents(_datastreamTask.getDestinationSerDes());
       // Send
-      _transportProvider.send(_datastreamTask.getDatastreamDestination().getConnectionString(), record,
+      String destination =
+          record.getDestination().orElse(_datastreamTask.getDatastreamDestination().getConnectionString());
+      _transportProvider.send(destination, record,
           (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record));
     } catch (Exception e) {
       if (_skipBadMessagesEnabled) {


### PR DESCRIPTION
The purpose of this class is to keep metrics of inFlight messages for
each topic partition; and the safe checkpoint processed.

Also I am introducing the concept of Destination in the DatastreamProducerRecord; If it is set, then it override the destination indicated at the datastream level.

This will be useful for MirrowMaker scenarios.
