### PR TITLE
Modify FlushlessEventProducerHandler to handle OOO acks and use in Mi…

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -86,6 +86,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         "Creating Kafka-based connector task for datastream task {} with commit interval {} ms, retry sleep duration {}"
             + " ms, and retry count {}", task, commitIntervalMillis, retrySleepDuration.toMillis(), retryCount);
     _task = task;
+    _producer = task.getEventProducer();
     _datastream = task.getDatastreams().get(0);
     _datastreamName = _datastream.getName();
     _taskName = task.getDatastreamTaskName();
@@ -184,7 +185,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     long pollInterval = 0; // so 1st call to poll is fast for purposes of startup
     _thread = Thread.currentThread();
 
-    _producer = _task.getEventProducer();
     _eventsProcessedCountLoggedTime = Instant.now();
 
     try {

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/FlushlessKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/FlushlessKafkaMirrorMakerConnectorTask.java
@@ -1,0 +1,95 @@
+package com.linkedin.datastream.connectors.kafka.mirrormaker;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.connectors.kafka.KafkaConsumerFactory;
+import com.linkedin.datastream.server.DatastreamProducerRecord;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.FlushlessEventProducerHandler;
+
+
+/**
+ * Package-private class that extends from {@link KafkaMirrorMakerConnectorTask} to override methods involved in
+ * flushless producing of events. This class will be instantiated if the KafkaMirrorMakerConnector config has
+ * isFlushlessModeEnabled set to true. Otherwise, the KafkaMirrorMakerConnectorTask (which does occasional flush) will
+ * be used. Note that this FlushlessKafkaMirrorMakerConnectorTask does do flush on hard-commit, whenever a graceful
+ * shutdown occurs.
+ */
+class FlushlessKafkaMirrorMakerConnectorTask extends KafkaMirrorMakerConnectorTask {
+
+  // Use the KafkaMirrorMakerConnectorTask logger
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaMirrorMakerConnectorTask.class.getName());
+
+  private final FlushlessEventProducerHandler<Long> _flushlessProducer;
+
+  protected FlushlessKafkaMirrorMakerConnectorTask(KafkaConsumerFactory<?, ?> factory, Properties consumerProps,
+      DatastreamTask task, long commitIntervalMillis, Duration retrySleepDuration, int retryCount) {
+    super(factory, consumerProps, task, commitIntervalMillis, retrySleepDuration, retryCount);
+    _flushlessProducer = new FlushlessEventProducerHandler<>(_producer);
+  }
+
+  @Override
+  protected void sendDatastreamProducerRecord(DatastreamProducerRecord datastreamProducerRecord) throws Exception {
+    KafkaMirrorMakerCheckpoint sourceCheckpoint =
+        new KafkaMirrorMakerCheckpoint(datastreamProducerRecord.getCheckpoint());
+    _flushlessProducer.send(datastreamProducerRecord, sourceCheckpoint.getTopic(), sourceCheckpoint.getPartition(),
+        sourceCheckpoint.getOffset());
+
+  }
+
+  @Override
+  protected void maybeCommitOffsets(Consumer<?, ?> consumer, boolean hardCommit) {
+    boolean isTimeToCommit = System.currentTimeMillis() - _lastCommittedTime > _offsetCommitInterval;
+
+    if (hardCommit) { // hard commit (flush and commit checkpoints)
+      LOG.info("Calling flush on the producer.");
+      _task.getEventProducer().flush();
+      consumer.commitSync();
+      // verify that the producer is caught up with the consumer, since flush was called
+      for (TopicPartition tp : consumer.assignment()) {
+        _flushlessProducer.getAckCheckpoint(tp.topic(), tp.partition()).ifPresent(ackCheckpoint -> {
+          long committedCheckpoint =
+              Optional.ofNullable(consumer.committed(tp)).map(OffsetAndMetadata::offset).orElse(0L);
+          if (!Objects.equals(ackCheckpoint, committedCheckpoint)) {
+            LOG.error(
+                "Ack checkpoint should match committed checkpoint after flushing and checkpointing. Ack checkpoint: "
+                    + "{}, consumer position: {}", ackCheckpoint, committedCheckpoint);
+          }
+        });
+
+        // verify that the in-flight count is 0 after flush
+        long inFlightCount = _flushlessProducer.getInFlightCount(tp.topic(), tp.partition());
+        if (inFlightCount > 0) {
+          LOG.error("Flushless producer inflight count for topic {} partition {} should be 0 after flush, but was {}",
+              tp.topic(), tp.partition(), inFlightCount);
+        }
+      }
+      // clear the flushless producer state after flushing all messages and checkpointing
+      _flushlessProducer.clear();
+      _lastCommittedTime = System.currentTimeMillis();
+
+    } else if (isTimeToCommit) { // soft commit (no flush, just commit checkpoints)
+      LOG.info("Trying to commit offsets.");
+      Map<TopicPartition, OffsetAndMetadata> offsets = new HashMap<>();
+      for (TopicPartition tp : consumer.assignment()) {
+        // add 1 to the last acked checkpoint to set to the offset of the next message to consume
+        _flushlessProducer.getAckCheckpoint(tp.topic(), tp.partition())
+            .ifPresent(o -> offsets.put(tp, new OffsetAndMetadata(o + 1)));
+      }
+      consumer.commitSync(offsets);
+      _lastCommittedTime = System.currentTimeMillis();
+    }
+  }
+}
+

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerCheckpoint.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerCheckpoint.java
@@ -1,0 +1,51 @@
+package com.linkedin.datastream.connectors.kafka.mirrormaker;
+
+import org.apache.commons.lang.Validate;
+
+
+/**
+ * Represents a KafkaMirrorMaker source checkpoint in format: topic-partition-offset
+ */
+public class KafkaMirrorMakerCheckpoint {
+  private static final String DELIMITER = "-";
+  private String _topic;
+  private int _partition;
+  private long _offset;
+
+  public KafkaMirrorMakerCheckpoint(String topic, int partition, long offset) {
+    _topic = topic;
+    _partition = partition;
+    _offset = offset;
+  }
+
+  public KafkaMirrorMakerCheckpoint(String checkpoint) {
+    Validate.notNull(checkpoint, "Checkpoint cannot be null");
+    String[] parts = checkpoint.split(DELIMITER);
+    if (parts.length != 3) {
+      throw new IllegalArgumentException(
+          "Checkpoint should be in format: topic-partition-offset, but found: " + checkpoint);
+    }
+
+    _topic = parts[0];
+    _partition = Integer.valueOf(parts[1]);
+    _offset = Long.valueOf(parts[2]);
+  }
+
+  @Override
+  public String toString() {
+    return _topic + DELIMITER + _partition + DELIMITER + _offset;
+  }
+
+  public String getTopic() {
+    return _topic;
+  }
+
+  public int getPartition() {
+    return _partition;
+  }
+
+  public long getOffset() {
+    return _offset;
+  }
+
+}

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -32,7 +32,6 @@ import com.linkedin.datastream.server.DatastreamTaskImpl;
 
 public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
 
