### PR TITLE
Attempt to fix MirrorMaker flaky tests

### DIFF
--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -261,8 +261,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         "did not shut down on time");
   }
 
-  // TODO: fix the flaky test: DDSDBUS-13037
-  @Test(enabled = false)
+  @Test
   public void testAutoPauseOnSendFailure() throws Exception {
     String yummyTopic = "YummyPizza";
     createTopic(_zkUtils, yummyTopic);
@@ -335,7 +334,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         "did not shut down on time");
   }
 
-  @Test(enabled = false)
+  @Test
   public void testAutoPauseAndResumeOnSendFailure() throws Exception {
     String yummyTopic = "YummyPizza";
     createTopic(_zkUtils, yummyTopic);


### PR DESCRIPTION
Test case is flaky with the error below. Basically test case tries to send 2 good events and then hit an error on the 3rd event, which causes partition to pause. The test case checks that when the partition is auto-paused, we should have received the first 2 good events. However it looks like in some cases only 1 of the events were sent.

This is likely due to a recent change to MockDatastreamEventProducer handling the sendEvent in another thread. We should only do this if the sendCallback needs to be throttled. Otherwise, just use the same thread to send event and invoke callback.

Gradle suite > Gradle test > com.linkedin.datastream.connectors.kafka.mirrormaker.TestKafkaMirrorMakerConnectorTask.testAutoPauseOnSendFailure FAILED
    java.lang.AssertionError: The events before the failure should have been sent expected:<2> but was:<1>
        at org.testng.Assert.fail(Assert.java:89)
        at org.testng.Assert.failNotEquals(Assert.java:489)
        at org.testng.Assert.assertEquals(Assert.java:118)
        at org.testng.Assert.assertEquals(Assert.java:365)
        at com.linkedin.datastream.connectors.kafka.mirrormaker.TestKafkaMirrorMakerConnectorTask.testAutoPauseOnSendFailure(TestKafkaMirrorMakerConnectorTask.java:295)

