### PR TITLE
Create abstract Kafka-based connector task and use for KafkaConnector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -1,0 +1,446 @@
+package com.linkedin.datastream.connectors.kafka;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.codehaus.jackson.type.TypeReference;
+import org.slf4j.Logger;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.JsonUtils;
+import com.linkedin.datastream.common.VerifiableProperties;
+import com.linkedin.datastream.connectors.CommonConnectorMetrics;
+import com.linkedin.datastream.server.DatastreamEventProducer;
+import com.linkedin.datastream.server.DatastreamProducerRecord;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.DatastreamTaskStatus;
+
+
+/**
+ * Base class for connector task, where the connector is Kafka-based. This base class provides basic structure for
+ * Kafka-based connectors, which usually have similar processing pattern: subscribe() then run-loop to poll() and
+ * process(). This also handles managing metrics as well as checkpointing at a configurable offset commit interval.
+ */
+abstract public class AbstractKafkaBasedConnectorTask implements Runnable, ConsumerRebalanceListener {
+
+  private final Logger _logger;
+
+  protected static final String PROCESSING_DELAY_LOG_THRESHOLD_MS = "processingDelayLogThreshold";
+  protected static final long DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MS = Duration.ofMinutes(1).toMillis();
+  protected final long _processingDelayLogThresholdMs;
+  protected long _lastCommittedTime = System.currentTimeMillis();
+  protected int _eventsProcessedCount = 0;
+  protected static final Duration LOG_EVENTS_PROCESSED_PROGRESS_DURATION = Duration.ofMinutes(1);
+  protected Instant _eventsProcessedCountLoggedTime;
+  private static final long POLL_BUFFER_TIME_MS = 1000;
+
+  protected final Properties _consumerProps;
+  protected final String _datastreamName;
+  protected final Datastream _datastream;
+
+  // lifecycle
+  protected volatile boolean _shouldDie = false;
+  protected final CountDownLatch _startedLatch = new CountDownLatch(1);
+  protected final CountDownLatch _stoppedLatch = new CountDownLatch(1);
+
+  // config
+  protected final DatastreamTask _task;
+  protected final long _offsetCommitInterval;
+  protected final Duration _retrySleepDuration;
+  protected final int _retryCount;
+  protected final Optional<Map<Integer, Long>> _startOffsets;
+
+  // state
+  protected volatile Thread _thread;
+  protected volatile String _taskName;
+  protected DatastreamEventProducer _producer;
+  protected Consumer<?, ?> _consumer;
+
+  protected CommonConnectorMetrics _consumerMetrics;
+
+  protected AbstractKafkaBasedConnectorTask(Properties consumerProps, DatastreamTask task, long commitIntervalMillis,
+      Duration retrySleepDuration, int retryCount, Logger logger) {
+    _logger = logger;
+    _logger.info(
+        "Creating Kafka-based connector task for datastream task {} with commit interval {} ms, retry sleep duration {}"
+            + " ms, and retry count {}", task, commitIntervalMillis, retrySleepDuration.toMillis(), retryCount);
+    _task = task;
+    _datastream = task.getDatastreams().get(0);
+    _datastreamName = _datastream.getName();
+    _taskName = task.getDatastreamTaskName();
+
+    _consumerProps = consumerProps;
+    VerifiableProperties properties = new VerifiableProperties(_consumerProps);
+    _processingDelayLogThresholdMs = properties.containsKey(PROCESSING_DELAY_LOG_THRESHOLD_MS) ?
+        properties.getLong(PROCESSING_DELAY_LOG_THRESHOLD_MS) : DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MS;
+    _retryCount = retryCount;
+    _startOffsets = Optional.ofNullable(_datastream.getMetadata().get(DatastreamMetadataConstants.START_POSITION))
+        .map(json -> JsonUtils.fromJson(json, new TypeReference<Map<Integer, Long>>() {
+        }));
+    _offsetCommitInterval = commitIntervalMillis;
+    _retrySleepDuration = retrySleepDuration;
+
+    _consumerMetrics = createCommonConnectorMetrics(this.getClass().getSimpleName(), _datastreamName, _logger);
+  }
+
+  protected CommonConnectorMetrics createCommonConnectorMetrics(String className, String key, Logger errorLogger) {
+    CommonConnectorMetrics consumerMetrics = new CommonConnectorMetrics(className, key, errorLogger);
+    consumerMetrics.createEventProcessingMetrics();
+    consumerMetrics.createPollMetrics();
+    consumerMetrics.createPartitionMetrics();
+    return consumerMetrics;
+  }
+
+  /**
+   * Create a Kafka consumer using the consumer properties.
+   * @param consumerProps the Kafka consumer properties
+   * @return a KafkaConsumer
+   */
+  abstract Consumer<?, ?> createKafkaConsumer(Properties consumerProps);
+
+  /**
+   * Subscribe the consumer to a topic list or regex pattern and optionally set a callback (ConsumerRebalanceListener).
+   */
+  abstract void consumerSubscribe();
+
+  /**
+   * Translate the Kafka consumer record into a Datastream producer record.
+   * @param fromKafka the Kafka consumer record
+   * @param readTime the instant the record was polled from Kafka
+   * @return a Datastream producer record
+   */
+  abstract DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, Instant readTime) throws Exception;
+
+  /**
+   * Translate the Kafka consumer records if necessary and send the batch of records to destination.
+   * @param records the Kafka consumer records
+   * @param readTime the instant the records were successfully polled from the Kafka source
+   */
+  protected void translateAndSendBatch(ConsumerRecords<?, ?> records, Instant readTime) throws Exception {
+    for (ConsumerRecord<?, ?> record : records) {
+      try {
+        sendMessage(record, readTime);
+      } catch (RuntimeException e) {
+        _consumerMetrics.updateErrorRate(1);
+        // Throw the exception and let the connector rewind and retry.
+        throw e;
+      }
+    }
+  }
+
+  protected void sendMessage(ConsumerRecord<?, ?> record, Instant readTime) throws Exception {
+    int count = 0;
+    while (true) {
+      count++;
+      try {
+        int numBytes = record.serializedKeySize() + record.serializedValueSize();
+        _consumerMetrics.updateBytesProcessedRate(numBytes);
+        DatastreamProducerRecord datastreamProducerRecord = translate(record, readTime);
+        sendDatastreamProducerRecord(datastreamProducerRecord);
+        return; // Break the retry loop and exit.
+      } catch (Exception e) {
+        _logger.error("Error sending Message. task: {} ; error: {};", _taskName, e.toString());
+        _logger.error("Stack Trace: {}", Arrays.toString(e.getStackTrace()));
+        if (_shouldDie || count >= _retryCount) {
+          _logger.info("Send messages failed with exception: {}", e);
+          throw e;
+        }
+        _logger.warn("Sleeping for {} seconds before retrying. Retry {} of {}",
+            _retrySleepDuration.getSeconds(), count, _retryCount);
+        Thread.sleep(_retrySleepDuration.toMillis());
+      }
+    }
+  }
+
+  protected void sendDatastreamProducerRecord(DatastreamProducerRecord datastreamProducerRecord) throws Exception {
+    _producer.send(datastreamProducerRecord, null);
+  }
+
+  @Override
+  public void run() {
+    _logger.info("Starting the Kafka-based connector task for {}", _task);
+    boolean startingUp = true;
+    long pollInterval = 0; // so 1st call to poll is fast for purposes of startup
+    _thread = Thread.currentThread();
+
+    _producer = _task.getEventProducer();
+    _eventsProcessedCountLoggedTime = Instant.now();
+
+    try {
+      try (Consumer<?, ?> consumer = createKafkaConsumer(_consumerProps)) {
+        _consumer = consumer;
+        consumerSubscribe();
+
+        ConsumerRecords<?, ?> records;
+        while (!_shouldDie) {
+          // read a batch of records
+          records = pollRecords(pollInterval);
+
+          // handle startup notification if this is the 1st poll call
+          if (startingUp) {
+            pollInterval = getPollIntervalMs();
+            startingUp = false;
+            _startedLatch.countDown();
+          }
+
+          if (records != null && !records.isEmpty()) {
+            Instant readTime = Instant.now();
+            processRecords(records, readTime);
+            trackEventsProcessedProgress(records.count());
+          }
+        } // end while loop
+
+        // shutdown
+        maybeCommitOffsets(consumer, true);
+      }
+    } catch (Exception e) {
+      _logger.error("{} failed with exception.", _taskName, e);
+      _task.setStatus(DatastreamTaskStatus.error(e.getMessage()));
+      throw new DatastreamRuntimeException(e);
+    } finally {
+      _stoppedLatch.countDown();
+      _logger.info("{} stopped", _taskName);
+    }
+  }
+
+  public void stop() {
+    _logger.info("{} stopping", _taskName);
+    _shouldDie = true;
+    if (_consumer != null) {
+      _consumer.wakeup();
+    }
+    _thread.interrupt();
+  }
+
+  public boolean awaitStart(long timeout, TimeUnit unit) throws InterruptedException {
+    return _startedLatch.await(timeout, unit);
+  }
+
+  public boolean awaitStop(long timeout, TimeUnit unit) throws InterruptedException {
+    return _stoppedLatch.await(timeout, unit);
+  }
+
+  protected void trackEventsProcessedProgress(int recordCount) {
+    _eventsProcessedCount += recordCount;
+    Duration timeSinceLastLog = Duration.between(_eventsProcessedCountLoggedTime, Instant.now());
+    if (timeSinceLastLog.compareTo(LOG_EVENTS_PROCESSED_PROGRESS_DURATION) > 0) {
+      _logger.info("Processed {} records in {} seconds for datastream {}", _eventsProcessedCount,
+          timeSinceLastLog.getSeconds(), _datastreamName);
+      _eventsProcessedCount = 0;
+      _eventsProcessedCountLoggedTime = Instant.now();
+    }
+  }
+
+  /**
+   * Poll the records from Kafka using the specified timeout (milliseconds). If poll() fails and if retryCount is
+   * configured, this method will sleep for some duration and try polling again.
+   * @param pollInterval the timeout (in milliseconds) spent waiting in poll() if data is not available in buffer.
+   * @return the Kafka consumer records polled
+   * @throws InterruptedException if thread is interrupted during retry sleep
+   */
+  protected ConsumerRecords<?, ?> pollRecords(long pollInterval) throws InterruptedException {
+    ConsumerRecords<?, ?> records;
+    try {
+      long curPollTime = System.currentTimeMillis();
+      records = _consumer.poll(pollInterval);
+      long pollDurationMs = System.currentTimeMillis() - curPollTime;
+      if (pollDurationMs > pollInterval + POLL_BUFFER_TIME_MS) {
+        // record poll time exceeding client poll timeout
+        _logger.warn("ConsumerId: {}, Kafka client poll took {} ms (> poll timeout {} + buffer time {} ms)",
+            _taskName, pollDurationMs, pollInterval, POLL_BUFFER_TIME_MS);
+        _consumerMetrics.updateClientPollOverTimeout(1);
+      }
+      _consumerMetrics.updateNumPolls(1);
+      _consumerMetrics.updateEventCountsPerPoll(records.count());
+      if (!records.isEmpty()) {
+        _consumerMetrics.updateEventsProcessedRate(records.count());
+        _consumerMetrics.updateLastEventReceivedTime(Instant.now());
+      }
+      return records;
+    } catch (NoOffsetForPartitionException e) {
+      handleNoOffsetForPartitionException(e);
+      return ConsumerRecords.EMPTY;
+    } catch (WakeupException e) {
+      _logger.warn("Got a WakeupException, shutdown in progress {}.", e);
+      return ConsumerRecords.EMPTY;
+    } catch (Exception e) {
+      handlePollRecordsException(e);
+      return ConsumerRecords.EMPTY;
+    }
+  }
+
+  /**
+   * Processes the Kafka consumer records by translating them and sending them to the event producer.
+   * @param records the Kafka consumer records
+   * @param readTime the time at which the records were successfully polled from Kafka
+   */
+  protected void processRecords(ConsumerRecords<?, ?> records, Instant readTime) {
+    try {
+      // send the batch out the other end
+      // TODO(misanchez): we should have a way to signal the producer to stop and throw an exception
+      //                  in case the _shouldDie signal is set (similar to kafka wakeup)
+      translateAndSendBatch(records, readTime);
+
+      if (System.currentTimeMillis() - readTime.toEpochMilli() > _processingDelayLogThresholdMs) {
+        _consumerMetrics.updateProcessingAboveThreshold(1);
+      }
+
+      if (!_shouldDie) {
+        // potentially commit our offsets (if its been long enough and all sends were successful)
+        maybeCommitOffsets(_consumer, false);
+      }
+    } catch (Exception e) {
+      handleProcessRecordsException(e);
+    }
+  }
+
+  /**
+   * Handle when Kafka consumer throws OffsetOutOfRangeException. The base behavior is no-op.
+   * @param e the Exception
+   */
+  protected void handleOffsetOutOfRangeException(OffsetOutOfRangeException e) { }
+
+  /**
+   * Handle when Kafka consumer throws NoOffsetForPartitionException. The base behavior is to seek to start position
+   * for all partitions.
+   * @param e the Exception
+   */
+  protected void handleNoOffsetForPartitionException(NoOffsetForPartitionException e) {
+    _logger.info("Poll threw NoOffsetForPartitionException for partitions {}.", e.partitions());
+    if (!_shouldDie) {
+      seekToStartPosition(_consumer, e.partitions());
+    }
+  }
+
+  /**
+   * Handle exception during pollRecords(). The base behavior is to sleep for some time.
+   * @param e the Exception
+   * @throws InterruptedException
+   */
+  protected void handlePollRecordsException(Exception e) throws InterruptedException {
+    _logger.warn("Poll threw an exception. Sleeping for {} seconds and retrying. Exception: {}",
+        _retrySleepDuration.getSeconds(), e);
+    if (!_shouldDie) {
+      Thread.sleep(_retrySleepDuration.toMillis());
+    }
+  }
+
+  /**
+   * Handle exception during processRecords(). The base behavior is to seek to previous checkpoints and retry on the
+   * next poll.
+   * @param e the Exception
+   */
+  protected void handleProcessRecordsException(Exception e) {
+    _logger.info("Sending the messages failed with exception: {}", e);
+    if (_shouldDie) {
+      _logger.warn("Exiting without commit, no point to try to recover in shouldDie mode.");
+      return; // return to skip the commit after the while loop
+    }
+    _logger.info("Trying to start processing from previous checkpoint.");
+    Map<TopicPartition, OffsetAndMetadata> lastCheckpoint = new HashMap<>();
+    Set<TopicPartition> tpWithNoCommits = new HashSet<>();
+    // construct last checkpoint
+    _consumer.assignment().forEach(tp -> {
+      OffsetAndMetadata offset =  _consumer.committed(tp);
+      // offset can be null if there was no prior commit
+      if (offset == null) {
+        tpWithNoCommits.add(tp);
+      } else {
+        lastCheckpoint.put(tp, _consumer.committed(tp));
+      }
+    });
+    _logger.info("Seeking to previous checkpoints {} and start.", lastCheckpoint);
+    // reset consumer to last checkpoint
+    lastCheckpoint.forEach((tp, offsetAndMetadata) -> _consumer.seek(tp, offsetAndMetadata.offset()));
+    if (!tpWithNoCommits.isEmpty()) {
+      _logger.info("Seeking to start position {} and start.", tpWithNoCommits);
+      seekToStartPosition(_consumer, tpWithNoCommits);
+    }
+  }
+
+  /**
+   * @return the poll timeout (in milliseconds) to use in the Kafka consumer poll().
+   */
+  protected long getPollIntervalMs() {
+    return _offsetCommitInterval / 2; // leave time for processing, assume 50-50
+  }
+
+  /**
+   * Flush the producer and commit the offsets if the configured offset commit interval has been reached, or if
+   * force is set to true.
+   * @param consumer the Kafka consumer
+   * @param force whether flush and commit should happen unconditionally
+   */
+  protected void maybeCommitOffsets(Consumer<?, ?> consumer, boolean force) {
+    long now = System.currentTimeMillis();
+    long timeSinceLastCommit = now - _lastCommittedTime;
+    if (force || timeSinceLastCommit > _offsetCommitInterval) {
+      _logger.info("Trying to flush the producer and commit offsets.");
+      _producer.flush();
+      consumer.commitSync();
+      _lastCommittedTime = System.currentTimeMillis();
+    }
+  }
+
+  private void seekToStartPosition(Consumer<?, ?> consumer, Set<TopicPartition> partitions) {
+    if (_startOffsets.isPresent()) {
+      _logger.info("Datastream is configured with StartPosition. Trying to start from {}",
+          _startOffsets.get());
+      seekToOffset(consumer, partitions, _startOffsets.get());
+    } else {
+      // means we have no saved offsets for some partitions, reset it to latest for those
+      consumer.seekToEnd(partitions);
+    }
+  }
+
+  private void seekToOffset(Consumer<?, ?> consumer, Set<TopicPartition> partitions,
+      Map<Integer, Long> startOffsets) {
+    partitions.forEach(tp -> {
+      Long offset = startOffsets.get(tp.partition());
+      if (offset == null) {
+        String msg = String.format("Couldn't find the offset for partition %s", tp);
+        _logger.error(msg);
+        throw new DatastreamRuntimeException(msg);
+      }
+      consumer.seek(tp, offset);
+    });
+
+    _logger.info("Seek completed to the offsets.");
+  }
+
+  @Override
+  public void onPartitionsRevoked(Collection<TopicPartition> topicPartitions) {
+    _logger.info("Partition ownership revoked for {}, checkpointing.", topicPartitions);
+    if (!_shouldDie) { // There is a commit at the end of the run method, skip extra commit in shouldDie mode.
+      maybeCommitOffsets(_consumer, true); // happens inline as part of poll
+    }
+  }
+
+  @Override
+  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    _consumerMetrics.updateRebalanceRate(1);
+    //nop
+    _logger.info("Partition ownership assigned for {}.", partitions);
+  }
+}

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -3,128 +3,47 @@ package com.linkedin.datastream.connectors.kafka;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import java.util.Properties;
-import java.util.Set;
 import java.util.StringJoiner;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import com.google.common.annotations.VisibleForTesting;
