### PR TITLE
Datastreams that have connector-managed destination are always consid…

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -142,7 +142,7 @@ public class CachedDatastreamReader {
 
       if (ds == null) {
         LOG.info("Datastream {} does not exist in cache/ZK.", datastreamName);
-      } else if (!DatastreamUtils.isConnectorManagedDestination(ds) && !DatastreamUtils.hasValidDestination(ds)) {
+      } else if (!DatastreamUtils.hasValidDestination(ds)) {
         LOG.info("Datastream {} does not have a valid destination yet and is not ready for use.", datastreamName);
       } else {
         _datastreams.put(datastreamName, ds);

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/DatastreamUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/DatastreamUtils.java
@@ -115,12 +115,20 @@ public final class DatastreamUtils {
         && !stream.getSource().getConnectionString().isEmpty();
   }
 
+  /**
+   * A stream has a valid destination if:
+   * a) the metadata denotes that the stream has a connector-managed destination (so destination info is not required)
+   * b) the stream contains non-empty destination connection string and partition count greater than zero
+   * @param stream the datastream to validate destination for
+   * @return true if the condition above applies; false otherwise
+   */
   public static boolean hasValidDestination(Datastream stream) {
-    return stream.hasDestination()
+    return isConnectorManagedDestination(stream)
+        || (stream.hasDestination()
         && stream.getDestination().hasConnectionString()
         && !stream.getDestination().getConnectionString().isEmpty()
         && stream.getDestination().hasPartitions()
-        && stream.getDestination().getPartitions() > 0;
+        && stream.getDestination().getPartitions() > 0);
   }
 
   public static boolean hasValidOwner(Datastream stream) {


### PR DESCRIPTION
…ered to have valid destination

In previous PR, I modified CachedDatastreamReader to skip destination validation for datastreams with connector-managed destinations (i.e. MirrorMaker); however, I found that this wasn't the only place that destination validation was happening. So instead I added the extra logic inside DatastreamUtils.hasValidDestination() instead, so that the check will be skipped everywhere.