### PR TITLE
Allow maxTasks to exceed cluster size in BroadcastStrategy

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategyFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategyFactory.java
@@ -8,13 +8,19 @@ import com.linkedin.datastream.server.api.strategy.AssignmentStrategyFactory;
 
 
 public class BroadcastStrategyFactory implements AssignmentStrategyFactory {
+  // the number of datastream tasks to create for a datastream
   public static final String CFG_MAX_TASKS = "maxTasks";
+  // the max number of datastream tasks that can be assigned to each instance, for a datastream
+  public static final String CFG_LIMIT_MAX_TASKS = "dsTaskLimitPerInstance";
   public static final int DEFAULT_MAX_TASKS = 12;
+  public static final int DEFAULT_DS_TASK_LIMIT_PER_INSTANCE = 1;
+
 
   @Override
   public AssignmentStrategy createStrategy(Properties assignmentStrategyProperties) {
     VerifiableProperties props = new VerifiableProperties(assignmentStrategyProperties);
     int maxTasks = props.getInt(CFG_MAX_TASKS, DEFAULT_MAX_TASKS);
-    return new BroadcastStrategy(maxTasks);
+    int dsTaskLimitPerInstance = props.getInt(CFG_LIMIT_MAX_TASKS, DEFAULT_DS_TASK_LIMIT_PER_INSTANCE);
+    return new BroadcastStrategy(maxTasks, dsTaskLimitPerInstance);
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
@@ -31,7 +31,7 @@ public class TestBroadcastStrategy {
   private static final Logger LOG = LoggerFactory.getLogger(TestBroadcastStrategy.class.getName());
 
   @Test
-  public void testBroadcastStrategyCreatesAssignmentAcrossAllInstances() {
+  public void testCreatesAssignmentAcrossAllInstances() {
     String[] instances = new String[]{"instance1", "instance2", "instance3"};
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS);
@@ -40,28 +40,58 @@ public class TestBroadcastStrategy {
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), datastreams.size());
     }
+
+    // test with broadcast strategy where max tasks is not capped by instances size
+    BroadcastStrategy unlimitedStrategy = new BroadcastStrategy(DEFAULT_MAX_TASKS, 100);
+    assignment = unlimitedStrategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+    int expected = datastreams.size() * DEFAULT_MAX_TASKS / instances.length;
+    for (String instance : instances) {
+      Assert.assertEquals(assignment.get(instance).size(), expected);
+    }
   }
 
   @Test
-  public void testBroadcastStrategyMaxTasks() {
+  public void testMaxTasks() {
     int numDatastreams = 10;
     int numInstances = 20;
     int maxTasks = 7;
     int expectedTotalTasks = numDatastreams * maxTasks;
     List<DatastreamGroup> datastreams = generateDatastreams("ds", numDatastreams);
     doTestMaxTasks(new BroadcastStrategy(maxTasks), numInstances, expectedTotalTasks, datastreams);
+
+    // test with broadcast strategy where max tasks is not capped by instances size
+    numInstances = 7;
+    maxTasks = 20;
+    expectedTotalTasks = numDatastreams * maxTasks;
+    doTestMaxTasks(new BroadcastStrategy(maxTasks, 1000), numInstances, expectedTotalTasks, datastreams);
   }
 
   @Test
-  public void testBroadcastStrategyMaxTasks2() {
+  public void testMaxTasksDatastreamOverride() {
     int numDatastreams = 25;
     int numInstances = 32;
     int maxTasks = 6;
     List<DatastreamGroup> datastreams = generateDatastreams("ds", numDatastreams);
     datastreams.get(0).getDatastreams().get(0).getMetadata().put(CFG_MAX_TASKS, "18");
-
     int expectedTotalTasks = numDatastreams * maxTasks + (18 - maxTasks);
     doTestMaxTasks(new BroadcastStrategy(maxTasks), numInstances, expectedTotalTasks, datastreams);
+
+    // test with broadcast strategy where max tasks is not capped by instances size
+    numInstances = 6;
+    maxTasks = 32;
+    expectedTotalTasks = numDatastreams * maxTasks - (maxTasks - 18);
+    doTestMaxTasks(new BroadcastStrategy(maxTasks, 1000), numInstances, expectedTotalTasks, datastreams);
+  }
+
+  @Test
+  public void testDsTaskLimitPerInstance() {
+    int numDatastreams = 10;
+    int numInstances = 3;
+    int maxTasks = 9;
+    int dsTaskLimitPerInstance = 2;
+    int expectedTotalTasks = numDatastreams * numInstances * dsTaskLimitPerInstance;
+    List<DatastreamGroup> datastreams = generateDatastreams("ds", numDatastreams);
+    doTestMaxTasks(new BroadcastStrategy(maxTasks, dsTaskLimitPerInstance), numInstances, expectedTotalTasks, datastreams);
   }
 
   private void doTestMaxTasks(BroadcastStrategy strategy, int numInstances, int expectedTotalTasks,
@@ -91,7 +121,7 @@ public class TestBroadcastStrategy {
   }
 
   @Test
-  public void testBroadcastStrategyDoesntCreateNewTasksWhenCalledSecondTime() {
+  public void testDontCreateNewTasksWhenCalledSecondTime() {
     String[] instances = new String[]{"instance1", "instance2", "instance3"};
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS);
@@ -106,10 +136,23 @@ public class TestBroadcastStrategy {
       LOG.info("Old assignment : " + oldAssignmentTasks);
       Assert.assertTrue(newAssignmentTasks.containsAll(oldAssignmentTasks));
     }
+
+    // test with broadcast strategy where max tasks is not capped by instances size
+    strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS, 100);
+    assignment = strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+    newAssignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
+    for (String instance : instances) {
+      Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
+      Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
+      Assert.assertEquals(oldAssignmentTasks.size(), newAssignmentTasks.size());
+      LOG.info("New assignment : " + newAssignmentTasks);
+      LOG.info("Old assignment : " + oldAssignmentTasks);
+      Assert.assertTrue(newAssignmentTasks.containsAll(oldAssignmentTasks));
+    }
   }
 
   @Test
-  public void testBroadcastStrategyRemovesDatastreamTasksWhenDatastreamIsDeleted() {
+  public void testRemoveDatastreamTasksWhenDatastreamIsDeleted() {
     List<String> instances = Arrays.asList("instance1", "instance2", "instance3");
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS);
@@ -125,10 +168,27 @@ public class TestBroadcastStrategy {
       Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
       Assert.assertEquals(oldAssignmentTasks.size() - 1, newAssignmentTasks.size());
     }
+
+    // test with broadcast strategy where max tasks is not capped by instances size
+    datastreams = generateDatastreams("ds", 5);
+    strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS, 100);
+    assignment = strategy.assign(datastreams, instances, new HashMap<>());
+
+    datastreams.remove(0);
+
+    newAssignment = strategy.assign(datastreams, instances, assignment);
+
+    // Ensure that the datastream tasks for the existing instances didn't change.
+    for (String instance : instances) {
+      Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
+      Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
+      Assert.assertEquals(oldAssignmentTasks.size() - (DEFAULT_MAX_TASKS / instances.size()),
+          newAssignmentTasks.size());
+    }
   }
 
   @Test
-  public void testBroadcastStrategyCreatesNewTasksOnlyForNewDatastreamWhenDatastreamIsCreated() {
+  public void testCreateNewTasksOnlyForNewDatastreamWhenDatastreamIsCreated() {
     List<String> instances = Arrays.asList("instance1", "instance2", "instance3");
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 5);
     BroadcastStrategy strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS);
@@ -148,10 +208,31 @@ public class TestBroadcastStrategy {
       Assert.assertTrue(oldAssignmentTasks.stream()
           .allMatch(x -> x.getTaskPrefix().equals(newDatastream.getTaskPrefix()) || newAssignmentTasks.contains(x)));
     }
+
+    // test with broadcast strategy where max tasks is not capped by instances size
+    datastreams = generateDatastreams("ds", 5);
+    strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS, 100);
+    assignment = strategy.assign(datastreams, instances, new HashMap<>());
+
+    newDatastreams = new ArrayList<>(datastreams);
+    DatastreamGroup newDatastream1 = generateDatastreams("newds", 1).get(0);
+    newDatastreams.add(newDatastream1);
+
+    newAssignment = strategy.assign(newDatastreams, instances, assignment);
+
+    // Ensure that the datastream tasks for the existing instances didn't change.
+    for (String instance : instances) {
+      Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
+      Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
+      Assert.assertEquals(oldAssignmentTasks.size() + (DEFAULT_MAX_TASKS / instances.size()),
+          newAssignmentTasks.size());
+      Assert.assertTrue(oldAssignmentTasks.stream()
+          .allMatch(x -> x.getTaskPrefix().equals(newDatastream1.getTaskPrefix()) || newAssignmentTasks.contains(x)));
+    }
   }
 
   @Test
