### PR TITLE
Attempt to fix BMM over-produce problem

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -41,7 +41,7 @@ import com.linkedin.datastream.server.providers.CheckpointProvider;
  */
 public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAware {
 
-  private static final Duration CANCEL_TASK_TIMEOUT = Duration.ofSeconds(5);
+  private static final Duration CANCEL_TASK_TIMEOUT = Duration.ofSeconds(30);
   protected final String _connectorName;
   private final Logger _logger;
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -78,6 +78,7 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_SLA_MS = "60000"; // 1 minute
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS = "180000"; // 3 minutes
   private static final long LATENCY_SLIDING_WINDOW_LENGTH_MS = Duration.ofMinutes(5).toMillis();
+  private static final Duration LONG_FLUSH_WARN_THRESHOLD = Duration.ofMinutes(5);
 
   private final int _availabilityThresholdSlaMs;
   // Alternate SLA for comparision with the main
@@ -313,6 +314,10 @@ public class EventProducer implements DatastreamEventProducer {
     _dynamicMetricsManager.createOrUpdateHistogram(MODULE, AGGREGATE, FLUSH_LATENCY_MS_STRING, flushLatencyMs);
     _dynamicMetricsManager.createOrUpdateHistogram(MODULE, _datastreamTask.getConnectorType(), FLUSH_LATENCY_MS_STRING,
         flushLatencyMs);
+
+    if (flushLatencyMs > LONG_FLUSH_WARN_THRESHOLD.toMillis()) {
+      _logger.warn("Flush took longer than {} minutes", LONG_FLUSH_WARN_THRESHOLD.toMinutes());
+    }
   }
 
   /**


### PR DESCRIPTION
TODO: description still in progress

2018/06/12 05:04:04.903 ERROR [KafkaMirrorMakerConnectorTask] [KafkaMirrorMaker task thread test-datastream_b21e2f90-3b83-4876-9128-a14fc0d66dd8 1] [brooklin-service] [] test-datastream_b21e2f90-3b83-4876-9128-a14fc0d66dd8 failed with exception.
org.apache.kafka.common.errors.InterruptException: Flush interrupted.
        at org.apache.kafka.clients.producer.KafkaProducer.flush(KafkaProducer.java:960) ~[kafka-clients-0.11.0.94.jar:?]
        at com.linkedin.datastream.kafka.client.KafkaProducerWrapper.flush(KafkaProducerWrapper.java:276) ~[brooklin-kafka-18.0.7.jar:?]
        at com.linkedin.datastream.kafka.LiKafkaTransportProvider.lambda$flush$8(LiKafkaTransportProvider.java:328) ~[brooklin-kafka-18.0.7.jar:?]
        at com.linkedin.datastream.kafka.LiKafkaTransportProvider$$Lambda$280/1293917676.accept(Unknown Source) ~[?:?]
        at java.util.ArrayList.forEach(ArrayList.java:1249) ~[?:1.8.0_40]
        at com.linkedin.datastream.kafka.LiKafkaTransportProvider.flush(LiKafkaTransportProvider.java:328) ~[brooklin-kafka-18.0.7.jar:?]
        at com.linkedin.datastream.server.EventProducer.flush(EventProducer.java:307) ~[datastream-server-9.0.8.jar:?]
        at com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask.maybeCommitOffsets(AbstractKafkaBasedConnectorTask.java:445) ~[datastream-kafka-connector-9.0.8.jar:?]
        at com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask.processRecords(AbstractKafkaBasedConnectorTask.java:391) ~[datastream-kafka-connector-9.0.8.jar:?]
        at com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask.run(AbstractKafkaBasedConnectorTask.java:279) ~[datastream-kafka-connector-9.0.8.jar:?]
        at java.lang.Thread.run(Thread.java:745) [?:1.8.0_40]
Caused by: java.lang.InterruptedException
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:998) ~[?:1.8.0_40]
        at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1304) ~[?:1.8.0_40]
        at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:231) ~[?:1.8.0_40]
        at org.apache.kafka.clients.producer.internals.ProduceRequestResult.await(ProduceRequestResult.java:76) ~[kafka-clients-0.11.0.94.jar:?]
        at org.apache.kafka.clients.producer.internals.RecordAccumulator.awaitFlushCompletion(RecordAccumulator.java:586) ~[kafka-clients-0.11.0.94.jar:?]
        at org.apache.kafka.clients.producer.KafkaProducer.flush(KafkaProducer.java:958) ~[kafka-clients-0.11.0.94.jar:?]
        ... 10 more
2018/06/12 05:04:04.904 INFO [KafkaProducer] [kafka-producer-network-thread | DatastreamLiKafkaProducer] [brooklin-service] [] [Producer clientId=DatastreamLiKafkaProducer, transactionalId=nullClosing the Kafka producer with timeoutMillis = 2000 ms.
2018/06/12 05:04:04.904 WARN [KafkaProducer] [kafka-producer-network-thread | DatastreamLiKafkaProducer] [brooklin-service] [] [Producer clientId=DatastreamLiKafkaProducer, transactionalId=nullOverriding close timeout 2000 ms to 0 ms in order to prevent useless blocking due to self-join. This means you have incorrectly invoked close with a non-zero timeout from the producer call-back.
2018/06/12 05:04:04.904 INFO [KafkaProducer] [kafka-producer-network-thread | DatastreamLiKafkaProducer] [brooklin-service] [] [Producer clientId=DatastreamLiKafkaProducer, transactionalId=nullProceeding to force close the producer since pending requests could not be completed within timeout 2000 ms.
2018/06/12 05:04:04.905 ERROR [LiKafkaTransportProvider:test-datastream_b21e2f90-3b83-4876-9128-a14fc0d66dd8] [kafka-producer-network-thread | DatastreamLiKafkaProducer] [brooklin-service] [] Sending a message with source checkpoint voyager-api-search-lix_service_call/12/22591463 to topic voyager-api-search-lix_service_call partition Optional.empty for datastream task test-datastream_b21e2f90-3b83-4876-9128-a14fc0d66dd8(KafkaMirrorMaker), partitions=[0] threw an exception.
org.apache.kafka.common.errors.NotLeaderForPartitionException: This server is not the leader for that topic-partition.
