### PR TITLE
Move pause/resume to abstract Kafka connector, fix config bug

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -4,17 +4,25 @@ import java.time.Duration;
 import java.time.temporal.ChronoUnit;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.PartitionInfo;
 import org.slf4j.Logger;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.DatastreamSource;
+import com.linkedin.datastream.common.DatastreamUtils;
+import com.linkedin.datastream.common.JsonUtils;
 import com.linkedin.datastream.common.ReflectionUtils;
 import com.linkedin.datastream.common.ThreadUtils;
 import com.linkedin.datastream.common.VerifiableProperties;
@@ -133,7 +141,69 @@ public abstract class AbstractKafkaConnector implements Connector {
   @Override
   public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
-    // nop
+    // validate for paused partitions
+    validatePausedPartitions(datastreams, allDatastreams);
+  }
+
+
+  private void validatePausedPartitions(List<Datastream> datastreams, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
+    for (Datastream ds : datastreams) {
+      validatePausedPartitions(ds, allDatastreams);
+    }
+  }
+
+  private void validatePausedPartitions(Datastream datastream, List<Datastream> allDatastreams)
+      throws DatastreamValidationException {
+    Map<String, Set<String>> pausedSourcePartitionsMap = DatastreamUtils.getDatastreamSourcePartitions(datastream);
+
+    for (String source : pausedSourcePartitionsMap.keySet()) {
+      Set<String> newPartitions = pausedSourcePartitionsMap.get(source);
+
+      // Validate that partitions actually exist and convert any "*" to actual list of partitions.
+      // For that, get the list of existing partitions first.
+      List<PartitionInfo> partitionInfos = getKafkaTopicPartitions(datastream, source);
+      Set<String> allPartitions = new HashSet<>();
+      for (PartitionInfo info : partitionInfos) {
+        allPartitions.add(String.valueOf(info.partition()));
+      }
+
+      // if there is any * in the new list, just convert it to actual list of partitions.
+      if (newPartitions.contains(DatastreamMetadataConstants.REGEX_PAUSE_ALL_PARTITIONS_IN_A_TOPIC)) {
+        newPartitions.clear();
+        newPartitions.addAll(allPartitions);
+      } else {
+        // Else make sure there aren't any partitions that don't exist.
+        newPartitions.retainAll(allPartitions);
+      }
+    }
+
+    // Now write back the set to datastream
+    datastream.getMetadata()
+        .put(DatastreamMetadataConstants.PAUSED_SOURCE_PARTITIONS_KEY, JsonUtils.toJson(pausedSourcePartitionsMap));
+  }
+
+  private List<PartitionInfo> getKafkaTopicPartitions(Datastream datastream, String topic)
+      throws DatastreamValidationException {
+    List<PartitionInfo> partitionInfos = null;
+
+    DatastreamSource source = datastream.getSource();
+    String connectionString = source.getConnectionString();
+
+    KafkaConnectionString parsed = KafkaConnectionString.valueOf(connectionString);
+
+    try (Consumer<?, ?> consumer = KafkaConnectorTask.createConsumer(_consumerFactory, _consumerProps,
+        "KafkaConnectorPartitionFinder", parsed)) {
+      partitionInfos = consumer.partitionsFor(topic);
+      if (partitionInfos == null) {
+        throw new DatastreamValidationException("Can't get partition info from kafka for topic: " + topic);
+      }
+    } catch (Exception e) {
+      throw new DatastreamValidationException(
+          "Exception received while retrieving info on kafka topic partitions: " + e);
+    }
+
+    return partitionInfos;
   }
 
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/FlushlessKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/FlushlessKafkaMirrorMakerConnectorTask.java
@@ -45,7 +45,6 @@ class FlushlessKafkaMirrorMakerConnectorTask extends KafkaMirrorMakerConnectorTa
         new KafkaMirrorMakerCheckpoint(datastreamProducerRecord.getCheckpoint());
     _flushlessProducer.send(datastreamProducerRecord, sourceCheckpoint.getTopic(), sourceCheckpoint.getPartition(),
         sourceCheckpoint.getOffset());
-
   }
 
   @Override

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
@@ -1,28 +1,20 @@
 package com.linkedin.datastream.connectors.kafka.mirrormaker;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
 import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