+
+import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.NoOffsetForPartitionException;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
-import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.WakeupException;
-import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.BrooklinEnvelopeMetadataConstants;
-import com.linkedin.datastream.common.Datastream;
-import com.linkedin.datastream.common.DatastreamMetadataConstants;
-import com.linkedin.datastream.common.DatastreamRuntimeException;
-import com.linkedin.datastream.common.DatastreamSource;
-import com.linkedin.datastream.common.JsonUtils;
-import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.connectors.CommonConnectorMetrics;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.MetricsAware;
-import com.linkedin.datastream.server.DatastreamEventProducer;
 import com.linkedin.datastream.server.DatastreamProducerRecord;
 import com.linkedin.datastream.server.DatastreamProducerRecordBuilder;
 import com.linkedin.datastream.server.DatastreamTask;
-import com.linkedin.datastream.server.DatastreamTaskStatus;
 
 
-public class KafkaConnectorTask implements Runnable {
-  public static final String GROUP_ID_CONFIG = "group.id";
+public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectorTask.class);
   private static final String CLASS_NAME = KafkaConnectorTask.class.getSimpleName();
   // Regular expression to capture all metrics by this kafka connector.
   private static final String METRICS_PREFIX_REGEX = CLASS_NAME + MetricsAware.KEY_REGEX;
