### PR TITLE
Upgrade Kafka version

### DIFF
--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/BaseKafkaZkTest.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/BaseKafkaZkTest.java
@@ -36,6 +36,7 @@ public abstract class BaseKafkaZkTest {
     Properties kafkaConfig = new Properties();
     // we will disable auto topic creation for tests
     kafkaConfig.setProperty("auto.create.topics.enable", Boolean.FALSE.toString());
+    kafkaConfig.setProperty("offsets.topic.replication.factor", "1");
     kafkaConfig.setProperty("delete.topic.enable", Boolean.TRUE.toString());
     _kafkaCluster = new EmbeddedZookeeperKafkaCluster(kafkaConfig);
     _kafkaCluster.startup();

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedKafkaCluster.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedKafkaCluster.java
@@ -6,14 +6,16 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.kafka.common.utils.Time;
+
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
 
 import com.linkedin.datastream.common.FileUtils;
 import com.linkedin.datastream.common.NetworkUtils;
 
-import java.util.concurrent.TimeUnit;
-import kafka.server.KafkaConfig;
-import kafka.server.KafkaServer;
-import kafka.utils.Time;
 
 
 /**

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -4,7 +4,7 @@ ext {
     commonsHttpClientVersion = "3.1"
     slf4jVersion = "1.7.5"
     log4jVersion = "1.2.17"
-    kafkaVersion = "0.10.1.1"
+    kafkaVersion = "0.10.2.1"
     LIKafkaVersion = "0.0.4"
     jacksonVersion = "1.8.5"
     avroVersion = "1.4.0"


### PR DESCRIPTION
When KafkaMirrorMakerConnector is subscribed to large number of topic partitions, poll() is hanging indefinitely. 

I think it is because the topic-level 'max.message.bytes' config for __consumer_offsets was bumped up to 20MB to handle when consumer is assigned large number of partitions, yet the consumer is not able to consume fetch such large message.

In the broker config documentation for 'max.message.bytes': 
"The largest record batch size allowed by Kafka. If this is increased and there are consumers older than 0.10.2, the consumers' fetch size must also be increased so that the they can fetch record batches this large."

So I want to bump the Kafka version to at least 0.10.2 and I chose the version that kafka-mirror-maker uses.