### PR TITLE
Removing the SkipBadMessages feature from EventProducer

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -16,7 +16,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.BrooklinEnvelope;
-import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.ErrorLogger;
 import com.linkedin.datastream.metrics.BrooklinCounterInfo;
@@ -87,16 +86,12 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_SLA_MS = "60000"; // 1 minute
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS = "180000"; // 3 minutes
 
-  public static final String CFG_SKIP_BAD_MESSAGE = "skipBadMessage";
-  public static final String SKIPPED_BAD_MESSAGES_COUNTER = "skippedBadMessagesCounter";
-
   private final String _datastreamName;
   private final int _availabilityThresholdSlaMs;
   // Alternate SLA for comparision with the main
   private final int _availabilityThresholdAlternateSlaMs;
   private Instant _lastFlushTime = Instant.now();
   private final Duration _flushInterval;
-  private final boolean _skipBadMessagesEnabled;
 
   /**
    * Construct an EventProducer instance.
@@ -144,10 +139,7 @@ public class EventProducer implements DatastreamEventProducer {
     _dynamicMetricsManager.createOrUpdateCounter(MODULE, _datastreamTask.getConnectorType(),
         EVENTS_PRODUCED_OUTSIDE_SLA, 0);
 
-    _skipBadMessagesEnabled = skipBadMessageEnabled(task);
-    if (_skipBadMessagesEnabled) {
-      _dynamicMetricsManager.createOrUpdateCounter(MODULE, _datastreamName, SKIPPED_BAD_MESSAGES_COUNTER, 0);
-    }
+
   }
 
   public int getProducerId() {
@@ -190,27 +182,7 @@ public class EventProducer implements DatastreamEventProducer {
     } catch (Exception e) {
       String errorMessage = String.format("Failed send the event %s exception %s", record, e);
       _logger.warn(errorMessage, e);
-      if (_skipBadMessagesEnabled) {
-      /*
-       * If flag _skipBadMessagesEnabled is set, then message are skipped after an unsuccessful send
-       * Example of problems:
-       * - Message is above the message size supported by the destination.
-       * - The message can not be encoded to conform to the destination format (e.g. missing a field).
-       *
-       * This flag should only be set to true for use cases that can tolerate messages lost.
-       *
-       * Unfortunately the error could be a transient network problem, and not a problem with the message itself.
-       * For this reason is strongly recommended to put alerts in the SKIPPED_BAD_MESSAGES_RATE.
-       *
-       * TODO: Try to define a special exception for "badMessage" so we can differentiate between a send error,
-       * or a message compliance error. Right now is very hard to do that, because  will require to refactor a lot
-       * of library and code we do not control.
-       */
-        _logger.error("Skipping Message. task: {} ; error: {}", _datastreamTask, e);
-        _dynamicMetricsManager.createOrUpdateCounter(MODULE, _datastreamName, SKIPPED_BAD_MESSAGES_COUNTER, 1);
-      } else {
-        throw new DatastreamRuntimeException(errorMessage, e);
-      }
+      throw new DatastreamRuntimeException(errorMessage, e);
     }
 
     // It is possible that the connector is not calling flush at regular intervals, In which case we will force a periodic flush.
@@ -348,7 +320,6 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + TOTAL_EVENTS_PRODUCED));
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX + EVENT_PRODUCE_RATE));
-    metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + SKIPPED_BAD_MESSAGES_COUNTER));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_LATENCY_MS_STRING, Optional.of(
@@ -358,18 +329,5 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + FLUSH_LATENCY_MS_STRING));
 
     return Collections.unmodifiableList(metrics);
-  }
-
-  /**
-   * Look for config {@value CFG_SKIP_BAD_MESSAGE} in the datastream metadata and returns its value.
-   * Default value is false.
-   */
-  private static boolean skipBadMessageEnabled(DatastreamTask task) {
-    return task.getDatastreams()
-        .stream()
-        .findAny()
-        .map(Datastream::getMetadata)
-        .map(metadata -> metadata.getOrDefault(CFG_SKIP_BAD_MESSAGE, "false").toLowerCase().equals("true"))
-        .orElse(false);
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -11,13 +11,10 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
 
-import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.Datastream;
-import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.api.transport.SendCallback;
@@ -62,7 +59,6 @@ public class TestEventProducer {
 
     EventProducer eventProducer = new EventProducer(task, transport,
         new NoOpCheckpointProvider(), new Properties(), false);
-    Assert.assertNull(getBadMessageCounter(datastream));
 
     int eventCount = 5;
     for (int i = 0; i < eventCount; i++) {
@@ -71,49 +67,8 @@ public class TestEventProducer {
     Assert.assertEquals(eventCount, numEventsProduced.get());
   }
 
-  @Test
-  public void testSendAndSkipBadMessages() {
-    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "test-ds")[0];
-    StringMap metadata = datastream.getMetadata();
-    metadata.put(EventProducer.CFG_SKIP_BAD_MESSAGE, "true");
-    datastream.setMetadata(metadata);
 
-    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
 
-    // Create a "all-fail" transport provider
-    int failedCount = 3;
-    AtomicInteger numEventsProduced = new AtomicInteger();
-    TransportProvider transport = new NoOpTransportProvider() {
-      @Override
-      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
-        if (numEventsProduced.incrementAndGet() <= failedCount) {
-          throw new DatastreamRuntimeException();
-        }
-      }
-    };
-
-    EventProducer eventProducer = new EventProducer(task, transport,
-        new NoOpCheckpointProvider(), new Properties(), false);
-
-    int eventCount = 5;
-    for (int i = 0; i < eventCount; i++) {
-      eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
-    }
-
-    Assert.assertEquals(eventCount, numEventsProduced.get());
-
-    // Verify bad message count equals to messages produced
-    Counter badMessageCounter = getBadMessageCounter(datastream);
-    Assert.assertEquals(failedCount, badMessageCounter.getCount());
-
-  }
-
-  private Counter getBadMessageCounter(Datastream datastream) {
-    return DynamicMetricsManager.getInstance().getMetric(String.format("%s.%s.%s",
-        EventProducer.class.getSimpleName(),
-        datastream.getName(),
-        EventProducer.SKIPPED_BAD_MESSAGES_COUNTER));
-  }
 
   private DatastreamProducerRecord createDatastreamProducerRecord() {
     return createDatastreamProducerRecord(0, "0", 1);


### PR DESCRIPTION
`skipBadMessage` feature that was introduced for EventHub scenarios where the largeMessages needs to be ignored can result in data loss and it also results in the producers being torn down and recreated all the time. Hence removing the feature.

Event LargeMessages should ideally be skipped in the EventHubs transport and ideally just for the large messages even before we send these messages to EventHub.   