### PR TITLE
Adding capability in the AbstractKafkaConnector to restart tasks if they are not running

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
@@ -22,9 +22,9 @@ public class BrooklinEnvelopeMetadataConstants {
   // Table for which the event belongs
   public static final String TABLE = "Table";
 
-  // Timestamp of when the event was last modified in the source
+  // Timestamp of when the event was last modified in the source where the event was generated
   public static final String EVENT_TIMESTAMP = "EventTimestamp";
 
-  // Timestamp of the event source
+  // Timestamp of the event when it was written in the last leg (i.e. the Source of the connector)
   public static final String SOURCE_TIMESTAMP = "SourceTimestamp";
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -71,6 +71,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   // lifecycle
   protected volatile boolean _shouldDie = false;
+  protected volatile long _lastPolledTimeMs = System.currentTimeMillis();
   protected final CountDownLatch _startedLatch = new CountDownLatch(1);
   protected final CountDownLatch _stoppedLatch = new CountDownLatch(1);
 
@@ -87,6 +88,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   // state
   protected volatile Thread _thread;
+
   protected volatile String _taskName;
   protected DatastreamEventProducer _producer;
   protected Consumer<?, ?> _consumer;
@@ -160,6 +162,14 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
    */
   protected abstract DatastreamProducerRecord translate(ConsumerRecord<?, ?> fromKafka, Instant readTime)
       throws Exception;
+
+  /**
+   * Get the taskName
+   */
+  protected String getTaskName() {
+    return _taskName;
+  }
+
 
   /**
    * Translate the Kafka consumer records if necessary and send the batch of records to destination.
@@ -312,6 +322,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     ConsumerRecords<?, ?> records;
     try {
       long curPollTime = System.currentTimeMillis();
+      _lastPolledTimeMs = curPollTime;
       records = _consumer.poll(pollInterval);
       long pollDurationMs = System.currentTimeMillis() - curPollTime;
       if (pollDurationMs > pollInterval + POLL_BUFFER_TIME_MS) {
@@ -337,6 +348,10 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       handlePollRecordsException(e);
       return ConsumerRecords.EMPTY;
     }
+  }
+
+  protected long getLastPolledTimeMs() {
+    return _lastPolledTimeMs;
   }
 
   /**
@@ -730,4 +745,5 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   public boolean hasDatastream(String datastreamName) {
     return _datastreamName.equals(datastreamName);
   }
+
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -24,10 +24,15 @@ public class KafkaBasedConnectorConfig {
   public static final String CONFIG_RETRY_SLEEP_DURATION_MS = "retrySleepDurationMs";
   public static final String CONFIG_PAUSE_PARTITION_ON_ERROR = "pausePartitionOnError";
   public static final String CONFIG_PAUSE_ERROR_PARTITION_DURATION_MS = "pauseErrorPartitionDurationMs";
+  public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
+  public static final String NON_GOOD_STATE_THRESHOLD_MS = "nonGoodStateThresholdMs";
 
   private static final long DEFAULT_RETRY_SLEEP_DURATION_MS = Duration.ofSeconds(5).toMillis();
   private static final long DEFAULT_PAUSE_ERROR_PARTITION_DURATION_MS = Duration.ofMinutes(10).toMillis();
   private static final int DEFAULT_RETRY_COUNT = 5;
+  private static final int DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS = 300;
+  public static final long DEFAULT_NON_GOOD_STATE_THRESHOLD_MS = Duration.ofMinutes(10).toMillis();
+  public static final long MIN_NON_GOOD_STATE_THRESHOLD_MS = Duration.ofMinutes(1).toMillis();
 
   private final Properties _consumerProps;
   private final VerifiableProperties _connectorProps;
@@ -40,6 +45,9 @@ public class KafkaBasedConnectorConfig {
   private final Duration _retrySleepDuration;
   private final boolean _pausePartitionOnError;
   private final Duration _pauseErrorPartitionDuration;
+
+  private final int _daemonThreadIntervalSeconds;
+  private final long _nonGoodStateThresholdMs;
 
   public KafkaBasedConnectorConfig(Properties properties) {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
@@ -55,6 +63,9 @@ public class KafkaBasedConnectorConfig {
     _pauseErrorPartitionDuration = Duration.ofMillis(
         verifiableProperties.getLong(CONFIG_PAUSE_ERROR_PARTITION_DURATION_MS,
             DEFAULT_PAUSE_ERROR_PARTITION_DURATION_MS));
+    _daemonThreadIntervalSeconds = verifiableProperties.getInt(DAEMON_THREAD_INTERVAL_SECONDS, DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS);
+    _nonGoodStateThresholdMs = verifiableProperties.getLongInRange(NON_GOOD_STATE_THRESHOLD_MS, DEFAULT_NON_GOOD_STATE_THRESHOLD_MS,
+        MIN_NON_GOOD_STATE_THRESHOLD_MS, Long.MAX_VALUE);
 
     String factory =
         verifiableProperties.getString(CONFIG_CONSUMER_FACTORY_CLASS, KafkaConsumerFactoryImpl.class.getName());
@@ -83,6 +94,8 @@ public class KafkaBasedConnectorConfig {
     _retrySleepDuration = retrySleepDuration;
     _pausePartitionOnError = pausePartitionOnError;
     _pauseErrorPartitionDuration = pauseErrorPartitionDuration;
+    _daemonThreadIntervalSeconds = DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS;
+    _nonGoodStateThresholdMs = DEFAULT_NON_GOOD_STATE_THRESHOLD_MS;
   }
 
   public String getDefaultKeySerde() {
@@ -126,4 +139,11 @@ public class KafkaBasedConnectorConfig {
     return _connectorProps;
   }
 
+  public int getDaemonThreadIntervalSeconds() {
+    return _daemonThreadIntervalSeconds;
+  }
+
+  public long getNonGoodStateThresholdMs() {
+    return _nonGoodStateThresholdMs;
+  }
 }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -1,0 +1,97 @@
+package com.linkedin.datastream.connectors.kafka;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.PollUtils;
+import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.DatastreamTaskImpl;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+
+import static org.mockito.Mockito.*;
+
+
+public class TestAbstractKafkaConnector {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestAbstractKafkaConnector.class);
+
+  @Test
+  public void testConnectorRestartCalled() {
+    Properties props = new Properties();
+    props.setProperty("daemonThreadIntervalInSeconds", "1");
+    TestKafkaConnector connector = new TestKafkaConnector(false, props);
+    DatastreamTask datastreamTask = new DatastreamTaskImpl();
+    connector.onAssignmentChange(Collections.singletonList(datastreamTask));
+    connector.start();
+    PollUtils.poll(() -> connector.getCreateTaskCalled() >= 3, Duration.ofSeconds(1).toMillis(),
+        Duration.ofSeconds(10).toMillis());
+    Assert.assertTrue(connector.getCreateTaskCalled() >= 3);
+  }
+
+  @Test
+  public void testRestartThrowsException() {
+    Properties props = new Properties();
+    props.setProperty("daemonThreadIntervalInSeconds", "1");
+    TestKafkaConnector connector = new TestKafkaConnector(true, props);
+    DatastreamTask datastreamTask = new DatastreamTaskImpl();
+    connector.onAssignmentChange(Collections.singletonList(datastreamTask));
+    connector.start();
+    PollUtils.poll(() -> connector.getCreateTaskCalled() >= 3, Duration.ofSeconds(1).toMillis(),
+        Duration.ofSeconds(10).toMillis());
+    Assert.assertTrue(connector.getCreateTaskCalled() >= 3);
+  }
+
+  public class TestKafkaConnector extends AbstractKafkaConnector {
+
+    private boolean _restartThrows;
+    private int _createTaskCalled = 0;
+
+    public TestKafkaConnector(boolean restartThrows, Properties props) {
+      super("test", props, LOG);
+      _restartThrows = restartThrows;
+    }
+
+    @Override
+    protected AbstractKafkaBasedConnectorTask createKafkaBasedConnectorTask(DatastreamTask task) {
+      _createTaskCalled++;
+      AbstractKafkaBasedConnectorTask connectorTask = mock(AbstractKafkaBasedConnectorTask.class);
+      try {
+        when(connectorTask.awaitStop(anyLong(), anyObject())).thenReturn(true);
+      } catch (InterruptedException e) {
+        e.printStackTrace();
+      }
+      return connectorTask;
+    }
+
+    @Override
+    public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
+        throws DatastreamValidationException {
+    }
+
+    @Override
+    protected boolean isTaskRunning(DatastreamTask datastreamTask) {
+      return false;
+    }
+
+    @Override
+    protected void restartIfNotRunning(DatastreamTask task) {
+      if (_restartThrows) {
+        _restartThrows = false;
+        throw new RuntimeException();
+      }
+      super.restartIfNotRunning(task);
+    }
+
+    public int getCreateTaskCalled() {
+      return _createTaskCalled;
+    }
+  }
+}


### PR DESCRIPTION
Right now if the kafka connector tasks are not running because of a temporary connection issues, pipeline is stuck and it needs a manual operational procedure to bounce the machine to bring the pipeline back up. With this change, We provide a capability for KafkaConnectorTask to identify whether the task is healthy if it is not we stop the task and recreate the task. 
The default behavior in `AbstractKafkaBasedConnectorTask` is to check whether the poll was called within the last `nonGoodStateThresholdMs`. If it is not called, then the task is deemed unhealthy and restarted.