### PR TITLE
Remove ojdbc dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,22 +118,11 @@ project(':datastream-common') {
 
   dependencies {
     compile "org.apache.avro:avro:$avroVersion"
-    compile "com.oracle:ojdbc6:$ojdbcVersion"
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "com.intellij:annotations:$intellijAnnotations"
     compile group: 'com.google.guava', name: 'guava', version: '19.0'
     testCompile "org.mockito:mockito-core:$mockitoVersion"
-    testCompile "com.oracle:ojdbc6:11.2.0.2.0"
   }
-	tasks.create(name: "copyDependantLibs", type: Copy) {
-		from (configurations.runtime) {
-		}
-		into "$buildDir/dependant-libs"
-	}
-
-	jar {
-		dependsOn 'copyDependantLibs'
-	}
 }
 
 project(':datastream-server-api') {

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -17,5 +17,4 @@ ext {
     eventHubVersion = "0.9.0"
     samzaVersion = "0.11.0"
     mockitoVersion = "1.+"
-    ojdbcVersion="11.2.0.3"
 }


### PR DESCRIPTION
Was originally added when there was a test connecting to ei and needed
to load ojdbc drivers. Not needed anymore and the version used is causing
dependent libraries to break