### PR TITLE
use sliding time window histogram for reporting latency

### DIFF
--- a/datastream-common/src/test/java/com/linkedin/datastream/metrics/TestDynamicMetricsManager.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/metrics/TestDynamicMetricsManager.java
@@ -1,0 +1,37 @@
+package com.linkedin.datastream.metrics;
+
+import java.lang.reflect.Method;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.MetricRegistry;
+
+
+@Test
+public class TestDynamicMetricsManager {
+  private DynamicMetricsManager _metricsManager;
+
+  private static final String CLASS_NAME = TestDynamicMetricsManager.class.getName();
+
+  @BeforeMethod
+  public void setup(Method method) {
+    _metricsManager = DynamicMetricsManager.createInstance(new MetricRegistry(), method.getName());
+  }
+
+  @Test
+  public void testCreateOrUpdateSlidingWindowHistogram() throws Exception {
+    long highLatency = 10000;
+    _metricsManager.createOrUpdateSlidingWindowHistogram(CLASS_NAME, "test", "latency", 1, highLatency);
+    // definitely not ideal. but using Clock makes the API itself looks clumsy
+    // So keep using the system clock for now and if we see flakiness or something we can make changes
+    Thread.sleep(100);
+    _metricsManager.createOrUpdateSlidingWindowHistogram(CLASS_NAME, "test", "latency", 1, 10);
+    String fullName = MetricRegistry.name(CLASS_NAME, "test", "latency");
+    Histogram histogram = _metricsManager.getMetric(fullName);
+    // verify that we are not stuck in the old latency value
+    Assert.assertNotEquals(histogram.getSnapshot().getMax(), highLatency);
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -86,6 +86,7 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String AGGREGATE = "aggregate";
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_SLA_MS = "60000"; // 1 minute
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS = "180000"; // 3 minutes
+  private static final long LATENCY_SLIDING_WINDOW_LENGTH_MS = Duration.ofMinutes(5).toMillis();
 
   public static final String CFG_SKIP_BAD_MESSAGE = "skipBadMessage";
   public static final String SKIPPED_BAD_MESSAGES_COUNTER = "skippedBadMessagesCounter";
@@ -227,12 +228,14 @@ public class EventProducer implements DatastreamEventProducer {
     if (record.getEventsSourceTimestamp() > 0) {
       // Report availability metrics
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - record.getEventsSourceTimestamp();
-      _dynamicMetricsManager.createOrUpdateHistogram(MODULE, metadata.getTopic(), EVENTS_LATENCY_MS_STRING,
-          sourceToDestinationLatencyMs);
-      _dynamicMetricsManager.createOrUpdateHistogram(MODULE, AGGREGATE, EVENTS_LATENCY_MS_STRING,
-          sourceToDestinationLatencyMs);
-      _dynamicMetricsManager.createOrUpdateHistogram(MODULE, _datastreamTask.getConnectorType(),
-          EVENTS_LATENCY_MS_STRING, sourceToDestinationLatencyMs);
+      // Using a time sliding window for reporting latency specifically.
+      // Otherwise we report very stuck max value for slow source
+      _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, metadata.getTopic(), EVENTS_LATENCY_MS_STRING,
+          LATENCY_SLIDING_WINDOW_LENGTH_MS, sourceToDestinationLatencyMs);
+      _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, AGGREGATE, EVENTS_LATENCY_MS_STRING,
+          LATENCY_SLIDING_WINDOW_LENGTH_MS, sourceToDestinationLatencyMs);
+      _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, _datastreamTask.getConnectorType(),
+          EVENTS_LATENCY_MS_STRING, LATENCY_SLIDING_WINDOW_LENGTH_MS, sourceToDestinationLatencyMs);
 
       if (sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs) {
         _dynamicMetricsManager.createOrUpdateCounter(MODULE, AGGREGATE, EVENTS_PRODUCED_WITHIN_SLA, 1);


### PR DESCRIPTION
DDSDBUS-12578: use sliding time window histogram for reporting latency

By default the ExponentiallyDecayingReservoir is being used but that's not ideal for latency report. See the jira ticket.

Also not doing this for every histogram because ExponentiallyDecayingReservoir is good for most cases.