### PR TITLE
DDSDBUS-13496:delete datastreams with deleteRecursive

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -369,8 +369,9 @@ public class ZkAdapter {
       return;
     }
 
-    LOG.info("Deleting the zk path", path);
-    _zkclient.delete(path);
+    LOG.info("Deleting the zk path {} ", path);
+    // Pipeline could have created more nodes under datastream node. Delete all associated state with deleteRecursive
+    _zkclient.deleteRecursive(path);
   }
 
   /**


### PR DESCRIPTION
Pipelines can chose to store more state under dms/datastream nodes. If a
datastream is deleted, we need to use deleteRecursive zkClient API to
successfully delete a directory node.