### PR TITLE
fix NPE from CommonConnectorMetrics  during shutdown

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
@@ -219,12 +219,18 @@ public class CommonConnectorMetrics {
 
     public void resetStuckPartitions() {
       long numStuckPartitions = _numStuckPartitions.getAndSet(0);
-      AGGREGATED_NUM_STUCK_PARTITIONS.get(_className).getAndAdd(-numStuckPartitions);
+      AtomicLong aggregatedMetric = AGGREGATED_NUM_STUCK_PARTITIONS.get(_className);
+      if (aggregatedMetric != null) {
+        aggregatedMetric.getAndAdd(-numStuckPartitions);
+      }
     }
 
     public void updateStuckPartitions(long val) {
       long delta = val - _numStuckPartitions.getAndSet(val);
-      AGGREGATED_NUM_STUCK_PARTITIONS.get(_className).getAndAdd(delta);
+      AtomicLong aggregatedMetric = AGGREGATED_NUM_STUCK_PARTITIONS.get(_className);
+      if (aggregatedMetric != null) {
+        aggregatedMetric.getAndAdd(delta);
+      }
     }
 
     // Must be static as MetricInfos are requested from static context


### PR DESCRIPTION
This could happen because the moment we call stop(), we unregister all metrics and remove class level aggregate metrics from the concurrent hash map. However, events process are still happening on another thread, resulting in this NPE.