### PR TITLE
LISAMZA-8516: Use sync version of getAllDatastreams in initDatastream

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1111,6 +1111,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     ConnectorWrapper connector = connectorInfo.getConnector();
     DatastreamDeduper deduper = connectorInfo.getDatastreamDeduper();
 
+    // LISAMZA-8516: Changing a non-flusdh cache version to flush version to avoid erorrs in deduping datastreams
+    // which should be deduped, but fail to due to being created back to back and ZK client not syncing with master
     List<Datastream> allDatastreams = _datastreamCache.getAllDatastreams(true)
         .stream()
         .filter(d -> d.getConnectorName().equals(connectorName))


### PR DESCRIPTION
The Coordinator's initializeDatastream call fetches all datastreams in store using the Cached store whose
client does not request syncing with leader before fetch. It gets updates using a watch and if there are
frequent updates there is chance for it to be out of sync from the zk master. This more frequently results
in test flakiness where the chances of creating multiple datastreams in a short period of time is higher than
a production scenario. Though the issue can be fixed in tests, by adding a poll, using the sync version of
getAllDatastreams might be better to avoid the tiny possibility of not deduping streams which can be exacerbated
in a tools usage scenario where possibly multiple datastreams could be created in a short duration.
Since initializeDatastream is not a heavily used path, it should not cause noticeable performance degradation.
The create Datastream path might experience a degradation, but timeout logic should help with any extra delays.