### PR TITLE
Synchronize registering checkpoints to fix ConcurrentModificationExce…

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
@@ -131,7 +131,7 @@ public class FlushlessEventProducerHandler<T extends Comparable<T>> {
       return _inFlight.size();
     }
 
-    public void register(T checkpoint) {
+    public synchronized void register(T checkpoint) {
       _inFlight.add(checkpoint);
     }
 


### PR DESCRIPTION
…ption in flushless producer

Getting the following error while using flushless produce in Brooklin MM. The "_inFlight" set is the one being concurrently modified because the ack() method iterates over the collection while the register() method attempts to write to it. ack() is already synchronized, but register() needs to be synchronized as well.

It is noted in documentation of Collections.synchronizedCollection.synchronizedSet and Collections.synchronizedCollection that: "It is imperative that the user manually synchronize on the returned collection when traversing it via Iterator"

2018/05/07 21:48:35.411 ERROR [ProducerBatch] [kafka-producer-network-thread | DatastreamLiKafkaProducer] [brooklin-service] [] Error executing user-provided callback on message for topic-partition 'social-gesture-service_call-12'
java.util.ConcurrentModificationException: null
	at java.util.LinkedHashMap$LinkedHashIterator.nextNode(LinkedHashMap.java:711) ~[?:1.8.0_40]
	at java.util.LinkedHashMap$LinkedKeyIterator.next(LinkedHashMap.java:734) ~[?:1.8.0_40]
	at com.linkedin.datastream.server.FlushlessEventProducerHandler$CallbackStatus.ack(FlushlessEventProducerHandler.java:160) ~[datastream-server-api-7.0.3.jar:?]
	at com.linkedin.datastream.server.FlushlessEventProducerHandler.lambda$send$1(FlushlessEventProducerHandler.java:60) ~[datastream-server-api-7.0.3.jar:?]
	at com.linkedin.datastream.server.FlushlessEventProducerHandler$$Lambda$268/1837594824.onCompletion(Unknown Source) ~[?:?]
	at com.linkedin.datastream.server.EventProducer.onSendCallback(EventProducer.java:282) ~
...