-import java.util.Set;
 
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.common.PartitionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
-import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.DatastreamUtils;
-import com.linkedin.datastream.common.JsonUtils;
 import com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask;
 import com.linkedin.datastream.connectors.kafka.AbstractKafkaConnector;
 import com.linkedin.datastream.connectors.kafka.KafkaConnectionString;
-import com.linkedin.datastream.connectors.kafka.KafkaConnectorTask;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
@@ -102,72 +94,4 @@ public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
     return Collections.unmodifiableList(KafkaMirrorMakerConnectorTask.getMetricInfos());
   }
 
-  @Override
-  public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
-      throws DatastreamValidationException {
-    super.validateUpdateDatastreams(datastreams, allDatastreams);
-
-    // validate for paused partitions
-    validatePausedPartitions(datastreams, allDatastreams);
-  }
-
-  private void validatePausedPartitions(List<Datastream> datastreams, List<Datastream> allDatastreams)
-      throws DatastreamValidationException {
-    for (Datastream ds : datastreams) {
-      validatePausedPartitions(ds, allDatastreams);
-    }
-  }
-
-  private void validatePausedPartitions(Datastream datastream, List<Datastream> allDatastreams)
-      throws DatastreamValidationException {
-    Map<String, Set<String>> pausedSourcePartitionsMap = DatastreamUtils.getDatastreamSourcePartitions(datastream);
-
-    for (String source : pausedSourcePartitionsMap.keySet()) {
-      Set<String> newPartitions = pausedSourcePartitionsMap.get(source);
-
-      // Validate that partitions actually exist and convert any "*" to actual list of partitions.
-      // For that, get the list of existing partitions first.
-      List<PartitionInfo> partitionInfos = getKafkaTopicPartitions(datastream, source);
-      Set<String> allPartitions = new HashSet<>();
-      for (PartitionInfo info : partitionInfos) {
-        allPartitions.add(String.valueOf(info.partition()));
-      }
-
-      // if there is any * in the new list, just convert it to actual list of partitions.
-      if (newPartitions.contains(DatastreamMetadataConstants.REGEX_PAUSE_ALL_PARTITIONS_IN_A_TOPIC)) {
-        newPartitions.clear();
-        newPartitions.addAll(allPartitions);
-      } else {
-        // Else make sure there aren't any partitions that don't exist.
-        newPartitions.retainAll(allPartitions);
-      }
-    }
-
-    // Now write back the set to datastream
-    datastream.getMetadata()
-        .put(DatastreamMetadataConstants.PAUSED_SOURCE_PARTITIONS_KEY, JsonUtils.toJson(pausedSourcePartitionsMap));
-  }
-
-  private List<PartitionInfo> getKafkaTopicPartitions(Datastream datastream, String topic)
-      throws DatastreamValidationException {
-    List<PartitionInfo> partitionInfos = null;
-
-    DatastreamSource source = datastream.getSource();
-    String connectionString = source.getConnectionString();
-
-    KafkaConnectionString parsed = KafkaConnectionString.valueOf(connectionString);
-
-    try (Consumer<?, ?> consumer = KafkaConnectorTask.createConsumer(_consumerFactory, _consumerProps,
-        "MmPartitionFinder", parsed)) {
-      partitionInfos = consumer.partitionsFor(topic);
-      if (partitionInfos == null) {
-        throw new DatastreamValidationException("Can't get partition info from kafka for topic: " + topic);
-      }
-    } catch (Exception e) {
-      throw new DatastreamValidationException(
-          "Exception received while retrieving info on kafka topic partitions: " + e);
-    }
-
-    return partitionInfos;
-  }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -3,34 +3,20 @@ package com.linkedin.datastream.connectors.kafka.mirrormaker;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.apache.commons.lang.Validate;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.common.TopicPartition;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.BrooklinEnvelopeMetadataConstants;
-import com.linkedin.datastream.common.DatastreamConstants;
-import com.linkedin.datastream.common.DatastreamRuntimeException;
-import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.connectors.CommonConnectorMetrics;
 import com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask;
 import com.linkedin.datastream.connectors.kafka.KafkaBrokerAddress;
@@ -66,20 +52,6 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   private final KafkaConsumerFactory<?, ?> _consumerFactory;
   private final KafkaConnectionString _mirrorMakerSource;
 
