### PR TITLE
LISAMZA-8321: Fix Sql to Avro type conversion bug

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/databases/OracleTypeInterpreter.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/databases/OracleTypeInterpreter.java
@@ -3,7 +3,6 @@ package com.linkedin.datastream.common.databases;
 import java.io.IOException;
 import java.io.Reader;
 import java.io.StringWriter;
-import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Array;
 import java.sql.Blob;
@@ -93,29 +92,29 @@ public class OracleTypeInterpreter implements SqlTypeInterpreter {
       return sqlObject.toString();
     }
 
-    if (sqlObject instanceof BigDecimal) {
-      BigDecimal bd = ((BigDecimal) sqlObject);
+    if (sqlObject instanceof Number) {
+      Number number = ((Number) sqlObject);
 
       Schema primitiveSchema = getChildSchema(avroSchema, colName, ACCEPTABLE_PRIMITIVES);
 
       if (primitiveSchema.getType().equals(Schema.Type.STRING)) {
-        return bd.toString();
+        return number.toString();
       }
 
       if (primitiveSchema.getType().equals(Schema.Type.FLOAT)) {
-        return bd.floatValue();
+        return number.floatValue();
       }
 
       if (primitiveSchema.getType().equals(Schema.Type.INT)) {
-        return bd.intValue();
+        return number.intValue();
       }
 
       if (primitiveSchema.getType().equals(Schema.Type.LONG)) {
-        return bd.longValue();
+        return number.longValue();
       }
 
       if (primitiveSchema.getType().equals(Schema.Type.DOUBLE)) {
-        return bd.doubleValue();
+        return number.doubleValue();
       }
     }
 


### PR DESCRIPTION
Use the parent class type Number instead of BigDecimal to cast number types
to cover the primitive types whose types remain unchanged in sql result.