### PR TITLE
Exit early when woken up from commit in shutdown mode

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -28,6 +28,7 @@ public class KafkaBasedConnectorConfig {
   public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
   public static final String NON_GOOD_STATE_THRESHOLD_MS = "nonGoodStateThresholdMs";
   public static final String PROCESSING_DELAY_LOG_THRESHOLD_MS = "processingDelayLogThreshold";
+  public static final String CONFIG_ENABLE_LATEST_BROKER_OFFSETS_FETCHER = "enableLatestBrokerOffsetsFetcher";
 
   private static final long DEFAULT_RETRY_SLEEP_DURATION_MS = Duration.ofSeconds(5).toMillis();
   private static final long DEFAULT_PAUSE_ERROR_PARTITION_DURATION_MS = Duration.ofMinutes(10).toMillis();
@@ -54,6 +55,7 @@ public class KafkaBasedConnectorConfig {
 
   private final int _daemonThreadIntervalSeconds;
   private final long _nonGoodStateThresholdMs;
+  private final boolean _enableLatestBrokerOffsetsFetcher;
 
   public KafkaBasedConnectorConfig(Properties properties) {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
@@ -79,6 +81,8 @@ public class KafkaBasedConnectorConfig {
             MIN_NON_GOOD_STATE_THRESHOLD_MS, Long.MAX_VALUE);
     _processingDelayLogThresholdMs =
         verifiableProperties.getLong(PROCESSING_DELAY_LOG_THRESHOLD_MS, DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MS);
+    _enableLatestBrokerOffsetsFetcher =
+        verifiableProperties.getBoolean(CONFIG_ENABLE_LATEST_BROKER_OFFSETS_FETCHER, Boolean.FALSE);
 
     String factory =
         verifiableProperties.getString(CONFIG_CONSUMER_FACTORY_CLASS, KafkaConsumerFactoryImpl.class.getName());
@@ -111,6 +115,7 @@ public class KafkaBasedConnectorConfig {
     _daemonThreadIntervalSeconds = DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS;
     _nonGoodStateThresholdMs = DEFAULT_NON_GOOD_STATE_THRESHOLD_MS;
     _processingDelayLogThresholdMs = DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MS;
+    _enableLatestBrokerOffsetsFetcher = false;
   }
 
   public String getDefaultKeySerde() {
@@ -168,5 +173,9 @@ public class KafkaBasedConnectorConfig {
 
   public long getProcessingDelayLogThresholdMs() {
     return _processingDelayLogThresholdMs;
+  }
+
+  public boolean enableLatestBrokerOffsetsFetcher() {
+    return _enableLatestBrokerOffsetsFetcher;
   }
 }


### PR DESCRIPTION
2 changes in this PR:
- If consumer.commitSync() is taking a long time (> 10 mins), daemon thread may attempt to wakeup the consumer. Since the consumer.commitSync() is wrapped in a retry loop that catches KafkaException (WakeupException included), the task is failing to exit quickly. This can lead to ghost threads co-existing with new task threads created by daemon thread. The fix is to exit when being awaken.
- Wrap the start offsets fetcher feature in a config to be able to easily enable/disable it.