### PR TITLE
Avoid create/drop topic for DS with connector-managed destinations (M…

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -11,6 +11,12 @@ public class DatastreamMetadataConstants {
   public static final String IS_USER_MANAGED_DESTINATION_KEY = "system.IsUserManagedDestination";
 
   /**
+   * Represents whether the datastream has a connector managed destination, so destination should not be created on
+   * datastream creation
+   */
+  public static final String IS_CONNECTOR_MANAGED_DESTINATION_KEY = "system.IsConnectorManagedDestination";
+
+  /**
    * Whether the datastream should reuse existing datastream's destination if it is available.
    */
   public static final String REUSE_EXISTING_DESTINATION_KEY = "system.reuseExistingDestination";

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
@@ -10,6 +10,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask;
 import com.linkedin.datastream.connectors.kafka.AbstractKafkaConnector;
@@ -20,9 +21,9 @@ import com.linkedin.datastream.server.api.connector.DatastreamValidationExceptio
 
 
 /**
- * KafkaMirrorMakerConnector is similar to {@link KafkaConnector} but it has the ability to consume from multiple
- * topics in a cluster via regular expression pattern source, and it has the ability to produce to multiple topics
- * in the destination cluster.
+ * KafkaMirrorMakerConnector is similar to KafkaConnector but it has the ability to consume from multiple topics in a
+ * cluster via regular expression pattern source, and it has the ability to produce to multiple topics in the
+ * destination cluster.
  */
 public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaMirrorMakerConnector.class);
@@ -59,6 +60,11 @@ public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
       throw new DatastreamValidationException(
           String.format("BYOT is not allowed for connector %s. Datastream: %s", stream.getConnectorName(),
               stream));
+    }
+
+    if (!DatastreamUtils.isConnectorManagedDestination(stream)) {
+      stream.getMetadata()
+          .put(DatastreamMetadataConstants.IS_CONNECTOR_MANAGED_DESTINATION_KEY, Boolean.TRUE.toString());
     }
 
     // verify that the source regular expression can be compiled

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
@@ -12,6 +12,7 @@ import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamSource;
+import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.connectors.kafka.AbstractKafkaConnector;
 import com.linkedin.datastream.connectors.kafka.BaseKafkaZkTest;
@@ -97,6 +98,8 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     sourceRegex = "^(?!__)\\w+";
     ds = createDatastream("testInitializeDatastream4", _broker, sourceRegex, metadata);
     connector.initializeDatastream(ds, Collections.emptyList());
+
+    Assert.assertTrue(DatastreamUtils.isConnectorManagedDestination(ds));
   }
 
   @Test(expectedExceptions = DatastreamValidationException.class)

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderAdminFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderAdminFactory.java
@@ -20,6 +20,9 @@ public class DummyTransportProviderAdminFactory implements TransportProviderAdmi
 
   private final boolean _throwOnSend;
 
+  int _createDestinationCount = 0;
+  int _dropDestinationCount = 0;
+
   public DummyTransportProviderAdminFactory() {
     this(false);
   }
@@ -75,12 +78,12 @@ public class DummyTransportProviderAdminFactory implements TransportProviderAdmi
 
   @Override
   public void createDestination(Datastream datastream) {
-
+    _createDestinationCount++;
   }
 
   @Override
   public void dropDestination(Datastream datastream) {
-
+    _dropDestinationCount++;
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -95,6 +95,28 @@ public class DatastreamTestUtils {
   }
 
   /**
+   * Creates a test datastream of specific connector type
+   * @param connectorType connector type of the datastream to be created.
+   * @param datastreamName Name of the datastream to be created.
+   * @param source source connection string to be used.
+   * @return Datastream that is created.
+   */
+  public static Datastream createDatastreamWithoutDestination(String connectorType, String datastreamName, String source) {
+    Datastream ds = new Datastream();
+    ds.setName(datastreamName);
+    ds.setConnectorName(connectorType);
+    ds.setSource(new DatastreamSource());
+    ds.getSource().setConnectionString(source);
+    ds.setTransportProviderName(DummyTransportProviderAdminFactory.PROVIDER_NAME);
+    ds.setStatus(DatastreamStatus.INITIALIZING);
+    StringMap metadata = new StringMap();
+    metadata.put(DatastreamMetadataConstants.OWNER_KEY, "dummy_owner");
+    metadata.put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(Instant.now().toEpochMilli()));
+    ds.setMetadata(metadata);
+    return ds;
+  }
+
+  /**
    * Store the datastreams into the appropriate locations in zookeeper.
    * @param zkClient zookeeper client
    * @param cluster name of the datastream cluster

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/DatastreamUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/DatastreamUtils.java
@@ -122,6 +122,11 @@ public final class DatastreamUtils {
 
   public static boolean isUserManagedDestination(Datastream stream) {
     return StringUtils.equals(stream.getMetadata().get(DatastreamMetadataConstants.IS_USER_MANAGED_DESTINATION_KEY),
-        "true");
+        Boolean.TRUE.toString());
+  }
+
+  public static boolean isConnectorManagedDestination(Datastream stream) {
+    return StringUtils.equals(stream.getMetadata().get(DatastreamMetadataConstants.IS_CONNECTOR_MANAGED_DESTINATION_KEY),
+        Boolean.TRUE.toString());
   }
 }


### PR DESCRIPTION
…irrorMaker scenarios)

MirrorMaker datastreams are unique in that they encompass an entire pipeline (of multiple source and topic destinations). The coordinator should not create or delete destination topics in such cases, since the destination topics are determined as the connector reads messages.