-  // Set indicating if there is any change in task.
-  // Initialize _taskUpdates to all the updates which should be set to "true"
-  // at the time of startup.
-  private final ConcurrentLinkedQueue<DatastreamConstants.UpdateType> _taskUpdates =
-      new ConcurrentLinkedQueue<>(Arrays.asList(DatastreamConstants.UpdateType.PAUSE_RESUME_PARTITIONS));
-
-  // This variable is used only for testing
-  @VisibleForTesting
-  int _pausedPartitionsUpdatedCount = 0;
-
-  // stores source partitions that are paused for given datastream.
-  // Note: always use with a lock on pausedPartitionsUpdated
-  private Map<String, Set<String>> _pausedSourcePartitions = new ConcurrentHashMap<>();
-
   protected KafkaMirrorMakerConnectorTask(KafkaConsumerFactory<?, ?> factory, Properties consumerProps,
       DatastreamTask task, long commitIntervalMillis, Duration retrySleepDuration, int retryCount) {
     super(consumerProps, task, commitIntervalMillis, retrySleepDuration, retryCount, LOG);
@@ -89,25 +61,24 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
 
   @Override
   protected Consumer<?, ?> createKafkaConsumer(Properties consumerProps) {
+    Properties properties = new Properties();
+    properties.putAll(consumerProps);
     String bootstrapValue = String.join(KafkaConnectionString.BROKER_LIST_DELIMITER,
         _mirrorMakerSource.getBrokers().stream().map(KafkaBrokerAddress::toString).collect(Collectors.toList()));
-
-    consumerProps.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapValue);
-    consumerProps.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, _datastreamTask.getDatastreams().get(0).getName());
-    consumerProps.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
+    properties.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapValue);
+    properties.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, _datastreamName);
+    properties.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
         Boolean.FALSE.toString()); // auto-commits are unsafe
-    // TODO: read auto.offset.reset from the config or metadata so that this is configurable by SRE, who might want
-    // latest when pipeline is first set up but might want to change to "oldest" for all newly created topics, once
-    // pipeline is stabilized.
-    consumerProps.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
-    return _consumerFactory.createConsumer(consumerProps);
+    properties.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    LOG.info("Creating Kafka consumer for task {} with properties {}", _datastreamTask, properties);
+    return _consumerFactory.createConsumer(properties);
   }
 
   @Override
   protected void consumerSubscribe() {
+    LOG.info("About to subscribe to source: {}", _mirrorMakerSource.getTopicName());
     _consumer.subscribe(Pattern.compile(_mirrorMakerSource.getTopicName()), this);
   }
-
 
   @Override
   protected DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, Instant readTime) throws Exception {
@@ -131,15 +102,6 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     return builder.build();
   }
 
-
-  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-    _consumerMetrics.updateRebalanceRate(1);
-    LOG.info("Partition ownership assigned for {}.", partitions);
-    // update paused partitions, in case.
-    _taskUpdates.add(DatastreamConstants.UpdateType.PAUSE_RESUME_PARTITIONS);
-    // TODO: detect when new topic falls into subscription and create topic in destination.
-  }
-
   public static List<BrooklinMetricInfo> getMetricInfos() {
     List<BrooklinMetricInfo> metrics = new ArrayList<>();
     metrics.addAll(CommonConnectorMetrics.getEventProcessingMetrics(METRICS_PREFIX_REGEX));
@@ -148,100 +110,4 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     return metrics;
   }
 
