### PR TITLE
Upgrade pegasus version

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -8,7 +8,7 @@ ext {
     LIKafkaVersion = "0.0.4"
     jacksonVersion = "1.8.5"
     avroVersion = "1.4.0"
-    pegasusVersion = "11.0.17"
+    pegasusVersion = "20.0.4"
     zkclientVersion = "0.5"
     zookeeperVersion = "3.4.6"
     testngVersion = "6.4"


### PR DESCRIPTION
The current pegasus version (11.x) is ancient and causes class conflicts
to downstream modules. Upgrading it to 20.x.