### PR TITLE
Configurable per-datastream metrics instead of per-topic metrics

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -139,9 +139,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         }));
     _offsetCommitInterval = config.getCommitIntervalMillis();
     _retrySleepDuration = config.getRetrySleepDuration();
-    _consumerMetrics =
-        createKafkaBasedConnectorTaskMetrics(metricsPrefix,
-            _datastreamName, _logger);
+    _consumerMetrics = createKafkaBasedConnectorTaskMetrics(metricsPrefix, _datastreamName, _logger);
   }
 
   protected static String generateMetricsPrefix(String connectorName, String simpleClassName) {


### PR DESCRIPTION
Brooklin MM datastreams encompass many topics, unlike most other connectors for which 1 datastream = 1 topic. EventProducer emits per-topic metrics, which burdens server with creating so many metrics.

Introducing config option to emit per-datastream metrics instead of per-topic. For datastreams that encompass multiple topics, per-datastream metrics could be useful instead.