-  public void testBroadcastStrategyCreatesNewTasksOnlyForNewInstanceWhenInstanceIsAdded() {
+  public void testCreateNewTasksOnlyForNewInstanceWhenInstanceIsAdded() {
     List<String> instances = Arrays.asList("instance1", "instance2", "instance3");
     String instance4 = "instance4";
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 5);
@@ -170,5 +251,30 @@ public class TestBroadcastStrategy {
     }
 
     Assert.assertEquals(newAssignment.get(instance4).size(), datastreams.size());
+  }
+
+  @Test
+  public void testRebalanceTasksWhenNewInstanceIsAdded() {
+    // test that a rebalance occurs (redistribution of tasks) when a new instance is added, and broadcast strategy
+    // where num tasks is not limited by instance size is being used
+    List<String> instances = Arrays.asList("instance1", "instance2", "instance3");
+    String instance4 = "instance4";
+    List<DatastreamGroup> datastreams = generateDatastreams("ds", 5);
+    BroadcastStrategy strategy = new BroadcastStrategy(DEFAULT_MAX_TASKS, 100);
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(datastreams, instances, new HashMap<>());
+    List<String> newInstances = new ArrayList<>(instances);
+    newInstances.add(instance4);
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, newInstances, assignment);
+
+    // Ensure that the datastream tasks for the existing instances didn't change.
+    int expectedNumTasksPerInstance = DEFAULT_MAX_TASKS * datastreams.size() / newInstances.size();
+    for (String instance : instances) {
+      Set<DatastreamTask> oldAssignmentTasks = assignment.get(instance);
+      Set<DatastreamTask> newAssignmentTasks = newAssignment.get(instance);
+      Assert.assertEquals(newAssignmentTasks.size(), expectedNumTasksPerInstance);
+      Assert.assertTrue(newAssignmentTasks.stream().allMatch(oldAssignmentTasks::contains));
+    }
+
+    Assert.assertEquals(newAssignment.get(instance4).size(), expectedNumTasksPerInstance);
   }
 }


### PR DESCRIPTION
It might be useful to allow an instance to process multiple tasks from the same Datastream, to allow for more parallel consumers for a Datastream.

For example, in Brooklin MirrorMaker, sometimes a pipeline (Datastream) encompasses a very large number of topics. In this case we would want to instantiate multiple tasks/consumers for each host in the cluster for such Datastream.