-
   public Properties getKafkaProducerProperties() {
     Properties props = new Properties();
     props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, _kafkaCluster.getBrokers());

--- a/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestFlushlessEventProducerHandler.java
+++ b/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestFlushlessEventProducerHandler.java
@@ -6,6 +6,7 @@ import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Random;
 
 import org.testng.Assert;
@@ -15,7 +16,7 @@ import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.server.api.transport.DatastreamRecordMetadata;
 import com.linkedin.datastream.server.api.transport.SendCallback;
 
-import static com.linkedin.datastream.server.FlushlessEventProducerHandler.DestinationPartition;
+import static com.linkedin.datastream.server.FlushlessEventProducerHandler.SourcePartition;
 
 
 public class TestFlushlessEventProducerHandler {
@@ -31,15 +32,15 @@ public class TestFlushlessEventProducerHandler {
     long checkpoint = 1;
     DatastreamProducerRecord record = getDatastreamProducerRecord(checkpoint, TOPIC, 1);
 
-    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
-    handler.send(record, checkpoint);
-    Assert.assertNull(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()));
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()).get(), BIG_CHECKPOINT);
+    handler.send(record, TOPIC, 1, checkpoint);
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), Optional.empty());
     Assert.assertEquals(handler.getInFlightCount(TOPIC, 1), 1);
-    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, 1), null);
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, 1), Optional.empty());
     eventProducer.flush();
-    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()).get(), BIG_CHECKPOINT);
     Assert.assertEquals(handler.getInFlightCount(TOPIC, 1), 0);
-    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, 1), new Long(checkpoint));
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, 1).get(), new Long(checkpoint));
   }
 
   @Test
