### PR TITLE
Temporarily revive moved OracleDataSourceFactory to suppress backward…

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/OracleDataSourceFactory.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/OracleDataSourceFactory.java
@@ -1,0 +1,10 @@
+package com.linkedin.datastream.common;
+
+import javax.sql.DataSource;
+
+/*
+  TODO: ckung remove after usage of this in other MP(s) uses the version moved to /databases subdirectory
+ */
+public interface OracleDataSourceFactory {
+  DataSource createOracleDataSource(String uri, int queryTimeout) throws Exception;
+}


### PR DESCRIPTION
… compatibility failure

PCL is failing for brooklin-server, which makes reference to this class. This class was moved in previous check-in, so will have to revive it until brooklin-server is updated to refer to newer, moved version. 