### PR TITLE
Add nullable to column meta in Avro schema

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/DatabaseSource.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/DatabaseSource.java
@@ -175,13 +175,19 @@ public abstract class DatabaseSource {
   }
 
   public static class TableMetadata {
+
+    public static final String NULLABLE = "Y";
+    public static final String NOT_NULLABLE = "N";
+
     private String _columnSchemaName;
     private String _columnFieldTypeName;
     private String _colName;
     private int _precision;
     private int _scale;
+    private String _nullable;
 
-    public TableMetadata(@NotNull String colTypeName, @NotNull String colName, int precision, int scale) {
+    public TableMetadata(@NotNull String colTypeName, @NotNull String colName, @NotNull String nullable, int precision,
+        int scale) {
       String[] columnTypeParts = colTypeName.split("\\.");
 
       if (columnTypeParts.length == 1) {
@@ -192,6 +198,7 @@ public abstract class DatabaseSource {
         _columnFieldTypeName = columnTypeParts[1];
       }
 
+      _nullable = nullable;
       _precision = precision;
       _scale = scale;
       _colName = colName;
@@ -207,6 +214,10 @@ public abstract class DatabaseSource {
 
     public String getColName() {
       return _colName;
+    }
+
+    public String getNullable() {
+      return _nullable;
     }
 
     public int getPrecision() {

--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/FieldMetadata.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/FieldMetadata.java
@@ -18,15 +18,17 @@ public class FieldMetadata {
   private static final String META_VALUE_DELIMITER = "=";
 
   private final String _dbFieldName;
+  private final String _nullable;
   private int _dbFieldPosition;
   private Types _dbFieldType;
 
   private final Optional<Integer> _numberPrecision;
   private final Optional<Integer> _numberScale;
 
-  public FieldMetadata(@NotNull String dbFieldName, int dbFieldPosition, @NotNull Types dbFieldType,
+  public FieldMetadata(@NotNull String dbFieldName, String nullable, int dbFieldPosition, @NotNull Types dbFieldType,
       Optional<Integer> numberPrecision, Optional<Integer> numberScale) {
     _dbFieldName = dbFieldName;
+    _nullable = nullable;
     _dbFieldPosition = dbFieldPosition;
     _dbFieldType = dbFieldType;
     _numberPrecision = numberPrecision;
@@ -75,17 +77,22 @@ public class FieldMetadata {
         String.format("Missing metadata %s from meta string %s", OracleColumn.COL_POSITION, meta)));
     Types fieldType = Types.fromString(Preconditions.checkNotNull(metas.get(FieldType.FIELD_TYPE_NAME),
         String.format("Missing metadata %s from meta string %s", FieldType.FIELD_TYPE_NAME, meta)));
+    String nullable = Optional.ofNullable(metas.get(FieldType.NULLABLE)).orElse("");
 
     Optional<Integer> numberPrecision =
         Optional.ofNullable(metas.get(FieldType.PRECISION)).map(s -> Integer.valueOf(s));
     Optional<Integer> numberScale =
         Optional.ofNullable(metas.get(FieldType.SCALE)).map(s -> Integer.valueOf(s));
 
-    return new FieldMetadata(fieldName, fieldPosition, fieldType, numberPrecision, numberScale);
+    return new FieldMetadata(fieldName, nullable, fieldPosition, fieldType, numberPrecision, numberScale);
   }
 
   public String getDbFieldName() {
     return _dbFieldName;
+  }
+
+  public String getNullable() {
+    return _nullable;
   }
 
   public int getDbFieldPosition() {

--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/FieldType.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/FieldType.java
@@ -30,6 +30,8 @@ public interface FieldType {
   /* The key for the field type name stored in metadata */
   static final String FIELD_TYPE_NAME = "dbFieldType";
 
+  static final String NULLABLE = "nullable";
+
   /* The key for the precision of Number fields */
   static final String PRECISION = "numberPrecision";
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OracleDatabaseClient.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OracleDatabaseClient.java
@@ -216,8 +216,16 @@ public class OracleDatabaseClient extends DatabaseSource {
       int colCount = rsmd.getColumnCount();
 
       for (int i = 1; i <= colCount; i++) {
+        String nullable = "";
+        int nullableMetadata = rsmd.isNullable(i);
+        if (nullableMetadata == ResultSetMetaData.columnNullable) {
+          nullable = "Y";
+        } else if (nullableMetadata == ResultSetMetaData.columnNoNulls) {
+          nullable = "N";
+        }
         tableMetadataList.add(new TableMetadata(rsmd.getColumnTypeName(i),
             rsmd.getColumnName(i),
+            nullable,
             rsmd.getPrecision(i),
             rsmd.getScale(i)));
       }

--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OraclePrimitiveType.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OraclePrimitiveType.java
@@ -11,6 +11,7 @@ public class OraclePrimitiveType implements FieldType {
   private Types _type;
   private final int _scale;
   private final int _precision;
+  private final String _nullable;
 
   private final static HashSet<String> NUMBER_CLASSIFICATION = new HashSet<>();
   static {
@@ -21,9 +22,10 @@ public class OraclePrimitiveType implements FieldType {
     NUMBER_CLASSIFICATION.add(Types.NUMBER.toString());
   }
 
-  public OraclePrimitiveType(String fieldTypeName, int scale, int precision) {
+  public OraclePrimitiveType(String fieldTypeName, String nullable, int scale, int precision) {
     _scale = scale;
     _precision = precision;
+    _nullable = nullable;
 
     if (fieldTypeName.equals(Types.NUMBER.toString())) {
       _type = getNumberClassification(scale, precision);
@@ -85,6 +87,7 @@ public class OraclePrimitiveType implements FieldType {
   public String getMetadata() {
     StringBuilder meta = new StringBuilder();
     meta.append(String.format("%s=%s;", FIELD_TYPE_NAME, getFieldTypeName()));
+    meta.append(String.format("%s=%s;", NULLABLE, _nullable));
 
     if (NUMBER_CLASSIFICATION.contains(getFieldTypeName())) {
       meta.append(String.format("%s=%s;", SCALE, getScale()));

--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OracleTableFactory.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/OracleTableFactory.java
@@ -48,8 +48,8 @@ public class OracleTableFactory {
       String colName = metadata.getColName();
 
       FieldType childFieldType =
-          buildFieldType(metadata.getColumnSchemaName(), metadata.getColumnFieldTypeName(), metadata.getPrecision(),
-              metadata.getScale());
+          buildFieldType(metadata.getColumnSchemaName(), metadata.getColumnFieldTypeName(), metadata.getNullable(),
+              metadata.getPrecision(), metadata.getScale());
 
       childColumns.add(new OracleColumn(colName, childFieldType, childColumns.size()));
     }
@@ -79,11 +79,11 @@ public class OracleTableFactory {
    * @param precision precision of Numeric Types
    * @param scale scale of Numeric Types
    */
-  private FieldType buildFieldType(String schemaName, String fieldTypeName, int precision, int scale)
+  private FieldType buildFieldType(String schemaName, String fieldTypeName, String nullable, int precision, int scale)
       throws SQLException {
 
     if (_databaseSource.isPrimitive(fieldTypeName)) {
-      return buildOraclePrimitive(fieldTypeName, precision, scale);
+      return buildOraclePrimitive(fieldTypeName, nullable, precision, scale);
     }
 
     if (_databaseSource.isCollection(schemaName, fieldTypeName)) {
@@ -102,11 +102,12 @@ public class OracleTableFactory {
    * Build an OraclePrimitiveType FieldType. These include types such as (VARCHAR2, CHAR, etc)
    *
    * @param fieldTypeName name of the FieldType, (CHAR, VARCHAR)
+   * @param nullable the nullable of the FieldType (Y, N)
    * @param precision the precision of the NUMERIC (to help determine LONG vs INT)
    * @param scale the scale of the numeric (to help determine DOUBLE vs FLOAT)
    */
-  private FieldType buildOraclePrimitive(String fieldTypeName, int precision, int scale) {
-    return new OraclePrimitiveType(fieldTypeName, scale, precision);
+  private FieldType buildOraclePrimitive(String fieldTypeName, String nullable, int precision, int scale) {
+    return new OraclePrimitiveType(fieldTypeName, nullable, scale, precision);
   }
 
   /**
@@ -124,6 +125,7 @@ public class OracleTableFactory {
 
     FieldType elementFieldType = buildFieldType(metadata.getElementSchemaName(),
         metadata.getElementFieldTypeName(),
+        null,
         metadata.getElementPrecision(),
         metadata.getElementScale());
 
@@ -149,6 +151,7 @@ public class OracleTableFactory {
     for (OracleDatabaseClient.StructMetadata metadata : metadataList) {
       FieldType childFieldType = buildFieldType(metadata.getSchemaName(),
           metadata.getFieldTypeName(),
+          null,
           metadata.getPrecision(),
           metadata.getScale());
 

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
@@ -1,6 +1,7 @@
 package com.linkedin.datastream.avrogenerator;
 
 import java.util.Map;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -10,65 +11,64 @@ public class TestOraclePrimitive {
 
   @Test
   public void testConstructor() {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "string");
     Assert.assertEquals(primitive.getFieldTypeName(), "VARCHAR2");
     Assert.assertEquals(primitive.getSchemaName(), null);
 
-    primitive = new OraclePrimitiveType("CLOB", 0, 0);
+    primitive = new OraclePrimitiveType("CLOB", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "string");
 
-    primitive = new OraclePrimitiveType("DATE", 0, 0);
+    primitive = new OraclePrimitiveType("DATE", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "long");
 
-    primitive = new OraclePrimitiveType("BLOB", 0, 0);
+    primitive = new OraclePrimitiveType("BLOB", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "bytes");
 
-    primitive = new OraclePrimitiveType("NUMBER", 1, 0);
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 1, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "float");
 
-    primitive = new OraclePrimitiveType("NUMBER", 7, 0);
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 7, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "double");
 
-    primitive = new OraclePrimitiveType("NUMBER", 0, 10);
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 0, 10);
     Assert.assertEquals(primitive.getAvroFieldName(), "long");
 
-    primitive = new OraclePrimitiveType("NUMBER", 0, 1);
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 0, 1);
     Assert.assertEquals(primitive.getAvroFieldName(), "int");
 
-    primitive = new OraclePrimitiveType("NUMBER", -127, 0);
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, -127, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "string");
 
-    primitive = new OraclePrimitiveType("NUMBER", 0, 0);
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     Assert.assertEquals(primitive.getAvroFieldName(), "string");
   }
 
   @Test(expectedExceptions = RuntimeException.class)
   public void testInvalidScale() {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("NUMBER", 18, 0);
+    OraclePrimitiveType primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 18, 0);
   }
 
   @Test
   public void testGetMetadata() {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
-    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=VARCHAR2;");
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=VARCHAR2;nullable=Y;");
 
-    primitive = new OraclePrimitiveType("NUMBER", 10, 10);
-    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=DOUBLE;numberScale=10;numberPrecision=10;");
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 10, 10);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=DOUBLE;nullable=Y;numberScale=10;numberPrecision=10;");
 
-    primitive = new OraclePrimitiveType("NUMBER", -127, 0);
-    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;numberScale=-127;numberPrecision=0;");
+    primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NOT_NULLABLE, -127, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=N;numberScale=-127;numberPrecision=0;");
 
-    primitive = new OraclePrimitiveType("TIMESTAMP", -127, 0);
-    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=TIMESTAMP;");
+    primitive = new OraclePrimitiveType("TIMESTAMP", DatabaseSource.TableMetadata.NULLABLE, -127, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=TIMESTAMP;nullable=Y;");
   }
 
   @Test
   public void testToAvro() {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("NUMBER", 0, 10);
+    OraclePrimitiveType primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 0, 10);
     Map<String, Object> info = primitive.toAvro().info();
     String[] types = (String[]) info.get("type");
-
 
     Assert.assertEquals(types[0], "null");
     Assert.assertEquals(types[1], "long");

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleStruct.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleStruct.java
@@ -3,6 +3,7 @@ package com.linkedin.datastream.avrogenerator;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -12,7 +13,7 @@ public class TestOracleStruct {
 
   @Test
   public void testConstructorBasic() {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
     OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
 
@@ -29,7 +30,7 @@ public class TestOracleStruct {
   @Test
   @SuppressWarnings("unchecked")
   public void testToAvro() throws Exception {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
     OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
 
@@ -42,7 +43,6 @@ public class TestOracleStruct {
     Map<String, Object> info = struct.toAvro().info();
     List<Object> types = (List<Object>) info.get("type");
     Map<String, Object> recordType = (Map<String, Object>) types.get(0);
-
 
     Assert.assertEquals((String) types.get(1), "null");
     Assert.assertEquals((String) recordType.get("type"), "record");

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTable.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTable.java
@@ -13,7 +13,7 @@ public class TestOracleTable {
 
   @Test
   public void testConstructorBasic() {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
     OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
 
@@ -29,7 +29,7 @@ public class TestOracleTable {
 
   @Test
   public void testToAvro() throws Exception {
-    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", 0, 0);
+    OraclePrimitiveType primitive = new OraclePrimitiveType("VARCHAR2", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
     OracleColumn col1 = new OracleColumn("colName1", primitive, 1);
     OracleColumn col2 = new OracleColumn("colName2", primitive, 2);
 

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTableFactory.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOracleTableFactory.java
@@ -11,7 +11,8 @@ public class TestOracleTableFactory {
   @Test
   public void testE2EBuildFieldTypeFactory() throws Exception {
     OracleDatabaseClient client = Mockito.mock(OracleDatabaseClient.class);
-    DatabaseSource.TableMetadata meta = new DatabaseSource.TableMetadata("CHAR", "name", 0, 0);
+    DatabaseSource.TableMetadata meta =
+        new DatabaseSource.TableMetadata("CHAR", "name", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
 
     Mockito.when(client.getTableMetadata("schema", "view")).thenReturn(Collections.singletonList(meta));
     Mockito.when(client.isPrimitive("CHAR")).thenReturn(true);
@@ -24,7 +25,8 @@ public class TestOracleTableFactory {
   @Test
   public void testAbsentPrimaryKey() throws Exception {
     OracleDatabaseClient client = Mockito.mock(OracleDatabaseClient.class);
-    DatabaseSource.TableMetadata meta = new DatabaseSource.TableMetadata("CHAR", "name", 0, 0);
+    DatabaseSource.TableMetadata meta =
+        new DatabaseSource.TableMetadata("CHAR", "name", DatabaseSource.TableMetadata.NULLABLE, 0, 0);
 
     Mockito.when(client.getTableMetadata("schema", "view")).thenReturn(Collections.singletonList(meta));
     Mockito.when(client.isPrimitive("CHAR")).thenReturn(true);


### PR DESCRIPTION
Databus V2 and Brooklin-Oracle Avro schemas specify every field as "nullable" to facilitate backwards compatibility. However, Gobblin Avro schemas only specify an Avro field as "nullable" if the data is truly nullable in the Oracle DB.

To help with Gobblin compatibility, Brooklin-Oracle should provide whether the column is truly nullable in the Oracle DB. It can do this by adding information in the schema's "meta" fields.