@@ -47,17 +48,18 @@ public class TestFlushlessEventProducerHandler {
     RandomEventProducer eventProducer = new RandomEventProducer();
     FlushlessEventProducerHandler<Long> handler = new FlushlessEventProducerHandler<>(eventProducer);
 
-    // Send 100 messages
-    for (int i = 0; i < 1000; i++) {
-      DestinationPartition tp = new DestinationPartition(TOPIC, _rnd.nextInt(10));
-      sendEvent(tp, handler, i / 2);
+    // Send 1000 messages to 100 partitions
+    for (int i = 0; i < 10; i++) {
+      SourcePartition tp = new SourcePartition(TOPIC, i);
+      for (int j = 0; j < 100; j++) {
+        sendEvent(tp, handler, j);
+      }
     }
 
     for (int i = 0; i < 999; i++) {
       eventProducer.processOne();
       long minOffsetPending = eventProducer.minCheckpoint();
-      Long checkpoint = handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder());
-      long ackOffset = checkpoint == null ? -1 : checkpoint;
+      Long ackOffset = handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()).orElse(-1L);
 
       Assert.assertTrue(ackOffset < minOffsetPending,
           "Not true that " + ackOffset + " is less than " + minOffsetPending);
@@ -68,14 +70,102 @@ public class TestFlushlessEventProducerHandler {
       Assert.assertEquals(handler.getInFlightCount(TOPIC, par), 0);
     }
 
-    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()).get(), BIG_CHECKPOINT);
 
-    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()), BIG_CHECKPOINT);
+    Assert.assertEquals(handler.getAckCheckpoint(BIG_CHECKPOINT, Comparator.naturalOrder()).get(), BIG_CHECKPOINT);
   }
 
