### PR TITLE
Give Kafka connector task thread time to shutdown on its own

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -79,7 +79,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected final Datastream _datastream;
 
   // lifecycle
-  protected volatile boolean _shouldDie = false;
+  protected volatile boolean _shutdown = false;
   protected volatile long _lastPolledTimeMs = System.currentTimeMillis();
   protected final CountDownLatch _startedLatch = new CountDownLatch(1);
   protected final CountDownLatch _stoppedLatch = new CountDownLatch(1);
@@ -94,9 +94,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected final Duration _pauseErrorPartitionDuration;
   protected final long _processingDelayLogThresholdMs;
   protected final Optional<Map<Integer, Long>> _startOffsets;
-
-  // state
-  protected volatile Thread _thread;
 
   protected volatile String _taskName;
   protected final DatastreamEventProducer _producer;
@@ -228,10 +225,10 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   protected void sendMessage(ConsumerRecord<?, ?> record, Instant readTime) throws Exception {
     int sendAttempts = 0;
+    DatastreamProducerRecord datastreamProducerRecord = translate(record, readTime);
     while (true) {
-      sendAttempts++;
-      DatastreamProducerRecord datastreamProducerRecord = translate(record, readTime);
       try {
+        sendAttempts++;
         sendDatastreamProducerRecord(datastreamProducerRecord);
         int numBytes = record.serializedKeySize() + record.serializedValueSize();
         _consumerMetrics.updateBytesProcessedRate(numBytes);
@@ -239,7 +236,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       } catch (Exception e) {
         _logger.error("Error sending Message. task: {} ; error: {};", _taskName, e.toString());
         _logger.error("Stack Trace: {}", Arrays.toString(e.getStackTrace()));
-        if (_shouldDie || sendAttempts >= _maxRetryCount) {
+        if (_shutdown || sendAttempts >= _maxRetryCount) {
           _logger.error("Send messages failed with exception: {}", e);
           throw e;
         }
@@ -259,7 +256,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _logger.info("Starting the Kafka-based connector task for {}", _datastreamTask);
     boolean startingUp = true;
     long pollInterval = 0; // so 1st call to poll is fast for purposes of startup
-    _thread = Thread.currentThread();
 
     _eventsProcessedCountLoggedTime = Instant.now();
 
@@ -268,7 +264,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       consumerSubscribe();
 
       ConsumerRecords<?, ?> records;
-      while (!_shouldDie) {
+      while (!_shutdown) {
         // perform any pre-computations before poll()
         preConsumerPollHook();
 
@@ -290,9 +286,13 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       } // end while loop
 
       // shutdown
+      _logger.info("Flushing and committing offsets before task {} exits.", _taskName);
       maybeCommitOffsets(_consumer, true);
     } catch (WakeupException e) {
-      if (!_shouldDie) {
+      if (_shutdown) {
+        _logger.info("Got WakeupException, shutting down task {}.", _taskName);
+        maybeCommitOffsets(_consumer, true);
+      } else {
         _logger.error("Got WakeupException while not in shutdown mode.", e);
         throw e;
       }
@@ -309,12 +309,11 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   public void stop() {
     _logger.info("{} stopping", _taskName);
-    _shouldDie = true;
+    _shutdown = true;
     if (_consumer != null) {
       _consumer.wakeup();
     }
     _consumerMetrics.deregisterMetrics();
-    _thread.interrupt();
   }
 
   public boolean awaitStart(long timeout, TimeUnit unit) throws InterruptedException {
@@ -387,14 +386,14 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected void processRecords(ConsumerRecords<?, ?> records, Instant readTime) {
     // send the batch out the other end
     // TODO(misanchez): we should have a way to signal the producer to stop and throw an exception
-    //                  in case the _shouldDie signal is set (similar to kafka wakeup)
+    //                  in case the _shutdown signal is set (similar to kafka wakeup)
     translateAndSendBatch(records, readTime);
 
     if (System.currentTimeMillis() - readTime.toEpochMilli() > _processingDelayLogThresholdMs) {
       _consumerMetrics.updateProcessingAboveThreshold(1);
     }
 
-    if (!_shouldDie) {
+    if (!_shutdown) {
       // potentially commit our offsets (if its been long enough and all sends were successful)
       maybeCommitOffsets(_consumer, false);
     }
@@ -414,7 +413,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
    */
   protected void handleNoOffsetForPartitionException(NoOffsetForPartitionException e) {
     _logger.info("Poll threw NoOffsetForPartitionException for partitions {}.", e.partitions());
-    if (!_shouldDie) {
+    if (!_shutdown) {
       seekToStartPosition(_consumer, e.partitions());
     }
   }
@@ -427,7 +426,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected void handlePollRecordsException(Exception e) throws InterruptedException {
     _logger.warn("Poll threw an exception. Sleeping for {} seconds and retrying. Exception: {}",
         _retrySleepDuration.getSeconds(), e);
-    if (!_shouldDie) {
+    if (!_shutdown) {
       Thread.sleep(_retrySleepDuration.toMillis());
     }
   }
@@ -455,6 +454,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         }
       }
       _lastCommittedTime = System.currentTimeMillis();
+      _logger.info("Successfully committed offsets");
     }
   }
 
@@ -546,7 +546,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   @Override
   public void onPartitionsRevoked(Collection<TopicPartition> topicPartitions) {
     _logger.info("Partition ownership revoked for {}, checkpointing.", topicPartitions);
-    if (!_shouldDie && !topicPartitions.isEmpty()) { // there is a commit at the end of the run method, skip extra commit in shouldDie mode.
+    if (!_shutdown && !topicPartitions.isEmpty()) { // there is a commit at the end of the run method, skip extra commit in shouldDie mode.
       try {
         maybeCommitOffsets(_consumer, true); // happens inline as part of poll
       } catch (Exception e) {

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/MockDatastreamEventProducer.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/MockDatastreamEventProducer.java
@@ -26,22 +26,25 @@ public class MockDatastreamEventProducer implements DatastreamEventProducer {
   private ExecutorService _executorService = Executors.newFixedThreadPool(1);
   private Duration _callbackThrottleDuration;
   private Predicate<DatastreamProducerRecord> _sendFailCondition;
+  private Duration _flushDuration;
 
   public MockDatastreamEventProducer() {
-    this(null, null);
+    this(null, null, null);
   }
 
   public MockDatastreamEventProducer(Predicate<DatastreamProducerRecord> sendFailCondition) {
-    this(null, sendFailCondition);
+    this(null, sendFailCondition, null);
   }
 
   public MockDatastreamEventProducer(Duration callbackThrottleDuration) {
-    this(callbackThrottleDuration, null);
+    this(callbackThrottleDuration, null, null);
   }
 
-  public MockDatastreamEventProducer(Duration callbackThrottleDuration, Predicate<DatastreamProducerRecord> sendFailCondition) {
+  public MockDatastreamEventProducer(Duration callbackThrottleDuration,
+      Predicate<DatastreamProducerRecord> sendFailCondition, Duration flushDuration) {
     _callbackThrottleDuration = callbackThrottleDuration;
     _sendFailCondition = sendFailCondition;
+    _flushDuration = flushDuration;
   }
 
   @Override
@@ -79,6 +82,14 @@ public class MockDatastreamEventProducer implements DatastreamEventProducer {
 
   @Override
   public void flush() {
+    if (_flushDuration != null && !_flushDuration.isZero()) {
+      try {
+        Thread.sleep(_flushDuration.toMillis());
+      } catch (InterruptedException e) {
+        LOG.info("Flush interrupted");
+        return;
+      }
+    }
     _numFlushes++;
   }
 


### PR DESCRIPTION
During graceful shutdown of connector, the task should be given enough time to stop what it's doing, flush the producer, and commit the offsets. 

This fix removes the thread.interrupt() so that at the end of the run loop, the task can be given time to  flush and commit offsets. Currently, the following exception is being thrown because the thread is being interrupted during the last flush() that it attempts before exiting. Therefore, the offsets are also never committed. This leads to dupes during graceful bounce of BMM.

2018/06/12 03:15:38.969 INFO [KafkaMirrorMakerConnectorTask] [KafkaMirrorMaker task thread test-datastream_9935da46-f26a-4b26-86f3-0b662043d79f 1] [brooklin-service] [] Trying to flush the producer and commit offsets.
2018/06/12 03:15:38.976 INFO [ConnectorWrapper:KafkaMirrorMaker] [pool-8-thread-1] [brooklin-service] [] END: Connector::onAssignmentChange. Connector: KafkaMirrorMaker, Instance: lor1-app10051.prod.linkedin.com-0000001260, Duration: 7 milliseconds
2018/06/12 03:15:38.976 ERROR [KafkaMirrorMakerConnectorTask] [KafkaMirrorMaker task thread test-datastream_9935da46-f26a-4b26-86f3-0b662043d79f 1] [brooklin-service] [] test-datastream_9935da46-f26a-4b26-86f3-0b662043d79f failed with exception.
org.apache.kafka.common.errors.InterruptException: Flush interrupted.
        at org.apache.kafka.clients.producer.KafkaProducer.flush(KafkaProducer.java:960) ~[kafka-clients-0.11.0.94.jar:?]
        at com.linkedin.datastream.kafka.client.KafkaProducerWrapper.flush(KafkaProducerWrapper.java:276) ~[brooklin-kafka-18.0.7.jar:?]
        at com.linkedin.datastream.kafka.LiKafkaTransportProvider.lambda$flush$8(LiKafkaTransportProvider.java:328) ~[brooklin-kafka-18.0.7.jar:?]
        at com.linkedin.datastream.kafka.LiKafkaTransportProvider$$Lambda$275/1435025661.accept(Unknown Source) ~[?:?]
        at java.util.ArrayList.forEach(ArrayList.java:1249) ~[?:1.8.0_40]
        at com.linkedin.datastream.kafka.LiKafkaTransportProvider.flush(LiKafkaTransportProvider.java:328) ~[brooklin-kafka-18.0.7.jar:?]
        at com.linkedin.datastream.server.EventProducer.flush(EventProducer.java:307) ~[datastream-server-9.0.8.jar:?]
        at com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask.maybeCommitOffsets(AbstractKafkaBasedConnectorTask.java:445) ~[datastream-kafka-connector-9.0.8.jar:?]
        at com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask.run(AbstractKafkaBasedConnectorTask.java:285) ~[datastream-kafka-connector-9.0.8.jar:?]
