### PR TITLE
Basic structure for Brooklin MirrorMaker

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -117,12 +117,12 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
    * @param consumerProps the Kafka consumer properties
    * @return a KafkaConsumer
    */
-  abstract Consumer<?, ?> createKafkaConsumer(Properties consumerProps);
+  protected abstract Consumer<?, ?> createKafkaConsumer(Properties consumerProps);
 
   /**
    * Subscribe the consumer to a topic list or regex pattern and optionally set a callback (ConsumerRebalanceListener).
    */
-  abstract void consumerSubscribe();
+  protected abstract void consumerSubscribe();
 
   /**
    * Translate the Kafka consumer record into a Datastream producer record.
@@ -130,7 +130,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
    * @param readTime the instant the record was polled from Kafka
    * @return a Datastream producer record
    */
-  abstract DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, Instant readTime) throws Exception;
+  protected abstract DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, Instant readTime) throws Exception;
 
   /**
    * Translate the Kafka consumer records if necessary and send the batch of records to destination.

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -1,0 +1,126 @@
+package com.linkedin.datastream.connectors.kafka;
+
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.ReflectionUtils;
+import com.linkedin.datastream.common.ThreadUtils;
+import com.linkedin.datastream.common.VerifiableProperties;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.api.connector.Connector;
+
+
+/**
+ * Base class for connectors that consume from Kafka.
+ */
+public abstract class AbstractKafkaConnector implements Connector {
+
+  protected static final Duration RETRY_SLEEP_DURATION = Duration.ofSeconds(5);
+  protected static final int DEFAULT_RETRY_COUNT = 5;
+
+  public static final String DOMAIN_KAFKA_CONSUMER = "consumer";
+  public static final String CONFIG_COMMIT_INTERVAL_MILLIS = "commitIntervalMs";
+  public static final String CONFIG_CONSUMER_FACTORY_CLASS = "consumerFactoryClassName";
+  public static final String CONFIG_DEFAULT_KEY_SERDE = "defaultKeySerde";
+  public static final String CONFIG_DEFAULT_VALUE_SERDE = "defaultValueSerde";
+  public static final String CONFIG_RETRY_COUNT = "retryCount";
+  protected final String _defaultKeySerde;
+  protected final String _defaultValueSerde;
+  protected final KafkaConsumerFactory<?, ?> _consumerFactory;
+  protected final Properties _consumerProps;
+
+  protected final String _name;
+  protected final long _commitIntervalMillis;
+  protected final int _retryCount;
+
+  private final Logger _logger;
+  protected final ConcurrentHashMap<DatastreamTask, AbstractKafkaBasedConnectorTask> _runningTasks =
+      new ConcurrentHashMap<>();
+  protected final ExecutorService _executor = Executors.newCachedThreadPool(new ThreadFactory() {
+    private AtomicInteger threadCounter = new AtomicInteger(0);
+
+    @Override
+    public Thread newThread(Runnable r) {
+      Thread t = new Thread(r);
+      t.setDaemon(true);
+      t.setName(_name + " worker thread " + threadCounter.incrementAndGet());
+      t.setUncaughtExceptionHandler((thread, e) -> {
+        _logger.error("thread " + thread.getName() + " has died due to uncaught exception", e);
+      });
+      return t;
+    }
+  });
+
+  public AbstractKafkaConnector(String connectorName, Properties config, Logger logger) {
+    _name = connectorName;
+    _logger = logger;
+    VerifiableProperties verifiableProperties = new VerifiableProperties(config);
+    _defaultKeySerde = verifiableProperties.getString(CONFIG_DEFAULT_KEY_SERDE, "");
+    _defaultValueSerde = verifiableProperties.getString(CONFIG_DEFAULT_VALUE_SERDE, "");
+    _commitIntervalMillis = verifiableProperties.getLongInRange(CONFIG_COMMIT_INTERVAL_MILLIS,
+        Duration.ofMinutes(1).toMillis(), 0, Long.MAX_VALUE);
+    _retryCount = verifiableProperties.getInt(CONFIG_RETRY_COUNT, DEFAULT_RETRY_COUNT);
+
+    String factory = verifiableProperties.getString(CONFIG_CONSUMER_FACTORY_CLASS,
+        KafkaConsumerFactoryImpl.class.getName());
+    _consumerFactory = ReflectionUtils.createInstance(factory);
+    if (_consumerFactory == null) {
+      throw new DatastreamRuntimeException("Unable to instantiate factory class: " + factory);
+    }
+
+    _consumerProps = verifiableProperties.getDomainProperties(DOMAIN_KAFKA_CONSUMER);
+  }
+
+  protected abstract AbstractKafkaBasedConnectorTask createKafkaBasedConnectorTask(DatastreamTask task);
+
+  @Override
+  public void onAssignmentChange(List<DatastreamTask> tasks) {
+    _logger.info("onAssignmentChange called with tasks {}", tasks);
+
+    HashSet<DatastreamTask> toCancel = new HashSet<>(_runningTasks.keySet());
+    toCancel.removeAll(tasks);
+
+    for (DatastreamTask task : toCancel) {
+      AbstractKafkaBasedConnectorTask connectorTask = _runningTasks.remove(task);
+      connectorTask.stop();
+    }
+
+    for (DatastreamTask task : tasks) {
+      if (_runningTasks.containsKey(task)) {
+        continue; // already running
+      }
+      _logger.info("creating task for {}.", task);
+      AbstractKafkaBasedConnectorTask connectorTask = createKafkaBasedConnectorTask(task);
+      _runningTasks.put(task, connectorTask);
+      _executor.submit(connectorTask);
+    }
+  }
+
+  @Override
+  public void start() {
+    //nop
+  }
+
+  @Override
+  public void stop() {
+    _runningTasks.values().forEach(AbstractKafkaBasedConnectorTask::stop);
+    //TODO - should wait?
+    _runningTasks.clear();
+    if (!ThreadUtils.shutdownExecutor(_executor, Duration.of(5, ChronoUnit.SECONDS), _logger)) {
+      _logger.warn("Failed to shut down cleanly.");
+    }
+    _logger.info("stopped.");
+  }
+
+}

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectionString.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectionString.java
@@ -13,6 +13,7 @@ import java.util.StringJoiner;
  * kafka://[host1:port1,host2:port2...]/topicName
  */
 public class KafkaConnectionString {
+  public static final String BROKER_LIST_DELIMITER = ",";
   public static final String PREFIX_SCHEME_KAFKA = "kafka://";
   public static final String PREFIX_SCHEME_SECURE_KAFKA = "kafkassl://";
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -64,7 +64,7 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
   }
 
   @Override