-  private void sendEvent(DestinationPartition tp, FlushlessEventProducerHandler<Long> handler, long checkpoint) {
+  @Test
+  public void testOutOfOrderAck() throws Exception {
+    RandomEventProducer eventProducer = new RandomEventProducer();
+    FlushlessEventProducerHandler<Long> handler = new FlushlessEventProducerHandler<>(eventProducer);
+
+    int partition = 0;
+    SourcePartition tp = new SourcePartition(TOPIC, partition);
+
+    // Send 5 messages to partition 0 with increasing checkpoints (0-4)
+    for (int i = 0; i < 5; i++) {
+      sendEvent(tp, handler, i);
+    }
+
+    // simulate callback for checkpoint 4
+    eventProducer.process(tp, 4); // inflight result: 0, 1, 2, 3
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition), Optional.empty(),
+        "Safe checkpoint should be empty");
+
+    // simulate callback for checkpoint 2
+    eventProducer.process(tp, 2); // inflight result: 0, 1, 3
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition), Optional.empty(),
+        "Safe checkpoint should be empty");
+
+    // simulate callback for checkpoint 0
+    eventProducer.process(tp, 0); // inflight result: 1, 3
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition).get(), Long.valueOf(0),
+        "Safe checkpoint should be 0");
+
+    // simulate callback for checkpoint 1
+    eventProducer.process(tp, 0); // inflight result: 3
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition).get(), Long.valueOf(2),
+        "Safe checkpoint should be 1");
+
+    // send another event with checkpoint 5
+    sendEvent(tp, handler, 5); // inflight result: 3, 5
+    Assert.assertEquals(handler.getInFlightCount(TOPIC, partition), 2, "Number of inflight messages should be 2");
+
+    // simulate callback for checkpoint 3
+    eventProducer.process(tp, 0); // inflight result: 5
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition).get(), Long.valueOf(4),
+        "Safe checkpoint should be 4");
+
+    // simulate callback for checkpoint 5
+    eventProducer.process(tp, 0); // inflight result: empty
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition).get(), Long.valueOf(5),
+        "Safe checkpoint should be 5");
+
+    Assert.assertEquals(handler.getInFlightCount(TOPIC, partition), 0, "Number of inflight messages should be 0");
+
+    // send another event with checkpoint 6
+    sendEvent(tp, handler, 6);
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition).get(), Long.valueOf(5),
+        "Safe checkpoint should be 5");
+
+    // simulate callback for checkpoint 6
+    eventProducer.process(tp, 0); // inflight result: empty
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition).get(), Long.valueOf(6),
+        "Safe checkpoint should be 6");
+  }
+
+  @Test
+  public void testBackwardsOrderAck() throws Exception {
+    RandomEventProducer eventProducer = new RandomEventProducer();
+    FlushlessEventProducerHandler<Long> handler = new FlushlessEventProducerHandler<>(eventProducer);
+
+    int partition = 0;
+    SourcePartition tp = new SourcePartition(TOPIC, partition);
+
+    // Send 1000 messages to the source partition
+    for (int i = 0; i < 1000; i++) {
+      sendEvent(tp, handler, i);
+    }
+
+    // acknowledge the checkpoints in backward (descending order) to simulate worst case scenario
+    for (int i = 999; i > 0; i--) {
+      eventProducer.process(tp, i);
+      // validate that checkpoint has to be empty because oldest message was not yet acknowledged
+      Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition), Optional.empty(),
+          "Safe checkpoint should be empty");
+    }
+
+    // finally process the oldest message
+    eventProducer.process(tp, 0);
+    // validate that the checkpoint was finally updated to 999
+    Assert.assertEquals(handler.getAckCheckpoint(TOPIC, partition).get(), Long.valueOf(999),
+        "Safe checkpoint should be 999");
+  }
+
+  private void sendEvent(SourcePartition tp, FlushlessEventProducerHandler<Long> handler, long checkpoint) {
     DatastreamProducerRecord record = getDatastreamProducerRecord(checkpoint, tp.getKey(), tp.getValue());
-    handler.send(record, checkpoint);
+    handler.send(record, tp.getSource(), tp.getPartition(), checkpoint);
   }
 
   private DatastreamProducerRecord getDatastreamProducerRecord(Long checkpoint, String topic, int partition) {
@@ -90,8 +180,8 @@ public class TestFlushlessEventProducerHandler {
   }
 
   private static class RandomEventProducer implements DatastreamEventProducer {
-    Map<DestinationPartition, List<Pair<DatastreamProducerRecord, SendCallback>>> _queue = new HashMap<>();
-    List<DestinationPartition> tps = new ArrayList<>();
+    Map<SourcePartition, List<Pair<DatastreamProducerRecord, SendCallback>>> _queue = new HashMap<>();
+    List<SourcePartition> tps = new ArrayList<>();
     private double _exceptionProb;
 
     public RandomEventProducer() {
@@ -104,7 +194,7 @@ public class TestFlushlessEventProducerHandler {
 
     @Override
     public synchronized void send(DatastreamProducerRecord record, SendCallback callback) {
-      DestinationPartition tp = new DestinationPartition(TOPIC, record.getPartition().orElse(0));
+      SourcePartition tp = new SourcePartition(TOPIC, record.getPartition().orElse(0));
       if (!tps.contains(tp)) {
         tps.add(tp);
       }
@@ -114,7 +204,7 @@ public class TestFlushlessEventProducerHandler {
     public synchronized void processOne() {
       int start = _rnd.nextInt(tps.size());
       for (int i = 0; i < tps.size(); i++) {
-        DestinationPartition tp = tps.get((i + start) % tps.size());
+        SourcePartition tp = tps.get((i + start) % tps.size());
         if (!_queue.get(tp).isEmpty()) {
           Pair<DatastreamProducerRecord, SendCallback> pair = _queue.get(tp).remove(0);
           DatastreamProducerRecord record = pair.getKey();
@@ -130,6 +220,28 @@ public class TestFlushlessEventProducerHandler {
           return;
         }
       }
+    }
+
+    public synchronized void process(SourcePartition sourcePartition, int queueIndex) {
+      List<Pair<DatastreamProducerRecord, SendCallback>> messages = _queue.get(sourcePartition);
+      if (messages == null) {
+        throw new IllegalArgumentException(
+            "There are no messages in the queue for source partition " + sourcePartition);
+      }
+
+      if (queueIndex >= messages.size()) {
+        throw new IllegalArgumentException(
+            "Cannot remove message at index " + queueIndex + " for source partition " + sourcePartition
+                + " because messages count is " + messages.size());
+      }
+
+      Pair<DatastreamProducerRecord, SendCallback> pair = messages.remove(queueIndex);
+      DatastreamProducerRecord record = pair.getKey();
+      SendCallback callback = pair.getValue();
+
+      DatastreamRecordMetadata metadata =
+          new DatastreamRecordMetadata(record.getCheckpoint(), TOPIC, record.getPartition().orElse(0));
+      callback.onCompletion(metadata, null);
     }
 
     @Override


### PR DESCRIPTION
…rrorMaker

Documentation here: https://docs.google.com/document/d/14-MRojn7Mb1pVN2HFtJ1uMnWN-oDQMjJu7Bfmsuo8U0/edit#

Made changes to FlushlessEventProducerHandler to handle:
- when destination partitions are unknown (like in case of MirrorMaker where source and destination counts mismatch)
- out of order acknowledgements from the destination

Still TODO (will upload to this same PR): 
- unit test cases
- make flushless configurable in the MM connector