-  private static final long POLL_BUFFER_TIME_MS = 1000;
 
-  public static final String CFG_SKIP_BAD_MESSAGE = "skipBadMessage";
-  public static final String PROCESSING_DELAY_LOG_TRESHOLD_MS = "processingDelayLogThreshold";
-  public static final long DEFAULT_PROCESSING_DELAY_LOG_TRESHOLD_MS = Duration.ofMinutes(1).toMillis();
-  private final long _processingDelayLogThresholdMs;
-
+  private KafkaConnectionString _srcConnString =
+      KafkaConnectionString.valueOf(_task.getDatastreamSource().getConnectionString());
   private final KafkaConsumerFactory<?, ?> _consumerFactory;
-  private final Properties _consumerProps;
-  private final String _datastreamName;
-  private final Datastream _datastream;
-  private final Optional<Map<Integer, Long>> _startOffsets;
-
-  //lifecycle
-  private volatile boolean _shouldDie = false;
-  private final CountDownLatch _startedLatch = new CountDownLatch(1);
-  private final CountDownLatch _stoppedLatch = new CountDownLatch(1);
-  //config
-  private final DatastreamTask _task;
-  private final long _offsetCommitInterval;
-  private final Duration _retrySleepDuration;
-  private final int _retryCount;
-
-  //state
-  private volatile Thread _thread;
-  private volatile String _taskName;
-  private String _srcValue;
-  private DatastreamEventProducer _producer;
-  private Consumer<?, ?> _consumer;
-
-  private long _lastCommittedTime = System.currentTimeMillis();
-  private final CommonConnectorMetrics _consumerMetrics;
-
 
   public KafkaConnectorTask(KafkaConsumerFactory<?, ?> factory, Properties consumerProps, DatastreamTask task,
       long commitIntervalMillis, Duration retrySleepDuration, int retryCount) {
-    LOG.info("Creating kafka connector task for datastream task {} with commit interval {}Ms", task,
-        commitIntervalMillis);
-    _consumerProps = consumerProps;
-    VerifiableProperties properties = new VerifiableProperties(_consumerProps);
-
-    _processingDelayLogThresholdMs = properties.containsKey(PROCESSING_DELAY_LOG_TRESHOLD_MS) ?
-        properties.getLong(PROCESSING_DELAY_LOG_TRESHOLD_MS) : DEFAULT_PROCESSING_DELAY_LOG_TRESHOLD_MS;
-
+    super(consumerProps, task, commitIntervalMillis, retrySleepDuration, retryCount, LOG);
     _consumerFactory = factory;
-    _datastream = task.getDatastreams().get(0);
-    _task = task;
-    _retryCount = retryCount;
-
-    _startOffsets = Optional.ofNullable(_datastream.getMetadata().get(DatastreamMetadataConstants.START_POSITION))
-        .map(json -> JsonUtils.fromJson(json, new TypeReference<Map<Integer, Long>>() {
-        }));
-
-    _offsetCommitInterval = commitIntervalMillis;
-    _retrySleepDuration = retrySleepDuration;
-    _datastreamName = task.getDatastreams().get(0).getName();
-
-    _consumerMetrics = new CommonConnectorMetrics(CLASS_NAME, _datastreamName, LOG);
-    _consumerMetrics.createEventProcessingMetrics();
-    _consumerMetrics.createPollMetrics();
-    _consumerMetrics.createPartitionMetrics();
-    _taskName = task.getDatastreamTaskName();
-  }
-
-  public static Consumer<?, ?> createConsumer(KafkaConsumerFactory<?, ?> consumerFactory, Properties consumerProps,
-      String groupId, KafkaConnectionString connectionString) {
-
-    Properties props = getKafkaConsumerProperties(consumerProps, groupId, connectionString);
-    return consumerFactory.createConsumer(props);
   }
 
   @VisibleForTesting