-  // Note: This method is supposed to be called from run() thread, so in effect, it is "single threaded".
-  // The only updates that can happen to _taskUpdates queue outside this method is addition of
-  // new update type when there is any update to datastream task (in method checkForUpdateTask())
-  @Override
-  protected void preConsumerPollHook() {
-    // See if there was any update in task and take actions.
-    while (!_taskUpdates.isEmpty()) {
-      DatastreamConstants.UpdateType updateType = _taskUpdates.remove();
-      if (updateType != null) {
-        switch (updateType) {
-          case PAUSE_RESUME_PARTITIONS:
-            pausePartitions();
-            break;
-          default:
-            String msg = String.format("Unknown update type {} for task {}.", updateType, _taskName);
-            _logger.error(msg);
-            throw new DatastreamRuntimeException(msg);
-        }
-      }
-    }
-  }
-
-  @Override
-  public void checkForUpdateTask(DatastreamTask datastreamTask) {
-    // check if there was any change in paused partitions.
-    checkForPausedPartitionsUpdate(datastreamTask);
-  }
-
-  // This method checks if there is any change in set of paused partitions for given datastreamtask.
-  private void checkForPausedPartitionsUpdate(DatastreamTask datastreamTask) {
-    // Check if there is any change in paused partitions
-    // first get the given set of paused source partitions from metadata
-    Map<String, Set<String>> newPausedSourcePartitionsMap = new HashMap<>();
-    newPausedSourcePartitionsMap =
-        DatastreamUtils.getDatastreamSourcePartitions(datastreamTask.getDatastreams().get(0));
-
-    if (!newPausedSourcePartitionsMap.equals(_pausedSourcePartitions)) {
-      _pausedSourcePartitions.clear();
-      _pausedSourcePartitions.putAll(newPausedSourcePartitionsMap);
-      _taskUpdates.add(DatastreamConstants.UpdateType.PAUSE_RESUME_PARTITIONS);
-    }
-  }
-
-  // TODO: Move logic to pause partitions to AbstractKafkaConnector
-  // This method pauses/resumes partitions.
-  private void pausePartitions() {
-    // This is only for testing purpose.
-    _pausedPartitionsUpdatedCount++;
-
-    Validate.isTrue(_consumer != null);
-
-    LOG.info("List of partitions to pause changed for datastream: {}. The list is: {}", _datastream.getName(),
-        _pausedSourcePartitions);
-
-    // contains list of new partitions to pause
-    Set<TopicPartition> partitionsToPause = new HashSet<>();
-
-    // get the config that's already there on the consumer
-    Set<TopicPartition> pausedPartitions = _consumer.paused();
-    Set<TopicPartition> assignedPartitions = _consumer.assignment();
-
-    // Get partitions to pause
-    for (String source : _pausedSourcePartitions.keySet()) {
-      for (String partition : _pausedSourcePartitions.get(source)) {
-        partitionsToPause.add(new TopicPartition(source, Integer.parseInt(partition)));
-      }
-    }
-
-    // Make sure those partitions are assigned to this task.
-    partitionsToPause.retainAll(assignedPartitions);
-
-    // If the partitions to pause are paused already, don't do anything.
-    if (partitionsToPause.equals(pausedPartitions)) {
-      return;
-    }
-
-    // Resume current paused partitions by default.
-    _consumer.resume(pausedPartitions);
-    LOG.info("Resumed these partitions: {}", pausedPartitions);
-
-    // pause partitions to pause
-    _consumer.pause(partitionsToPause);
-    LOG.info("Paused these partitions: {}", partitionsToPause);
-  }
-
-  @VisibleForTesting
-  int getPausedPartitionsUpdateCount() {
-    return _pausedPartitionsUpdatedCount;
-  }
-
-  @VisibleForTesting
-  Map<String, Set<String>> getPausedSourcePartitions() {
-    Map<String, Set<String>> pausedSourcePartitions = new ConcurrentHashMap<>();
-    pausedSourcePartitions.putAll(_pausedSourcePartitions);
-    return pausedSourcePartitions;
-  }
 }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
@@ -192,11 +192,12 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
         new KafkaMirrorMakerConnector("MirrorMakerConnector", getDefaultConfig(Optional.empty()));
     Datastream ds = createDatastream("testFlushlessModeEnabled", _broker, "Pizza", new StringMap());
 
-    // assert that flushless task is created
+    // assert that flushless task is not created
     Assert.assertTrue(connector.createKafkaBasedConnectorTask(
         new DatastreamTaskImpl(Arrays.asList(ds))) instanceof KafkaMirrorMakerConnectorTask);
   }
 
+  @Test
   public void testValidateDatastreamUpdatePausedPartitions() throws Exception {
     String topic = "Topic";
     Map<String, Set<String>> pausedPartitions = new HashMap<>();


### PR DESCRIPTION
Config bug directly used same property bag object whenever creating Kafka consumers. This caused all datastreams to use the same group.id and bootstrap.servers configs as the first datastream created because consumerProps.putIfAbsent() only works the first time.

Move pause/resume functionality to abstract Kafka connector so that it could be used by KafkaConnector as well.