### PR TITLE
LISAMZA-8734: Serialize SQLXML type with getString API

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/databases/OracleTypeInterpreter.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/databases/OracleTypeInterpreter.java
@@ -119,7 +119,7 @@ public class OracleTypeInterpreter implements SqlTypeInterpreter {
     }
 
     if (sqlObject instanceof SQLXML) {
-      return sqlObject.toString();
+      return ((SQLXML) sqlObject).getString();
     }
 
     if (sqlObject instanceof byte[]) {

--- a/datastream-common/src/test/java/com/linkedin/datastream/common/databases/TestOracleTypeInterpreter.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/common/databases/TestOracleTypeInterpreter.java
@@ -1,12 +1,19 @@
 package com.linkedin.datastream.common.databases;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.Reader;
+import java.io.Writer;
 import java.math.BigDecimal;
 import java.sql.SQLException;
+import java.sql.SQLXML;
 import java.sql.Struct;
 import java.sql.Timestamp;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
+import javax.xml.transform.Result;
+import javax.xml.transform.Source;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Type;
@@ -20,7 +27,7 @@ import com.linkedin.datastream.common.DatastreamRuntimeException;
 
 public class TestOracleTypeInterpreter {
   //CHECKSTYLE:OFF
-  public static final Schema GENERIC_SCHEMA = Schema.parse("{\"name\":\"DaftPunk_Songs\",\"doc\":\"Auto-generatedAvroschemaformusic.sy$daftPunk.GeneratedatFeb10,201205:41:48PMPST\",\"type\":\"record\",\"meta\":\"dbFieldName=music.sy$daft_punk_songs;pk=getLucky;\",\"namespace\":\"com.linkedin.events.anet\",\"fields\":[{\"name\":\"txn\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=TXN;dbFieldType=NUMBER;dbFieldPosition=0;\"},{\"name\":\"getLucky\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=GET_LUCKY;dbFieldType=NUMBER;dbFieldPosition=1;\"},{\"name\":\"settings\",\"type\":[{\"name\":\"SETTINGS_T\",\"type\":\"record\",\"fields\":[{\"name\":\"settings\",\"type\":{\"items\":{\"name\":\"settingT\",\"type\":\"record\",\"meta\":\"dbFieldName=SETTINGS;dbFieldType=STRUCT;dbFieldPosition=0;\",\"fields\":[{\"name\":\"instantCrush\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=INSTANT_CRUSH;dbFieldType=NUMBER;dbFieldPosition=0;\"},{\"name\":\"oneMoreTime\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=ONE_MORE_TIME;dbFieldType=NUMBER;dbFieldPosition=1;\"},{\"name\":\"somethingAboutUs\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=SOMETHING_ABOUT_US;dbFieldType=VARCHAR;dbFieldPosition=2;\"},{\"name\":\"daFunk\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=DA_FUNK;dbFieldType=NUMBER;dbFieldPosition=3;\"},{\"name\":\"robotRock\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=ROBOT_ROCK;dbFieldType=NUMBER;dbFieldPosition=4;\"}]},\"name\":\"settingsArray\",\"type\":\"array\"}}]},\"null\"],\"meta\":\"dbFieldName=SETTINGS;dbFieldType=STRUCT;dbFieldPosition=17;\"},{\"name\":\"contact\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=CONTACT;dbFieldType=VARCHAR;dbFieldPosition=18;\"},{\"name\":\"digitalLove\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=DIGITAL_LOVE;dbFieldType=TIMESTAMP;dbFieldPosition=19;\"},{\"name\":\"humanAfterAll\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=HUMAN_AFTER_ALL;dbFieldType=VARCHAR;dbFieldPosition=20;\"}]}");
+  public static final Schema GENERIC_SCHEMA = Schema.parse("{\"name\":\"DaftPunk_Songs\",\"doc\":\"Auto-generatedAvroschemaformusic.sy$daftPunk.GeneratedatFeb10,201205:41:48PMPST\",\"type\":\"record\",\"meta\":\"dbFieldName=music.sy$daft_punk_songs;pk=getLucky;\",\"namespace\":\"com.linkedin.events.anet\",\"fields\":[{\"name\":\"txn\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=TXN;dbFieldType=NUMBER;dbFieldPosition=0;\"},{\"name\":\"getLucky\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=GET_LUCKY;dbFieldType=NUMBER;dbFieldPosition=1;\"},{\"name\":\"settings\",\"type\":[{\"name\":\"SETTINGS_T\",\"type\":\"record\",\"fields\":[{\"name\":\"settings\",\"type\":{\"items\":{\"name\":\"settingT\",\"type\":\"record\",\"meta\":\"dbFieldName=SETTINGS;dbFieldType=STRUCT;dbFieldPosition=0;\",\"fields\":[{\"name\":\"instantCrush\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=INSTANT_CRUSH;dbFieldType=NUMBER;dbFieldPosition=0;\"},{\"name\":\"oneMoreTime\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=ONE_MORE_TIME;dbFieldType=NUMBER;dbFieldPosition=1;\"},{\"name\":\"somethingAboutUs\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=SOMETHING_ABOUT_US;dbFieldType=VARCHAR;dbFieldPosition=2;\"},{\"name\":\"daFunk\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=DA_FUNK;dbFieldType=NUMBER;dbFieldPosition=3;\"},{\"name\":\"robotRock\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=ROBOT_ROCK;dbFieldType=NUMBER;dbFieldPosition=4;\"}]},\"name\":\"settingsArray\",\"type\":\"array\"}}]},\"null\"],\"meta\":\"dbFieldName=SETTINGS;dbFieldType=STRUCT;dbFieldPosition=17;\"},{\"name\":\"contact\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=CONTACT;dbFieldType=VARCHAR;dbFieldPosition=18;\"},{\"name\":\"digitalLove\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=DIGITAL_LOVE;dbFieldType=TIMESTAMP;dbFieldPosition=19;\"},{\"name\":\"humanAfterAll\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=HUMAN_AFTER_ALL;dbFieldType=VARCHAR;dbFieldPosition=20;\"},{\"name\":\"technologic\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=TECHNOLOGIC;dbFieldType= XMLTYPE;dbFieldPosition=20;\"}]}");
   public static final Schema COMPLEX_SCHEMA = Schema.parse("{\"type\":\"record\",\"name\":\"BIG_CITIES_V12\",\"namespace\":\"com.linkedin.events.cities\",\"fields\":[{\"name\":\"key\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=KEY;dbFieldType=NUMBER;dbFieldPosition=1;\"},{\"name\":\"tokyo\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=TOKYO;dbFieldType=CHAR;dbFieldPosition=32;\"},{\"name\":\"delhi\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=DELHI;dbFieldType=CHAR;dbFieldPosition=33;\"},{\"name\":\"geo\",\"type\":{\"type\":\"record\",\"name\":\"DATABUS_GEO_T\",\"fields\":[{\"name\":\"country\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=COUNTRY;dbFieldType=VARCHAR;dbFieldType=CHAR;dbFieldPosition=0;\"},{\"name\":\"geoPlaceMaskCode\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=GEO_PLACE_MASK_CODE;dbFieldType=CHAR;dbFieldPosition=5;\"},{\"name\":\"latitudeDeg\",\"type\":[\"float\",\"null\"],\"meta\":\"dbFieldName=LATITUDE_DEG;dbFieldType=NUMBER;dbFieldPosition=6;\"},{\"name\":\"longitudeDeg\",\"type\":[\"float\",\"null\"],\"meta\":\"dbFieldName=LONGITUDE_DEG;dbFieldType=NUMBER;dbFieldPosition=7;\"}]},\"meta\":\"dbFieldName=GEO;dbFieldPosition=34;dbFieldType=DATABUS_GEO_T;\"},{\"name\":\"mexicoCity\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=MEXICO_CITY;dbFieldType=CHAR;dbFieldPosition=41;\"},{\"name\":\"smallerCities\",\"type\":{\"type\":\"array\",\"items\":{\"type\":\"record\",\"name\":\"smallCityT\",\"fields\":[{\"name\":\"cityId\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=CITY_ID;dbFieldType=NUMBER;dbFieldPosition=0;\"},{\"name\":\"cityName\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=CITY_NAME;dbFieldType=VARCHAR2;dbFieldPosition=1;\"}],\"meta\":\"dbFieldName=SMALLER_CITIES;dbFieldType=ARRAY;dbFieldPosition=42;\"}}},{\"name\":\"osaka\",\"type\":[\"string\",\"null\"],\"meta\":\"dbFieldName=OSAKA;dbFieldType=CHAR;dbFieldPosition=43;\"},{\"name\":\"newYork\",\"type\":[\"long\",\"null\"],\"meta\":\"dbFieldName=NEW_YORK;dbFieldType=NUMBER;dbFieldPosition=74;\"}],\"meta\":\"dbFieldName=sy$BIG_CITIES;\"}");
   //CHECKSTYLE:ON
 
@@ -86,6 +93,54 @@ public class TestOracleTypeInterpreter {
     Assert.assertEquals(object, ts.getTime());
     Assert.assertTrue(object instanceof Long);
   }
+
+  @Test
+  public void testSqlObjectToAvroXML() throws SQLException {
+    SQLXML ts = new SQLXML() {
+      @Override
+      public void free() throws SQLException {
+      }
+      @Override
+      public InputStream getBinaryStream() throws SQLException {
+        return null;
+      }
+      @Override
+      public OutputStream setBinaryStream() throws SQLException {
+        return null;
+      }
+      @Override
+      public Reader getCharacterStream() throws SQLException {
+        return null;
+      }
+      @Override
+      public Writer setCharacterStream() throws SQLException {
+        return null;
+      }
+      @Override
+      public String getString() throws SQLException {
+        return " <?xml version=\"1.0\" encoding=\"UTF-8\" ?>\n"
+            + " <!DOCTYPE Test SQLXML Type\n"
+            + " <subTag:configuration random config\">\n"
+            + "</subTag:configuration>";
+      }
+      @Override
+      public void setString(String value) throws SQLException {
+      }
+      @Override
+      public <T extends Source> T getSource(Class<T> sourceClass) throws SQLException {
+        return null;
+      }
+      @Override
+      public <T extends Result> T setResult(Class<T> resultClass) throws SQLException {
+        return null;
+      }
+    };
+
+    Object object = new OracleTypeInterpreter().sqlObjectToAvro(ts, "technologic", GENERIC_SCHEMA);
+    Assert.assertTrue(object instanceof String);
+    Assert.assertEquals(object, ts.getString());
+  }
+
 
   @Test(expectedExceptions = DatastreamRuntimeException.class)
   public void testSqlObjectToAvroUnexpectedType() throws SQLException {


### PR DESCRIPTION
OracleSQLInterpreter's sqlObjectToAvro API is used to convert Oracle DB types
to Avro compatible types to push into Kafka for Brooklin datastreams.
XMLs get converted to Strings and current code uses object.toString
which returns a serialized reference rather than the actual xml
serialized. Use getString API instead which is meant to do what we want