@@ -135,155 +54,32 @@ public class KafkaConnectorTask implements Runnable {
     String bootstrapValue = csv.toString();
 
     Properties props = new Properties();
-    props.put("bootstrap.servers", bootstrapValue);
-    props.put("group.id", groupId);
-    props.put("enable.auto.commit", "false"); //auto-commits are unsafe
-    props.put("auto.offset.reset", "none");
-    props.put("security.protocol", connectionString.isSecure() ? "SSL" : "PLAINTEXT");
+    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapValue);
+    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); //auto-commits are unsafe
+    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, connectionString.isSecure() ? "SSL" : "PLAINTEXT");
     props.putAll(consumerProps);
     return props;
   }
 
   @Override
-  public void run() {
-    LOG.info("Starting the kafka connector task for {}", _task);
-    boolean startingUp = true;
-    long pollInterval = 0; //so 1st call to poll is fast for purposes of startup
-    _thread = Thread.currentThread();
-    try {
+  void consumerSubscribe() {
+    KafkaConnectionString srcConnString =
+        KafkaConnectionString.valueOf(_task.getDatastreamSource().getConnectionString());
+    _consumer.subscribe(Collections.singletonList(srcConnString.getTopicName()), this);
+  }
 
-      DatastreamSource source = _task.getDatastreamSource();
-      KafkaConnectionString srcConnString = KafkaConnectionString.valueOf(source.getConnectionString());
+  public static Consumer<?, ?> createConsumer(KafkaConsumerFactory<?, ?> consumerFactory, Properties consumerProps,
+      String groupId, KafkaConnectionString connectionString) {
 
-      _srcValue = srcConnString.toString();
-      _producer = _task.getEventProducer();
-      String kafkaGroupId = getKafkaGroupId(_task);
+    Properties props = getKafkaConsumerProperties(consumerProps, groupId, connectionString);
+    return consumerFactory.createConsumer(props);
+  }
 
-      try (Consumer<?, ?> consumer = createConsumer(_consumerFactory, _consumerProps, kafkaGroupId, srcConnString)) {
-        _consumer = consumer;
-        ConsumerRecords<?, ?> records;
-        consumer.subscribe(Collections.singletonList(srcConnString.getTopicName()), new ConsumerRebalanceListener() {
-          @Override
-          public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
-            LOG.info("Partition ownership revoked for {}, checkpointing.", partitions);
-            if (!_shouldDie) { // There is a commit at the end of the run method, skip extra commit in shouldDie mode.
-              maybeCommitOffsets(consumer, true); //happens inline as part of poll
-            }
-          }
-
-          @Override
-          public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-            _consumerMetrics.updateRebalanceRate(1);
-            //nop
-            LOG.info("Partition ownership assigned for {}.", partitions);
-          }
-        });
-
-        while (!_shouldDie) {
-          //read a batch of records
-          try {
-            long curPollTime = System.currentTimeMillis();
-            records = consumer.poll(pollInterval);
-            long pollDurationMs = System.currentTimeMillis() - curPollTime;
-            if (pollDurationMs > pollInterval + POLL_BUFFER_TIME_MS) {
-              // Record poll time exceeding client poll timeout
-              LOG.warn(String.format("ConsumerId: %s, Kafka client poll took %d ms (> poll timeout %d + buffer time %d ms)",
-                  _taskName, pollDurationMs, pollInterval, POLL_BUFFER_TIME_MS));
-              _consumerMetrics.updateClientPollOverTimeout(1);
-            }
-            _consumerMetrics.updateNumPolls(1);
-            _consumerMetrics.updateEventCountsPerPoll(records.count());
-            if (!records.isEmpty()) {
-              _consumerMetrics.updateEventsProcessedRate(records.count());
-              _consumerMetrics.updateLastEventReceivedTime(Instant.now());
-            }
-          } catch (NoOffsetForPartitionException e) {
-            LOG.info("Poll threw NoOffsetForPartitionException for partitions {}.", e.partitions());
-            if (_shouldDie) {
-              continue;
-            }
-            seekToStartPosition(consumer, e.partitions());
-            continue;
-          } catch (WakeupException e) {
-            LOG.warn("Got a Wakeup Exception, shutdown in progress {}.", e);
-            continue;
-
-          } catch (Exception e) {
-            LOG.warn("Poll threw an exception. Sleeping for {} seconds and retrying. Exception: {}",
-                _retrySleepDuration.getSeconds(), e);
-            if (_shouldDie) {
-              continue;
-            }
-            Thread.sleep(_retrySleepDuration.toMillis());
-            continue;
-          }
-
-          //handle startup notification if this is the 1st poll call
-          if (startingUp) {
-            pollInterval = _offsetCommitInterval / 2; //leave time for processing, assume 50-50
-            startingUp = false;
-            _startedLatch.countDown();
-          }
-
-          try {
-
-            //send the batch out the other end
-            long readTime = System.currentTimeMillis();
-            String strReadTime = String.valueOf(readTime);
-            // TODO(misanchez): we should have a way to signal the producer to stop and throw an exception
-            //                  in case the _shouldDie signal is set (similar to kafka wakeup)
-            translateAndSendBatch(records, readTime, strReadTime);
-
-            if (System.currentTimeMillis() - readTime > _processingDelayLogThresholdMs) {
-              _consumerMetrics.updateProcessingAboveThreshold(1);
-            }
-
-            if (_shouldDie) {
-              continue;
-            }
-
-            //potentially commit our offsets (if its been long enough and all sends were successful)
-            maybeCommitOffsets(consumer, false);
-          } catch (Exception e) {
-            LOG.info("sending the messages failed with exception: {}", e);
-            if (_shouldDie) {
-              LOG.warn("Exiting without commit, not point to try to recover in shouldDie mode.");
-              return; // Return to skip the commit after the while loop.
-            }
-            LOG.info("Trying to start processing from previous checkpoint.");
-            Map<TopicPartition, OffsetAndMetadata> lastCheckpoint = new HashMap<>();
-            Set<TopicPartition> tpWithNoCommits = new HashSet<>();
-            //construct last checkpoint
-            consumer.assignment().forEach(tp -> {
-              OffsetAndMetadata offset =  consumer.committed(tp);
-              // offset can be null if there was no prior commit
-              if (offset == null) {
-                tpWithNoCommits.add(tp);
-              } else {
-                lastCheckpoint.put(tp, consumer.committed(tp));
-              }
-            });
-            LOG.info("Seeking to previous checkpoints {} and start.", lastCheckpoint);
-            //reset consumer to last checkpoint
-            lastCheckpoint.forEach((tp, offsetAndMetadata) -> consumer.seek(tp, offsetAndMetadata.offset()));
-            if (!tpWithNoCommits.isEmpty()) {
-              LOG.info("Seeking to start position {} and start ", tpWithNoCommits);
-              seekToStartPosition(consumer, tpWithNoCommits);
-            }
-          }
-        }
-
-        //shutdown
-        maybeCommitOffsets(consumer, true);
-      }
-    } catch (Exception e) {
-      LOG.error("{} failed with exception.", _taskName, e);
-      _task.setStatus(DatastreamTaskStatus.error(e.getMessage()));
-      throw new DatastreamRuntimeException(e);
-    } finally {
-      _stoppedLatch.countDown();
-      LOG.info("{} stopped", _taskName);
-    }
+  @Override
+  Consumer<?, ?> createKafkaConsumer(Properties consumerProps) {
+    return createConsumer(_consumerFactory, consumerProps, getKafkaGroupId(_task), _srcConnString);
   }
 
   @VisibleForTesting