-  void consumerSubscribe() {
+  protected void consumerSubscribe() {
     KafkaConnectionString srcConnString =
         KafkaConnectionString.valueOf(_task.getDatastreamSource().getConnectionString());
     _consumer.subscribe(Collections.singletonList(srcConnString.getTopicName()), this);
@@ -78,7 +78,7 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
   }
 
   @Override
-  Consumer<?, ?> createKafkaConsumer(Properties consumerProps) {
+  protected Consumer<?, ?> createKafkaConsumer(Properties consumerProps) {
     return createConsumer(_consumerFactory, consumerProps, getKafkaGroupId(_task), _srcConnString);
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
@@ -1,0 +1,87 @@
+package com.linkedin.datastream.connectors.kafka.mirrormaker;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamUtils;
+import com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask;
+import com.linkedin.datastream.connectors.kafka.AbstractKafkaConnector;
+import com.linkedin.datastream.connectors.kafka.KafkaConnectionString;
+import com.linkedin.datastream.metrics.BrooklinMetricInfo;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+
+
+/**
+ * KafkaMirrorMakerConnector is similar to {@link KafkaConnector} but it has the ability to consume from multiple
+ * topics in a cluster via regular expression pattern source, and it has the ability to produce to multiple topics
+ * in the destination cluster.
+ */
+public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaMirrorMakerConnector.class);
+
+  public KafkaMirrorMakerConnector(String connectorName, Properties config) {
+    super(connectorName, config, LOG);
+  }
+
+  @Override
+  protected AbstractKafkaBasedConnectorTask createKafkaBasedConnectorTask(DatastreamTask task) {
+    return new KafkaMirrorMakerConnectorTask(_consumerFactory, _consumerProps, task, _commitIntervalMillis,
+        RETRY_SLEEP_DURATION, _retryCount);
+  }
+
+  @Override
+  public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
+    // verify that the MirrorMaker Datastream will not be re-used
+    if (DatastreamUtils.isReuseAllowed(stream)) {
+      throw new DatastreamValidationException(
+          String.format("Destination reuse is not allowed for connector %s. Datastream: %s", stream.getConnectorName(),
+              stream));
+    }
+
+    // verify that BYOT is not used
+    if (DatastreamUtils.isUserManagedDestination(stream)) {
+      throw new DatastreamValidationException(
+          String.format("BYOT is not allowed for connector %s. Datastream: %s", stream.getConnectorName(),
+              stream));
+    }
+
+
+    if (DatastreamUtils.isReuseAllowed(stream)) {
+      throw new DatastreamValidationException(
+          String.format("Destination reuse is not allowed for connector %s. Datastream: %s", stream.getConnectorName(),
+              stream));
+    }
+
+    // verify that the source regular expression can be compiled
+    KafkaConnectionString connectionString = KafkaConnectionString.valueOf(stream.getSource().getConnectionString());
+    try {
+      Pattern.compile(connectionString.getTopicName());
+    } catch (PatternSyntaxException e) {
+      throw new DatastreamValidationException(
+          String.format("Regular expression in Datastream source connection string (%s) is ill-formatted.",
+              stream.getSource().getConnectionString()), e);
+    }
+  }
+
+  @Override
+  public String getDestinationName(Datastream stream) {
+    // return %s so that topic can be inserted into the destination string at produce time
+    return "%s";
+  }
+
+  @Override
+  public List<BrooklinMetricInfo> getMetricInfos() {
+    return Collections.unmodifiableList(KafkaMirrorMakerConnectorTask.getMetricInfos());
+  }
+
+
+}

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorFactory.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorFactory.java
@@ -1,0 +1,18 @@
+package com.linkedin.datastream.connectors.kafka.mirrormaker;
+
+import java.util.Properties;
+
+import com.linkedin.datastream.server.api.connector.ConnectorFactory;
+
+
+/**
+ * Factory for creating KafkaMirrorMakerConnector instances.
+ */
+public class KafkaMirrorMakerConnectorFactory implements ConnectorFactory<KafkaMirrorMakerConnector> {
+
+  @Override
+  public KafkaMirrorMakerConnector createConnector(String connectorName, Properties config) {
+    return new KafkaMirrorMakerConnector(connectorName, config);
+  }
+
+}

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -1,0 +1,116 @@
+package com.linkedin.datastream.connectors.kafka.mirrormaker;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Properties;
+import java.util.StringJoiner;
+import java.util.regex.Pattern;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.BrooklinEnvelope;
+import com.linkedin.datastream.common.BrooklinEnvelopeMetadataConstants;
+import com.linkedin.datastream.connectors.CommonConnectorMetrics;
+import com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask;
+import com.linkedin.datastream.connectors.kafka.KafkaConnectionString;
+import com.linkedin.datastream.connectors.kafka.KafkaConsumerFactory;
+import com.linkedin.datastream.metrics.BrooklinMetricInfo;
+import com.linkedin.datastream.metrics.MetricsAware;
+import com.linkedin.datastream.server.DatastreamProducerRecord;
+import com.linkedin.datastream.server.DatastreamProducerRecordBuilder;
+import com.linkedin.datastream.server.DatastreamTask;
+
+
+/**
+ * KafkaMirrorMakerConnectorTask consumes from Kafka using regular expression pattern subscription. This means that the
+ * task is consuming from multiple topics at once. When a new topic falls into the subscription, the task should
+ * create the topic in the destination before attempting to produce to it.
+ *
+ * This task is responsible for specifying the destination for every DatastreamProducerRecord it sends downstream. As
+ * such, the Datastream destination connection string should be a format String, where "%s" should be replaced by the
+ * specific topic to send to.
+ */
+public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTask {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaMirrorMakerConnectorTask.class.getName());
+  private static final String CLASS_NAME = KafkaMirrorMakerConnectorTask.class.getSimpleName();
+  private static final String METRICS_PREFIX_REGEX = CLASS_NAME + MetricsAware.KEY_REGEX;
+
+  private final KafkaConsumerFactory<?, ?> _consumerFactory;
+  private final KafkaConnectionString _mirrorMakerSource;
+
+  protected KafkaMirrorMakerConnectorTask(KafkaConsumerFactory<?, ?> factory, Properties consumerProps,
+      DatastreamTask task, long commitIntervalMillis, Duration retrySleepDuration, int retryCount) {
+    super(consumerProps, task, commitIntervalMillis, retrySleepDuration, retryCount, LOG);
+    _consumerFactory = factory;
+    _mirrorMakerSource = KafkaConnectionString.valueOf(_task.getDatastreamSource().getConnectionString());
+  }
+
+  @Override
+  protected Consumer<?, ?> createKafkaConsumer(Properties consumerProps) {
+    StringJoiner csv = new StringJoiner(KafkaConnectionString.BROKER_LIST_DELIMITER);
+    _mirrorMakerSource.getBrokers().forEach(broker -> csv.add(broker.toString()));
+    String bootstrapValue = csv.toString();
+
+    consumerProps.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapValue);
+    consumerProps.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, _task.getDatastreams().get(0).getName());
+    consumerProps.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+        Boolean.FALSE.toString()); // auto-commits are unsafe
+    // TODO: read auto.offset.reset from the config or metadata so that this is configurable by SRE, who might want
+    // latest when pipeline is first set up but might want to change to "oldest" for all newly created topics, once
+    // pipeline is stabilized.
+    consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+    return _consumerFactory.createConsumer(consumerProps);
+  }
+
+  @Override
+  protected void consumerSubscribe() {
+    _consumer.subscribe(Pattern.compile(_mirrorMakerSource.getTopicName()), this);
+  }
+
+  @Override
+  protected DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, Instant readTime) throws Exception {
+    HashMap<String, String> metadata = new HashMap<>();
+    metadata.put("kafka-origin-cluster", _mirrorMakerSource.toString());
+    String topic = fromKafka.topic();
+    metadata.put("kafka-origin-topic", topic);
+    int partition = fromKafka.partition();
+    String partitionStr = String.valueOf(partition);
+    metadata.put("kafka-origin-partition", partitionStr);
+    String offsetStr = String.valueOf(fromKafka.offset());
+    metadata.put("kafka-origin-offset", offsetStr);
+    metadata.put(BrooklinEnvelopeMetadataConstants.EVENT_TIMESTAMP, String.valueOf(readTime.toEpochMilli()));
+    BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null, metadata);
+    DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
+    builder.addEvent(envelope);
+    builder.setEventsSourceTimestamp(readTime.toEpochMilli());
+    builder.setSourceCheckpoint(topic + "-" + partitionStr + "-" + offsetStr);
+    builder.setDestination(String.format(_task.getDatastreamDestination().getConnectionString(), topic));
+    return builder.build();
+  }
+
+  @Override
+  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    _consumerMetrics.updateRebalanceRate(1);
+    LOG.info("Partition ownership assigned for {}.", partitions);
+    // TODO: detect when new topic falls into subscription and create topic in destination.
+  }
+
+  public static List<BrooklinMetricInfo> getMetricInfos() {
+    List<BrooklinMetricInfo> metrics = new ArrayList<>();
+    metrics.addAll(CommonConnectorMetrics.getEventProcessingMetrics(METRICS_PREFIX_REGEX));
+    metrics.addAll(CommonConnectorMetrics.getEventPollMetrics(METRICS_PREFIX_REGEX));
+    metrics.addAll(CommonConnectorMetrics.getPartitionSpecificMetrics(METRICS_PREFIX_REGEX));
+    return metrics;
+  }
+
+}

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/BaseKafkaZkTest.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/BaseKafkaZkTest.java
@@ -1,0 +1,57 @@
+package com.linkedin.datastream.connectors.kafka;
+
+import java.util.Properties;
+
+import org.I0Itec.zkclient.ZkConnection;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import kafka.utils.ZkUtils;
+
+import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.kafka.EmbeddedZookeeperKafkaCluster;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
+
+
+/**
+ * Base test class for test cases that rely on EmbeddedZookeeperKafkaCluster so that all tests in a given class could
+ * share the same zookeeper-kafka cluster and zk client/utils.
+ */
+@Test
+public abstract class BaseKafkaZkTest {
+
+  protected EmbeddedZookeeperKafkaCluster _kafkaCluster;
+  protected ZkClient _zkClient;
+  protected ZkUtils _zkUtils;
+  protected String _broker;
+
+  @BeforeClass(alwaysRun = true)
+  public void beforeClassSetup() throws Exception {
+    DynamicMetricsManager.createInstance(new MetricRegistry(), getClass().getSimpleName());
+    Properties kafkaConfig = new Properties();
+    // we will disable auto topic creation for tests
+    kafkaConfig.setProperty("auto.create.topics.enable", Boolean.FALSE.toString());
+    _kafkaCluster = new EmbeddedZookeeperKafkaCluster(kafkaConfig);
+    _kafkaCluster.startup();
+    _broker = _kafkaCluster.getBrokers().split("\\s*,\\s*")[0];
+    _zkClient = new ZkClient(_kafkaCluster.getZkConnection());
+    _zkUtils = new ZkUtils(_zkClient, new ZkConnection(_kafkaCluster.getZkConnection()), false);
+  }
+
+  @AfterClass(alwaysRun = true)
+  public void afterClassTeardown() {
+    if (_zkUtils != null) {
+      _zkUtils.close();
+    }
+    if (_zkClient != null) {
+      _zkClient.close();
+    }
+    if (_kafkaCluster != null && _kafkaCluster.isStarted()) {
+      _kafkaCluster.shutdown();
+    }
+    _broker = null;
+  }
+
+}

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
@@ -5,14 +5,8 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Properties;
 
