### PR TITLE
EventProducer metrics for send latency and flush latency

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
@@ -22,6 +22,9 @@ public class DatastreamProducerRecord {
   private List<BrooklinEnvelope> _events;
   private final long _eventsSourceTimestamp;
 
+  // timestamp of when the record was sent to transport provider
+  private Optional<Long> _eventsSendTimestamp = Optional.empty();
+
   DatastreamProducerRecord(List<BrooklinEnvelope> events, Optional<Integer> partition, Optional<String> partitionKey,
       String checkpoint, long eventsSourceTimestamp) {
     this(events, partition, partitionKey, Optional.empty(), checkpoint, eventsSourceTimestamp);
@@ -71,6 +74,14 @@ public class DatastreamProducerRecord {
    */
   public long getEventsSourceTimestamp() {
     return _eventsSourceTimestamp;
+  }
+
+  public void setEventsSendTimestamp(long timestamp) {
+    _eventsSendTimestamp = Optional.of(timestamp);
+  }
+
+  public Optional<Long> getEventsSendTimestamp() {
+    return _eventsSendTimestamp;
   }
 
   /**


### PR DESCRIPTION
Added metrics for send and flush latency. This might help us to figure out why the process+send loop is taking long and causing poll() to exceed timeout.