### PR TITLE
Misc MirrorMaker bug fixes

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -103,7 +103,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   protected KafkaBasedConnectorTaskMetrics _consumerMetrics;
 
-  protected AbstractKafkaBasedConnectorTask(KafkaBasedConnectorConfig config, DatastreamTask task, Logger logger) {
+  protected AbstractKafkaBasedConnectorTask(KafkaBasedConnectorConfig config, DatastreamTask task, Logger logger,
+      String metricsPrefix) {
     _logger = logger;
     _logger.info(
         "Creating Kafka-based connector task for datastream task {} with commit interval {} ms, retry sleep duration {}"
@@ -128,7 +129,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _offsetCommitInterval = config.getCommitIntervalMillis();
     _retrySleepDuration = config.getRetrySleepDuration();
 
-    _consumerMetrics = createKafkaBasedConnectorTaskMetrics(this.getClass().getSimpleName(), _datastreamName, _logger);
+    _consumerMetrics = createKafkaBasedConnectorTaskMetrics(metricsPrefix, _datastreamName, _logger);
   }
 
   protected KafkaBasedConnectorTaskMetrics createKafkaBasedConnectorTaskMetrics(String className, String key, Logger errorLogger) {

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -38,7 +38,7 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
   private final KafkaConsumerFactory<?, ?> _consumerFactory;
 
   public KafkaConnectorTask(KafkaBasedConnectorConfig config, DatastreamTask task) {
-    super(config, task, LOG);
+    super(config, task, LOG, CLASS_NAME);
     _consumerFactory = config.getConsumerFactory();
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/PausedSourcePartitionMetadata.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/PausedSourcePartitionMetadata.java
@@ -55,4 +55,8 @@ public class PausedSourcePartitionMetadata {
         Reason.SEND_ERROR);
   }
 
+  @Override
+  public String toString() {
+    return _reason.toString();
+  }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerCheckpoint.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerCheckpoint.java
@@ -4,10 +4,10 @@ import org.apache.commons.lang.Validate;
 
 
 /**
- * Represents a KafkaMirrorMaker source checkpoint in format: topic-partition-offset
+ * Represents a KafkaMirrorMaker source checkpoint in format: topic/partition/offset
  */
 public class KafkaMirrorMakerCheckpoint {
-  private static final String DELIMITER = "-";
+  private static final String DELIMITER = "/";
   private String _topic;
   private int _partition;
   private long _offset;

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -51,7 +51,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   private final KafkaConnectionString _mirrorMakerSource;
 
   protected KafkaMirrorMakerConnectorTask(KafkaBasedConnectorConfig config, DatastreamTask task) {
-    super(config, task, LOG);
+    super(config, task, LOG, CLASS_NAME);
     _consumerFactory = config.getConsumerFactory();
     _mirrorMakerSource = KafkaConnectionString.valueOf(_datastreamTask.getDatastreamSource().getConnectionString());
   }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
@@ -187,5 +187,10 @@ public class FlushlessEventProducerHandler<T extends Comparable<T>> {
     public int getPartition() {
       return getValue();
     }
+
+    @Override
+    public String toString() {
+      return getSource() + "-" + getPartition();
+    }
   }
 }


### PR DESCRIPTION
Found a few bugs while testing flushless mode in dev cluster:

- Metrics were not being emitted in flushless mode because we only register them with prefix "KafkaMirrorMakerTask", but we are updating the metrics using prefix "FlushlessMirrorMakerTask".
- KafkaMirrorMakerCheckpoint should not use "-" as delimiter, since actual topic names could have dashes.
- PausedSourcePartitionMetadata should override toString() to print out reason for pause, so that log messages are more descriptive.

Example logs that helped detect:
2018/03/27 18:41:25.585 ERROR [KafkaMirrorMakerConnectorTask] [KafkaMirrorMaker worker thread 2] [brooklin-service] [] Error sending Message. task: ckung-brooklin-mm_23da314a-26d8-4e09-82f5-769442bc8fb9 ; error: java.lang.IllegalArgumentException: Checkpoint should be in format: topic-partition-offset, but found: esp_ESPRESSO_MT2-BrooklinSampleDb1-12-1730035;

2018/03/27 18:42:00.596 INFO [KafkaMirrorMakerConnectorTask] [KafkaMirrorMaker worker thread 2] [brooklin-service] [] Current auto-pause partition set is: {esp_ESPRESSO_MT2-BrooklinSampleDb1-4=com.linkedin.datastream.connectors.kafka.PausedSourcePartitionMetadata@6727a370, esp_ESPRESSO_MT2-BrooklinSampleDb1-8=com.linkedin.datastream.connectors.kafka.PausedSourcePartitionMetadata@317497e2, esp_ESPRESSO_MT2-BrooklinSampleDb1-12=com.linkedin.datastream.connectors.kafka.PausedSourcePartitionMetadata@2cdc8afa, esp_ESPRESSO_MT2-BrooklinSampleDb1-0=com.linkedin.datastream.connectors.kafka.PausedSourcePartitionMetadata@658b5058}