### PR TITLE
Downgrade pegasus back to 11.0.17

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -8,7 +8,7 @@ ext {
     LIKafkaVersion = "0.0.4"
     jacksonVersion = "1.8.5"
     avroVersion = "1.4.0"
-    pegasusVersion = "21.0.0"
+    pegasusVersion = "11.0.17"
     zkclientVersion = "0.5"
     zookeeperVersion = "3.4.6"
     testngVersion = "6.4"


### PR DESCRIPTION
PCL failed for datastream: https://tools.corp.linkedin.com/apps/tools/crtui/#/testing/executions/7a6990ce-b9c0-450b-9ecd-3bec83d0b247/execution

Try without the pegasus version bump, since brooklin-server resolves to natural highest anyway