@@ -294,53 +90,10 @@ public class KafkaConnectorTask implements Runnable {
 
     return task.getDatastreams()
         .stream()
-        .map(ds -> ds.getMetadata().get(GROUP_ID_CONFIG))
+        .map(ds -> ds.getMetadata().get(ConsumerConfig.GROUP_ID_CONFIG))
         .filter(Objects::nonNull)
         .findFirst()
         .orElse(srcConnString + "-to-" + dstConnString);
-  }
-
-  private void seekToStartPosition(Consumer<?, ?> consumer, Set<TopicPartition> partitions) {
-    if (_startOffsets.isPresent()) {
-      LOG.info("Datastream is configured with StartPosition. Trying to start from {}",
-          _startOffsets.get());
-      seekToOffset(consumer, partitions, _startOffsets.get());
-    } else {
-      //means we have no saved offsets for some partitions, reset it to latest for those
-      consumer.seekToEnd(partitions);
-    }
-  }
-
-  private static void seekToOffset(Consumer<?, ?> consumer, Set<TopicPartition> partitions,
-      Map<Integer, Long> startOffsets) {
-    partitions.forEach(tp -> {
-      Long offset = startOffsets.get(tp.partition());
-      if (offset == null) {
-        String msg = String.format("Couldn't find the offset for partition %s", tp);
-        LOG.error(msg);
-        throw new DatastreamRuntimeException(msg);
-      }
-      consumer.seek(tp, offset);
-    });
-
-    LOG.info("Seek completed to the offsets.");
-  }
-
-  public void stop() {
-    LOG.info("{} stopping", _taskName);
-    _shouldDie = true;
-    if (_consumer != null) {
-      _consumer.wakeup();
-    }
-    _thread.interrupt();
-  }
-
-  public boolean awaitStart(long timeout, TimeUnit unit) throws InterruptedException {
-    return _startedLatch.await(timeout, unit);
-  }
-
-  public boolean awaitStop(long timeout, TimeUnit unit) throws InterruptedException {
-    return _stoppedLatch.await(timeout, unit);
   }
 
   public static List<BrooklinMetricInfo> getMetricInfos() {
@@ -351,67 +104,21 @@ public class KafkaConnectorTask implements Runnable {
     return metrics;
   }
 
-  private void maybeCommitOffsets(Consumer<?, ?> consumer, boolean force) {
-    long now = System.currentTimeMillis();
-    long timeSinceLastCommit = now - _lastCommittedTime;
-    if (force || timeSinceLastCommit > _offsetCommitInterval) {
-      LOG.info("Trying to flush the producer and commit offsets.");
-      _producer.flush();
-      consumer.commitSync();
-      _lastCommittedTime = System.currentTimeMillis();
-    }
-  }
-
-  private void translateAndSendBatch(ConsumerRecords<?, ?> records, long readTime, String strReadTime)
-      throws InterruptedException {
-    for (ConsumerRecord<?, ?> record : records) {
-      try {
-        sendMessage(record, readTime, strReadTime);
-      } catch (RuntimeException e) {
-        _consumerMetrics.updateErrorRate(1);
-        // Throw the exception and let the connector rewind and retry.
-        throw e;
-      }
-    }
-  }
-
-  private void sendMessage(ConsumerRecord<?, ?> record, long readTime, String strReadTime) throws InterruptedException {
-    int count = 0;
-    while (true) {
-      count++;
-      try {
-        int numBytes = record.serializedKeySize() + record.serializedValueSize();
-        _consumerMetrics.updateBytesProcessedRate(numBytes);
-        _producer.send(translate(record, readTime, strReadTime), null);
-        return; // Break the retry loop and exit.
-      } catch (RuntimeException e) {
-        LOG.error("Error sending Message. task: {} ; error: {};", _taskName, e.toString());
-        LOG.error("Stack Trace: {}", Arrays.toString(e.getStackTrace()));
-        if (_shouldDie || count >= _retryCount) {
-          LOG.info("Send messages failed with exception: {}", e);
-          throw e;
-        }
-        LOG.warn("Sleeping for {} seconds before retrying. Retry {} of {}",
-            _retrySleepDuration.getSeconds(), count, _retryCount);
-        Thread.sleep(_retrySleepDuration.toMillis());
-      }
-    }
-  }
-
-  private DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, long readTime, String strReadTime) {
+  @Override
+  protected DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, Instant readTime) {
     HashMap<String, String> metadata = new HashMap<>();
-    metadata.put("kafka-origin", _srcValue);
+    metadata.put("kafka-origin", _srcConnString.toString());
     int partition = fromKafka.partition();
     String partitionStr = String.valueOf(partition);
     metadata.put("kafka-origin-partition", partitionStr);
     String offsetStr = String.valueOf(fromKafka.offset());
     metadata.put("kafka-origin-offset", offsetStr);
-    metadata.put(BrooklinEnvelopeMetadataConstants.EVENT_TIMESTAMP, strReadTime);
+    metadata.put(BrooklinEnvelopeMetadataConstants.EVENT_TIMESTAMP, String.valueOf(readTime.toEpochMilli()));
     BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null, metadata);
     //TODO - copy over headers if/when they are ever supported
     DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
     builder.addEvent(envelope);
-    builder.setEventsSourceTimestamp(readTime);
+    builder.setEventsSourceTimestamp(readTime.toEpochMilli());
     builder.setPartition(partition); //assume source partition count is same as dest
     builder.setSourceCheckpoint(partitionStr + "-" + offsetStr);
 

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -8,6 +8,7 @@ import java.util.Properties;
 import java.util.concurrent.TimeUnit;
 
 import org.I0Itec.zkclient.ZkConnection;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -120,7 +121,7 @@ public class TestKafkaConnectorTask {
     Assert.assertEquals(KafkaConnectorTask.getKafkaGroupId(task), defaultGrpId);
 
     // Test with explicit group id
-    datastream.getMetadata().put(KafkaConnectorTask.GROUP_ID_CONFIG, "MyGroupId");
+    datastream.getMetadata().put(ConsumerConfig.GROUP_ID_CONFIG, "MyGroupId");
     Assert.assertEquals(KafkaConnectorTask.getKafkaGroupId(task), "MyGroupId");
   }
 


### PR DESCRIPTION
Extract common Kafka-based connector task code into an abstract base class. Connectors that use Kafka consumer underneath usually all follow this similar pattern. Converted the KafkaConnectorTask as an example, and verified that all the tests still pass.