### PR TITLE
Skip expensive validations for flushless producer shutdown

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -172,8 +172,8 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
       kafkaTask.stop();
       boolean stopped = kafkaTask.awaitStop(CANCEL_TASK_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS);
       if (!stopped) {
-        _logger.warn("Task {} took longer than {} minutes to stop. Interrupting the thread.", datastreamTask,
-            CANCEL_TASK_TIMEOUT.toMinutes());
+        _logger.warn("Task {} took longer than {} ms to stop. Interrupting the thread.", datastreamTask,
+            CANCEL_TASK_TIMEOUT.toMillis());
         _taskThreads.get(datastreamTask).interrupt();
       }
       _runningTasks.remove(datastreamTask);


### PR DESCRIPTION
During maybeCommitOffsets() call which is made right before the task shuts down, in flushless mode we do the following:

1. call producer.flush()
2. commit all offsets
3. verify that the flushless producer's acked checkpoints match up with source-of-truth consumer.committed() for all partitions
4. verify that the flushless producer's in-flight message count is 0 for all partitions

Step 3 is problematic because call to consumer.committed() is expensive and causing shutdown to take a long time. The connector detects that the task is taking > 30s to shut down and is interrupting the thread, which is undesirable. 

Step 4 is faulty because the in-flight message count need not be 0 if a partition was auto-paused due to errors and thus can still have in-flight messages when task is shutdown.

This PR is removing Steps 3 & 4 above.

===============================

2018/07/13 17:09:58.877 WARN [KafkaMirrorMakerConnector] [Thread-1] [brooklin-service] [] Task other-mm_cc87530d-348f-4aff-bc8c-864f472f292c(KafkaMirrorMaker), partitions=[0] took longer than 30 seconds to stop. Interrupting the thread.

2018/07/13 17:09:58.885 ERROR [KafkaMirrorMakerConnectorTask] [KafkaMirrorMaker task thread other-mm_cc87530d-348f-4aff-bc8c-864f472f292c 11] [brooklin-service] [] other-mm_cc87530d-348f-4aff-bc8c-864f472f292c failed with exception.
org.apache.kafka.common.errors.InterruptException: java.lang.InterruptedException
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.maybeThrowInterruptException(ConsumerNetworkClient.java:440) ~[kafka-clients-0.11.0.94.jar:?]
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.poll(ConsumerNetworkClient.java:250) ~[kafka-clients-0.11.0.94.jar:?]
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.poll(ConsumerNetworkClient.java:210) ~[kafka-clients-0.11.0.94.jar:?]
	at org.apache.kafka.clients.consumer.internals.ConsumerNetworkClient.poll(ConsumerNetworkClient.java:170) ~[kafka-clients-0.11.0.94.jar:?]
	at org.apache.kafka.clients.consumer.internals.ConsumerCoordinator.fetchCommittedOffsets(ConsumerCoordinator.java:482) ~[kafka-clients-0.11.0.94.jar:?]
	at org.apache.kafka.clients.consumer.KafkaConsumer.committed(KafkaConsumer.java:1389) ~[kafka-clients-0.11.0.94.jar:?]
	at com.linkedin.datastream.connectors.kafka.mirrormaker.KafkaMirrorMakerConnectorTask.lambda$maybeCommitOffsets$1(KafkaMirrorMakerConnectorTask.java:191) ~[datastream-kafka-connector-9.0.10.jar:?]
	at com.linkedin.datastream.connectors.kafka.mirrormaker.KafkaMirrorMakerConnectorTask$$Lambda$257/1156449851.accept(Unknown Source) ~[?:?]
	at java.util.Optional.ifPresent(Optional.java:159) ~[?:1.8.0_40]
	at com.linkedin.datastream.connectors.kafka.mirrormaker.KafkaMirrorMakerConnectorTask.maybeCommitOffsets(KafkaMirrorMakerConnectorTask.java:189) ~[datastream-kafka-connector-9.0.10.jar:?]
	at com.linkedin.datastream.connectors.kafka.AbstractKafkaBasedConnectorTask.run(AbstractKafkaBasedConnectorTask.java:290) ~[datastream-kafka-connector-9.0.10.jar:?]
	at java.lang.Thread.run(Thread.java:745) [?:1.8.0_40]
Caused by: java.lang.InterruptedException
	... 12 more