### PR TITLE
Stop connectors at end of unit tests

### DIFF
--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -34,6 +34,8 @@ public class TestAbstractKafkaConnector {
     PollUtils.poll(() -> connector.getCreateTaskCalled() >= 3, Duration.ofSeconds(1).toMillis(),
         Duration.ofSeconds(10).toMillis());
     Assert.assertTrue(connector.getCreateTaskCalled() >= 3);
+
+    connector.stop();
   }
 
   @Test
@@ -47,6 +49,8 @@ public class TestAbstractKafkaConnector {
     PollUtils.poll(() -> connector.getCreateTaskCalled() >= 3, Duration.ofSeconds(1).toMillis(),
         Duration.ofSeconds(10).toMillis());
     Assert.assertTrue(connector.getCreateTaskCalled() >= 3);
+
+    connector.stop();
   }
 
   public class TestKafkaConnector extends AbstractKafkaConnector {

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
@@ -192,6 +192,8 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     String someTopic = "someTopic";
     Assert.assertEquals(transportProviderAdmin.getDestination(someTopic),
         String.format(stream.getDestination().getConnectionString(), someTopic));
+
+    coordinator.stop();
   }
 
   @Test
@@ -275,6 +277,8 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     // prepare expected partitions for validation
     expectedPartitions.put(topic, new HashSet<>(Arrays.asList("0", "1")));
     verifyPausedPartitions(connector, datastream, pausedPartitions, expectedPartitions);
+
+    coordinator.stop();
   }
 
   @Test
@@ -470,6 +474,8 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
             + "\\\"manualPausedPartitions\\\":{\\\"YummyPizza\\\":[\\\"19\\\"],\\\"SaltyPizza\\\":[\\\"1\\\",\\\"9"
             + "\\\",\\\"25\\\"]},\\\"inFlightMessageCounts\\\":{\\\"SaltyPizza-9\\\":20}}\""),
         "instance2 results were not as expected");
+
+    connector.stop();
   }
 
   private void verifyPausedPartitions(Connector connector, Datastream datastream,


### PR DESCRIPTION
Some test cases have daemon threads that didn't stop after other test cases finished running. These changes are simply to invoke connector.stop() at the end of test cases that use a running Kafka connector.

2018-04-03 18:15:59 INFO  TestAbstractKafkaConnector:130 - Checking status of running kafka connector tasks.
2018-04-03 18:15:59 WARN  TestAbstractKafkaConnector:150 - Detected that the kafka connector task is not running for datastream task null(null), partitions=[]. Restarting it
2018-04-03 18:15:59 INFO  TestAbstractKafkaConnector:117 - creating task for null(null), partitions=[].