### PR TITLE
Differentiate log levels for 400/500 errors

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -129,6 +129,8 @@ public class ConnectorWrapper {
         stream.setDestination(new DatastreamDestination());
       }
       _connector.initializeDatastream(stream, allDatastreams);
+    } catch (DatastreamValidationException ex) {
+      throw ex;
     } catch (Exception ex) {
       logErrorAndException("initializeDatastream", ex);
       throw ex;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -594,8 +594,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           "Invalid input params for create request", e);
     } catch (DatastreamValidationException e) {
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, CALL_ERROR, 1);
-      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, "Failed to initialize Datastream: ",
-          e);
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST,
+          "Failed to initialize Datastream: " + datastream, e);
     } catch (DatastreamAlreadyExistsException e) {
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, CALL_ERROR, 1);
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_409_CONFLICT,

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -561,7 +561,6 @@ public class TestCoordinator {
       resource.create(ds2);
       Assert.fail("DatastreamValidationException expected on creation of testDatastream2 with a pre-used destination");
     } catch (RestLiServiceException e) {
-      Assert.assertTrue(e.getMessage().contains("DatastreamValidationException"));
     }
 
     ds2.getDestination().setConnectionString("testDestination2"); // Should succeed with a different destination

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -1,5 +1,20 @@
 package com.linkedin.datastream.server.dms;
 
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.DatastreamRestClient;
 import com.linkedin.datastream.DatastreamRestClientFactory;
@@ -22,20 +37,6 @@ import com.linkedin.restli.server.PagingContext;
 import com.linkedin.restli.server.PathKeys;
 import com.linkedin.restli.server.RestLiServiceException;
 import com.linkedin.restli.server.UpdateResponse;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.Callable;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
-import org.mockito.Mockito;
-import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.Test;
 
 
 /**


### PR DESCRIPTION
    Currently, we print the full exception (including stacktrace) for all
    errors in DMS handlers. In reality, we should only be that verbose for
    server-side errors (5xx) at error log level.
    
    All 4xx errors are client issues and printing the msg and cause should
    be sufficient for troubleshooting. Also it should be at warning level.
    
    This helps cut down false alarms caused by automatic diagnosis that
    filters specifically for exception/error log entries.