-import org.I0Itec.zkclient.ZkConnection;
 import org.testng.Assert;
-import org.testng.annotations.AfterTest;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
-
-import com.codahale.metrics.MetricRegistry;
-import kafka.utils.ZkUtils;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
@@ -20,38 +14,11 @@ import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.JsonUtils;
-import com.linkedin.datastream.common.zk.ZkClient;
-import com.linkedin.datastream.kafka.EmbeddedZookeeperKafkaCluster;
-import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 
 
 @Test
-public class TestKafkaConnector {
-
-  private EmbeddedZookeeperKafkaCluster _kafkaCluster;
-  private String _broker;
-  private ZkUtils _zkUtils;
-
-  @BeforeTest
-  public void setup() throws Exception {
-    DynamicMetricsManager.createInstance(new MetricRegistry(), "TestKafkaConnector");
-    Properties kafkaConfig = new Properties();
-    // we will disable auto topic creation for this test file
-    kafkaConfig.setProperty("auto.create.topics.enable", Boolean.FALSE.toString());
-    _kafkaCluster = new EmbeddedZookeeperKafkaCluster(kafkaConfig);
-    _kafkaCluster.startup();
-    _broker = _kafkaCluster.getBrokers().split("\\s*,\\s*")[0];
-    _zkUtils =
-        new ZkUtils(new ZkClient(_kafkaCluster.getZkConnection()), new ZkConnection(_kafkaCluster.getZkConnection()),
-            false);
-  }
-
-  @AfterTest
-  public void teardown() throws Exception {
-    _zkUtils.close();
-    _kafkaCluster.shutdown();
-  }
+public class TestKafkaConnector extends BaseKafkaZkTest {
 
   private Properties getDefaultConfig(Properties override) {
     Properties config = new Properties();
@@ -94,7 +61,7 @@ public class TestKafkaConnector {
   }
 
   @Test(expectedExceptions = DatastreamValidationException.class)
-  public void testInitializeDatastreamWithNonexistTopic() throws UnsupportedEncodingException, DatastreamValidationException {
+  public void testInitializeDatastreamWithNonexistTopic() throws DatastreamValidationException {
     String topicName = "testInitializeDatastreamWithNonexistTopic";
     Datastream ds = createDatastream("testInitializeDatastreamWithNonexistTopic", topicName);
     KafkaConnector connector =

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
@@ -1,0 +1,161 @@
+package com.linkedin.datastream.connectors.kafka.mirrormaker;
+
+import java.util.Collections;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
+import com.linkedin.datastream.common.DatastreamSource;
+import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.connectors.kafka.AbstractKafkaConnector;
+import com.linkedin.datastream.connectors.kafka.BaseKafkaZkTest;
+import com.linkedin.datastream.connectors.kafka.KafkaConsumerFactoryImpl;
+import com.linkedin.datastream.kafka.KafkaTransportProviderAdmin;
+import com.linkedin.datastream.server.CachedDatastreamReader;
+import com.linkedin.datastream.server.Coordinator;
+import com.linkedin.datastream.server.CoordinatorConfig;
+import com.linkedin.datastream.server.DummyTransportProviderAdminFactory;
+import com.linkedin.datastream.server.SourceBasedDeduper;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+import com.linkedin.datastream.server.assignment.BroadcastStrategy;
+
+import static com.linkedin.datastream.server.assignment.BroadcastStrategyFactory.*;
+
+
+@Test
+public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
+
+  private CachedDatastreamReader _cachedDatastreamReader;
+
+  private Properties getDefaultConfig(Optional<Properties> override) {
+    Properties config = new Properties();
+    config.put(KafkaMirrorMakerConnector.CONFIG_DEFAULT_KEY_SERDE, "keySerde");
+    config.put(KafkaMirrorMakerConnector.CONFIG_DEFAULT_VALUE_SERDE, "valueSerde");
+    config.put(KafkaMirrorMakerConnector.CONFIG_COMMIT_INTERVAL_MILLIS, "10000");
+    config.put(AbstractKafkaConnector.CONFIG_CONSUMER_FACTORY_CLASS, KafkaConsumerFactoryImpl.class.getName());
+    override.ifPresent(o -> config.putAll(o));
+    return config;
+  }
+
+  protected static Datastream createDatastream(String name, String broker, String sourceRegex, StringMap metadata) {
+    DatastreamSource source = new DatastreamSource();
+    source.setConnectionString("kafka://" + broker + "/" + sourceRegex);
+    Datastream datastream = new Datastream();
+    datastream.setName(name);
+    datastream.setConnectorName("KafkaMirrorMaker");
+    datastream.setSource(source);
+    datastream.setMetadata(metadata);
+    return datastream;
+  }
+
+  private Coordinator createCoordinator(String zkAddr, String cluster) throws Exception {
+    return createCoordinator(zkAddr, cluster, new Properties());
+  }
+
+  private Coordinator createCoordinator(String zkAddr, String cluster, Properties override) throws Exception {
+    Properties props = new Properties();
+    props.put(CoordinatorConfig.CONFIG_CLUSTER, cluster);
+    props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, zkAddr);
+    props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
+    props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
+    props.putAll(override);
+    ZkClient client = new ZkClient(zkAddr);
+    _cachedDatastreamReader = new CachedDatastreamReader(client, cluster);
+    Coordinator coordinator = new Coordinator(_cachedDatastreamReader, props);
+    DummyTransportProviderAdminFactory factory = new DummyTransportProviderAdminFactory();
+    coordinator.addTransportProvider(DummyTransportProviderAdminFactory.PROVIDER_NAME,
+        factory.createTransportProviderAdmin(DummyTransportProviderAdminFactory.PROVIDER_NAME, new Properties()));
+    return coordinator;
+  }
+
+  @Test
+  public void testInitializeDatastream() throws Exception {
+    String sourceRegex = "\\w+Event";
+    StringMap metadata = new StringMap();
+    metadata.put(DatastreamMetadataConstants.REUSE_EXISTING_DESTINATION_KEY, Boolean.FALSE.toString());
+    Datastream ds = createDatastream("testInitializeDatastream", _broker, sourceRegex, metadata);
+    KafkaMirrorMakerConnector connector =
+        new KafkaMirrorMakerConnector("testInitializeDatastream", getDefaultConfig(Optional.empty()));
+    connector.initializeDatastream(ds, Collections.emptyList());
+
+    sourceRegex = "SpecificTopic";
+    ds = createDatastream("testInitializeDatastream2", _broker, sourceRegex, metadata);
+    connector.initializeDatastream(ds, Collections.emptyList());
+
+    sourceRegex = "(\\w+Event)|^(Topic)";
+    ds = createDatastream("testInitializeDatastream3", _broker, sourceRegex, metadata);
+    connector.initializeDatastream(ds, Collections.emptyList());
+
+    sourceRegex = "^(?!__)\\w+";
+    ds = createDatastream("testInitializeDatastream4", _broker, sourceRegex, metadata);
+    connector.initializeDatastream(ds, Collections.emptyList());
+  }
+
+  @Test(expectedExceptions = DatastreamValidationException.class)
+  public void testInitializeDatastreamWithDestinationReuse() throws DatastreamValidationException {
+    String sourceRegex = "\\w+Event";
+    StringMap metadata = new StringMap();
+    metadata.put(DatastreamMetadataConstants.REUSE_EXISTING_DESTINATION_KEY, Boolean.TRUE.toString());
+    Datastream ds = createDatastream("testInitializeDatastreamWithDestinationReuse", _broker, sourceRegex, metadata);
+    KafkaMirrorMakerConnector connector =
+        new KafkaMirrorMakerConnector("testInitializeDatastreamWithDestinationReuse", getDefaultConfig(Optional.empty()));
+    connector.initializeDatastream(ds, Collections.emptyList());
+  }
+
+  @Test(expectedExceptions = DatastreamValidationException.class)
+  public void testInitializeDatastreamWithBYOT() throws DatastreamValidationException {
+    String sourceRegex = "\\w+Event";
+    StringMap metadata = new StringMap();
+    metadata.put(DatastreamMetadataConstants.IS_USER_MANAGED_DESTINATION_KEY, Boolean.TRUE.toString());
+    Datastream ds = createDatastream("testInitializeDatastreamWithBYOT", _broker, sourceRegex, metadata);
+    KafkaMirrorMakerConnector connector =
+        new KafkaMirrorMakerConnector("testInitializeDatastreamWithBYOT", getDefaultConfig(Optional.empty()));
+    connector.initializeDatastream(ds, Collections.emptyList());
+  }
+
+  @Test(expectedExceptions = DatastreamValidationException.class)
+  public void testInitializeDatastreamWithBadSource() throws DatastreamValidationException {
+    String sourceRegex = "*Event*";
+    StringMap metadata = new StringMap();
+    metadata.put(DatastreamMetadataConstants.REUSE_EXISTING_DESTINATION_KEY, Boolean.FALSE.toString());
+    Datastream ds = createDatastream("testInitializeDatastreamWithBadSource", _broker, sourceRegex, metadata);
+    KafkaMirrorMakerConnector connector =
+        new KafkaMirrorMakerConnector("testInitializeDatastreamWithBadSource", getDefaultConfig(Optional.empty()));
+    connector.initializeDatastream(ds, Collections.emptyList());
+  }
+
+  private KafkaTransportProviderAdmin getKafkaTransportProviderAdmin() {
+    Properties props = new Properties();
+    props.put("zookeeper.connect", _kafkaCluster.getZkConnection());
+    props.put("bootstrap.servers", _kafkaCluster.getBrokers());
+    return new KafkaTransportProviderAdmin(props);
+  }
+
+  @Test
+  public void testPopulateDatastreamDestination() throws Exception {
+    KafkaMirrorMakerConnector connector =
+        new KafkaMirrorMakerConnector("MirrorMakerConnector", getDefaultConfig(Optional.empty()));
+    Coordinator coordinator = createCoordinator(_kafkaCluster.getZkConnection(), "testPopulateDatastreamDestination");
+    coordinator.addConnector("KafkaMirrorMaker", connector, new BroadcastStrategy(DEFAULT_MAX_TASKS), false,
+        new SourceBasedDeduper(), null);
+    String transportProviderName = "kafkaTransportProvider";
+    KafkaTransportProviderAdmin transportProviderAdmin = getKafkaTransportProviderAdmin();
+    coordinator.addTransportProvider(transportProviderName, transportProviderAdmin);
+    coordinator.start();
+
+    StringMap metadata = new StringMap();
+    metadata.put(DatastreamMetadataConstants.REUSE_EXISTING_DESTINATION_KEY, Boolean.FALSE.toString());
+    Datastream stream = createDatastream("testPopulateDatastreamDestination", _broker, "\\w+Event", metadata);
+    stream.setTransportProviderName(transportProviderName);
+    coordinator.initializeDatastream(stream);
+
+    String someTopic = "someTopic";
+    Assert.assertEquals(transportProviderAdmin.getDestination(someTopic),
+        String.format(stream.getDestination().getConnectionString(), someTopic));
+  }
+}

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -1,0 +1,133 @@
+package com.linkedin.datastream.connectors.kafka.mirrormaker;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.io.Charsets;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import kafka.admin.AdminUtils;
+import kafka.utils.ZkUtils;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamDestination;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
+import com.linkedin.datastream.common.PollUtils;
+import com.linkedin.datastream.connectors.kafka.BaseKafkaZkTest;
+import com.linkedin.datastream.connectors.kafka.KafkaConsumerFactoryImpl;
+import com.linkedin.datastream.connectors.kafka.MockDatastreamEventProducer;
+import com.linkedin.datastream.server.DatastreamProducerRecord;
+import com.linkedin.datastream.server.DatastreamTaskImpl;
+
+
+public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
+
+
+  public Properties getKafkaProducerProperties() {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, _kafkaCluster.getBrokers());
+    props.put(ProducerConfig.ACKS_CONFIG, "all");
+    props.put(ProducerConfig.RETRIES_CONFIG, 100);
+    props.put(ProducerConfig.BATCH_SIZE_CONFIG, 16384);
+    props.put(ProducerConfig.LINGER_MS_CONFIG, 1);
+    props.put(ProducerConfig.BUFFER_MEMORY_CONFIG, 33554432);
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getCanonicalName());
+
+    return props;
+  }
+
+  private void produceEvents(String topic, int numEvents) {
+    try (Producer<byte[], byte[]> producer = new KafkaProducer<>(getKafkaProducerProperties())) {
+      for (int i = 0; i < numEvents; i++) {
+        producer.send(
+            new ProducerRecord<>(topic, ("key-" + i).getBytes(Charsets.UTF_8), ("value-" + i).getBytes(Charsets.UTF_8)),
+            (metadata, exception) -> {
+              if (exception != null) {
+                throw new RuntimeException("Failed to send message.", exception);
+              }
+            });
+      }
+      producer.flush();
+    }
+  }
+
+  private void createTopic(ZkUtils zkUtils, String topic) {
+    if (!AdminUtils.topicExists(zkUtils, topic)) {
+      AdminUtils.createTopic(zkUtils, topic, 1, 2, new Properties(), null);
+    }
+  }
+
+  @Test
+  public void testConsumeFromMultipleTopics() throws Exception {
+    String yummyTopic = "YummyPizza";
+    String saltyTopic = "SaltyPizza";
+    String saladTopic = "HealthySalad";
+
+    createTopic(_zkUtils, saladTopic);
+    createTopic(_zkUtils, yummyTopic);
+    createTopic(_zkUtils, saltyTopic);
+
+    // create a datastream to consume from topics ending in "Pizza"
+    StringMap metadata = new StringMap();
+    metadata.put(DatastreamMetadataConstants.REUSE_EXISTING_DESTINATION_KEY, Boolean.FALSE.toString());
+    Datastream datastream =
+        TestKafkaMirrorMakerConnector.createDatastream("pizzaStream", _broker, "\\w+Pizza", metadata);
+    datastream.setTransportProviderName("default");
+    DatastreamDestination destination = new DatastreamDestination();
+    destination.setConnectionString("%s");
+    datastream.setDestination(destination);
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+    MockDatastreamEventProducer datastreamProducer = new MockDatastreamEventProducer();
+    task.setEventProducer(datastreamProducer);
+
+    KafkaMirrorMakerConnectorTask connectorTask = createKafkaMirrorMakerConnectorTask(task);
+
+    // produce an event to each of the 3 topics
+    produceEvents(yummyTopic, 1);
+    produceEvents(saltyTopic, 1);
+    produceEvents(saladTopic, 1);
+
+    if (!PollUtils.poll(() -> datastreamProducer.getEvents().size() == 2, 100, 25000)) {
+      Assert.fail("did not transfer the msgs within timeout. transferred " + datastreamProducer.getEvents().size());
+    }
+
+    List<DatastreamProducerRecord> records = datastreamProducer.getEvents();
+    for (DatastreamProducerRecord record : records) {
+      String destinationTopic = record.getDestination().get();
+      Assert.assertTrue(destinationTopic.endsWith("Pizza"),
+          "Unexpected event consumed from Datastream and sent to topic: " + destinationTopic);
+    }
+
+    connectorTask.stop();
+    Assert.assertTrue(connectorTask.awaitStop(5000, TimeUnit.MILLISECONDS), "did not shut down on time");
+  }
+
+  private KafkaMirrorMakerConnectorTask createKafkaMirrorMakerConnectorTask(DatastreamTaskImpl task)
+      throws InterruptedException {
+    KafkaMirrorMakerConnectorTask connectorTask =
+        new KafkaMirrorMakerConnectorTask(new KafkaConsumerFactoryImpl(), new Properties(), task, 1000,
+            Duration.ofSeconds(0), 5);
+    Thread t = new Thread(connectorTask, "connector thread");
+    t.setDaemon(true);
+    t.setUncaughtExceptionHandler((t1, e) -> {
+      Assert.fail("connector thread died", e);
+    });
+    t.start();
+    if (!connectorTask.awaitStart(60, TimeUnit.SECONDS)) {
+      Assert.fail("connector did not start within timeout");
+    }
+    return connectorTask;
+  }
+}

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -94,8 +94,9 @@ public class KafkaTransportProvider implements TransportProvider {
       return new ProducerRecord<>(destination.getTopicName(), partition.get(), keyValue, payloadValue);
     } else {
       // If the partition is not specified. We use the partitionKey as the key. Kafka will use the hash of that
-      // to determine the partition.
-      return new ProducerRecord<>(destination.getTopicName(), record.getPartitionKey().get().getBytes(), payloadValue);
+      // to determine the partition. If partitionKey does not exist, use the key value.
+      keyValue = record.getPartitionKey().isPresent() ? record.getPartitionKey().get().getBytes() : keyValue;
+      return new ProducerRecord<>(destination.getTopicName(), keyValue, payloadValue);
     }
   }
 

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
@@ -32,8 +32,6 @@ public class DatastreamProducerRecord {
     Validate.notNull(events, "null event");
     events.forEach((e) -> Validate.notNull(e, "null event"));
     Validate.isTrue(eventsSourceTimestamp > 0, "events source timestamp is invalid");
-    Validate.isTrue(partition.isPresent() || partitionKey.isPresent(),
-        "Either partition or partitionKey should be present");
 
     _events = events;
     _partition = partition;


### PR DESCRIPTION
Just the basic structure of Brooklin MirrorMaker connector, which is similar to KafkaConnector except it can subscribe to a pattern and it can produce to multiple topics.

Still TODO:
- unit tests
- plug in flushless producer
- auto-pause and resume partition based on back-pressure
- create destination topic when new source topic is detected
- on-demand pause topic/partition
- updates to source regular expression pattern