### PR TITLE
Clean up broken logging statements printing %s and convert others to …

### DIFF
--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/OracleConnector.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/OracleConnector.java
@@ -142,7 +142,7 @@ public class OracleConnector implements Connector {
    * Shutdown each {@link OracleTaskHandler} as well as stop the daemon thread
    */
   public void stop() {
-    LOG.info(String.format("attempting to shutdown %s connector ...", CONNECTOR_TYPE));
+    LOG.info("attempting to shutdown {} connector ...", CONNECTOR_TYPE);
     _namedTaskHandlers.values().forEach(OracleTaskHandler::stop);
 
     if (!ThreadUtils.shutdownExecutor(_executorService, SHUTDOWN_TIMEOUT, LOG)) {
@@ -156,7 +156,7 @@ public class OracleConnector implements Connector {
     _daemonThreadExecutorService = null;
     _namedTaskHandlers.clear();
 
-    LOG.info(String.format("%s connector has successfully stopped", CONNECTOR_TYPE));
+    LOG.info("{} connector has successfully stopped", CONNECTOR_TYPE);
   }
 
   public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
@@ -170,9 +170,9 @@ public class OracleConnector implements Connector {
 
     tasks.forEach(task -> {
 
-      LOG.info(String.format("Handling task: %s with source: %s",
+      LOG.info("Handling task: {} with source: {}",
           task.getDatastreamTaskName(),
-          task.getDatastreamSource().getConnectionString()));
+          task.getDatastreamSource().getConnectionString());
 
       // pardon this task from the remove list
       tasksToStop.remove(task);
@@ -190,7 +190,7 @@ public class OracleConnector implements Connector {
           taskHandler.start();
 
         } catch (DatastreamException e) {
-          LOG.error(String.format("Failed to create Task Handler for Task: %s", task.getDatastreamTaskName()));
+          LOG.error("Failed to create Task Handler for Task: {}", task.getDatastreamTaskName());
         }
       }
     });

--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/OracleTaskHandler.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/OracleTaskHandler.java
@@ -132,7 +132,7 @@ public class OracleTaskHandler implements Runnable {
     try {
       _oracleConsumer.initializeConnection();
     } catch (DatastreamException e) {
-      LOG.error(String.format("Failed to create OracleConsumer for source: %s", _source.getConnectionString()));
+      LOG.error("Failed to create OracleConsumer for source: {}", _source.getConnectionString());
       throw e;
     }
   }
@@ -148,7 +148,7 @@ public class OracleTaskHandler implements Runnable {
    * restarting a thread
    */
   public void start() throws DatastreamException {
-    LOG.info(String.format("Starting OracleTaskHandler: %s", _handlerName));
+    LOG.info("Starting OracleTaskHandler: {}", _handlerName);
 
     try {
       _lastScn = getSafeCheckpoint();
@@ -165,7 +165,7 @@ public class OracleTaskHandler implements Runnable {
       return;
     }
 
-    LOG.warn(String.format("Detected that OracleTaskHandler %s is not running! Restarting...", _handlerName));
+    LOG.warn("Detected that OracleTaskHandler {} is not running! Restarting...", _handlerName);
 
     try {
       start();
@@ -177,7 +177,7 @@ public class OracleTaskHandler implements Runnable {
 
   @Override
   public void run() {
-    LOG.info("Start to run OracleTaskHandler, HandlerName: " + _handlerName);
+    LOG.info("Start to run OracleTaskHandler, HandlerName: {}", _handlerName);
     Instant lastStartTime = Instant.now();
 
     try {
@@ -206,10 +206,10 @@ public class OracleTaskHandler implements Runnable {
         lastStartTime = startTime;
 
         if (timeSinceLastPoll.compareTo(DEFAULT_SESSION_TIMEOUT) > 0) {
-          LOG.warn(format("OracleTaskHandler: %s, Time since last Oracle Poll is %d ms (> session timeout %d ms)",
+          LOG.warn("OracleTaskHandler: {}, Time since last Oracle Poll is {} ms (> session timeout {} ms)",
               _handlerName,
               timeSinceLastPoll.toMillis(),
-              DEFAULT_SESSION_TIMEOUT.toMillis()));
+              DEFAULT_SESSION_TIMEOUT.toMillis());
         }
 
         List<OracleChangeEvent> changeEvents;
@@ -230,17 +230,15 @@ public class OracleTaskHandler implements Runnable {
 
         // record issue if pollTime was too large
         if (pollTime.compareTo(DEFAULT_POLL_TIMEOUT) > 0) {
-          LOG.warn(format("OracleTaskHandler: %s took %d to ms to query Oracle Database (> %d ms poll timeout)",
+          LOG.warn("OracleTaskHandler: {} took {} to ms to query Oracle Database (> {} ms poll timeout)",
               _handlerName,
               pollTime.toMillis(),
-              DEFAULT_POLL_TIMEOUT.toMillis()));
+              DEFAULT_POLL_TIMEOUT.toMillis());
         }
 
         // skip to the next iteration if the there was 0 ChangeEvents
         if (changeEvents.size() == 0) {
-          LOG.debug(format("OracleTaskHandler: %s found 0 OracleChangeEvents using _lastScn: %d",
-              _handlerName,
-              _lastScn));
+          LOG.debug("OracleTaskHandler: {} found 0 OracleChangeEvents using lastScn: {}", _handlerName, _lastScn);
           continue;
         }
 
@@ -253,9 +251,8 @@ public class OracleTaskHandler implements Runnable {
         _eventsProcessedCountLog += changeEvents.size();
 
         Duration processingTime = Duration.between(processingStartTime, Instant.now());
-        LOG.debug(format("OracleTaskHandler: %s processing %d took %d(ms)", _handlerName,
-            changeEvents.size(),
-            processingTime.toMillis()));
+        LOG.debug("OracleTaskHandler: {} processing {} took {}(ms)", _handlerName, changeEvents.size(),
+            processingTime.toMillis());
 
         // If we got here, then we have successfully processed all the events
         // returned by the Poll. Now we have to update the {@code _lastScn}
@@ -299,8 +296,7 @@ public class OracleTaskHandler implements Runnable {
         String checkpoint = checkpointMap.get(PARTITION_NUM);
         _lastScn = Long.parseLong(checkpoint);
 
-        LOG.info(format("OracleTaskHandler: %s reset the lastScn to: %d", _handlerName,
-            _lastScn));
+        LOG.info("OracleTaskHandler: {} reset the lastScn to: {}", _handlerName, _lastScn);
 
         _messageHandler.resetErrorState();
       }
@@ -353,7 +349,7 @@ public class OracleTaskHandler implements Runnable {
     // a brand new datastreamTask and we want to start processing from
     // the latest SCN
     if (checkpointMap == null || checkpointMap.size() == 0) {
-      LOG.info(format("OracleTaskHandler: %s, did not find Checkpoint, finding the latest SCN", _handlerName));
+      LOG.info("OracleTaskHandler: {}, did not find Checkpoint, finding the latest SCN", _handlerName);
       long scn;
 
       try {
@@ -370,7 +366,7 @@ public class OracleTaskHandler implements Runnable {
     // we hard code the key to be 0
     String checkpoint = checkpointMap.get(PARTITION_NUM);
     long scn = Long.parseLong(checkpoint);
-    LOG.info(format("OracleTaskHandler: %s Found Checkpoint, _lastScn: %d", _handlerName, scn));
+    LOG.info("OracleTaskHandler: {} Found Checkpoint, lastScn: {}", _handlerName, scn);
 
     return scn;
   }
@@ -390,9 +386,7 @@ public class OracleTaskHandler implements Runnable {
     long oldScn = _lastScn;
     _lastScn = events.get(events.size() - 1).getScn();
 
-    LOG.debug(format("OracleTaskHandler: %s updated its _lastScn from old: %d to new: %d", _handlerName,
-        oldScn,
-        _lastScn));
+    LOG.debug("OracleTaskHandler: {} updated its lastScn from old: {} to new: {}", _handlerName, oldScn, _lastScn);
   }
 
   /**

--- a/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/consumer/OracleConsumer.java
+++ b/brooklin-oracle-tb-connector/src/main/java/com/linkedin/datastream/connectors/oracle/triggerbased/consumer/OracleConsumer.java
@@ -97,7 +97,7 @@ public class OracleConsumer {
       _dataSource = dataSourceFactory.createOracleDataSource(_uri, _queryTimeout);
       resetConnection();
     } catch (Exception e) {
-      LOG.error(String.format("Failed to create an Oracle Data Source for OracleConsumer: %s", getName()));
+      LOG.error("Failed to create an Oracle Data Source for OracleConsumer: {}", getName());
       throw new DatastreamException(e);
     }
 
@@ -114,7 +114,7 @@ public class OracleConsumer {
     try {
       _conn.close();
       _conn = null;
-      LOG.info(String.format("Closing OracleConsumer: %s", getName()));
+      LOG.info("Closing OracleConsumer: {}", getName());
     } catch (SQLException e) {
       LOG.warn(String.format("OracleConsumer: %s Failed to close connection", getName()), e);
     }
@@ -178,7 +178,7 @@ public class OracleConsumer {
 
       return changeEvents;
     } catch (SQLException e) {
-      LOG.error(String.format("Query failed: %s", _changeCaptureQuery));
+      LOG.error("Query failed: {}", _changeCaptureQuery);
       throw e;
     } finally {
       _conn.commit();
@@ -208,9 +208,7 @@ public class OracleConsumer {
       }
 
       if (scn == 0) {
-        throw new SQLException(String.format("Failed to get starting SCN for %s using sqlQuery: %s",
-            getName(),
-            sql));
+        throw new SQLException(String.format("Failed to get starting SCN for %s using sqlQuery: %s", getName(), sql));
       }
 
       LOG.info("latest SCN is: {}", scn);

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClient.java
@@ -387,7 +387,7 @@ public class DatastreamRestClient {
           return null;
         }
         if (isNotFoundHttpStatus(e)) {
-          LOG.debug(String.format("Datastream %s is not found", datastreamName));
+          LOG.debug("Datastream {} is not found", datastreamName);
         } else {
           String errorMessage = String.format("Get Datastream %s failed with error.", datastreamName);
           ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, e);

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClient.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClient.java
@@ -44,7 +44,7 @@ public class ServerComponentHealthRestClient {
     if (response != null && !response.isEmpty()) {
       return response.get(0);
     } else {
-      LOG.error("ServerComponentHealth getStatus {%s} {%s} failed with empty response.", type, scope);
+      LOG.error("ServerComponentHealth getStatus {} {} failed with empty response.", type, scope);
       return null;
     }
   }
@@ -54,7 +54,7 @@ public class ServerComponentHealthRestClient {
       FindRequest<ServerComponentHealth> request = _builders.findByStatus().typeParam(type).scopeParam(scope).contentParam(content).build();
       return _restClient.sendRequest(request).getResponse().getEntity().getElements();
     } catch (RemoteInvocationException e) {
-      LOG.error("Get serverComponentHealthStatus {%s} {%s} failed with error.", type, scope);
+      LOG.error("Get serverComponentHealthStatus {} {} failed with error.", type, scope);
       return null;
     }
   }
@@ -76,7 +76,7 @@ public class ServerComponentHealthRestClient {
     if (response != null && !response.isEmpty()) {
       return response.get(0);
     } else {
-      LOG.error("ServerComponentHealth getAllStatus {%s} {%s} failed with empty response.", type, scope);
+      LOG.error("ServerComponentHealth getAllStatus {} {} failed with empty response.", type, scope);
       return null;
     }
   }
@@ -86,7 +86,7 @@ public class ServerComponentHealthRestClient {
       FindRequest<ServerComponentHealth> request = _builders.findByAllStatus().typeParam(type).scopeParam(scope).contentParam(content).build();
       return _restClient.sendRequest(request).getResponse().getEntity().getElements();
     } catch (RemoteInvocationException e) {
-      LOG.error("Get serverComponentHealthAllStatus {%s} {%s} failed with error.", type, scope);
+      LOG.error("Get serverComponentHealthAllStatus {} {} failed with error.", type, scope);
       return null;
     }
   }

--- a/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
+++ b/datastream-client/src/test/java/com/linkedin/datastream/TestDatastreamRestClient.java
@@ -94,11 +94,11 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
   @Test
   public void testCreateTwoDatastreams() throws Exception {
     Datastream datastream = generateDatastream(6);
-    LOG.info("Datastream : " + datastream);
+    LOG.info("Datastream : {}", datastream);
     DatastreamRestClient restClient = createRestClient();
     restClient.createDatastream(datastream);
     Datastream createdDatastream = restClient.waitTillDatastreamIsInitialized(datastream.getName(), WAIT_TIMEOUT_MS);
-    LOG.info("Created Datastream : " + createdDatastream);
+    LOG.info("Created Datastream : {}", createdDatastream);
 
     datastream.setDestination(new DatastreamDestination());
     // server might have already set the destination so we need to unset it for comparison
@@ -107,10 +107,10 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
     Assert.assertEquals(createdDatastream, datastream);
 
     datastream = generateDatastream(7);
-    LOG.info("Datastream : " + datastream);
+    LOG.info("Datastream : {}", datastream);
     restClient.createDatastream(datastream);
     createdDatastream = restClient.waitTillDatastreamIsInitialized(datastream.getName(), WAIT_TIMEOUT_MS);
-    LOG.info("Created Datastream : " + createdDatastream);
+    LOG.info("Created Datastream : {}", createdDatastream);
 
     datastream.setDestination(new DatastreamDestination());
     // server might have already set the destination so we need to unset it for comparison
@@ -125,13 +125,13 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
     _datastreamCluster.startupServer(1);
 
     Datastream datastream = generateDatastream(5);
-    LOG.info("Datastream : " + datastream);
+    LOG.info("Datastream : {}", datastream);
 
     int followerDmsPort = _datastreamCluster.getDatastreamPorts().get(1);
     DatastreamRestClient restClient = DatastreamRestClientFactory.getClient("http://localhost:" + followerDmsPort);
     restClient.createDatastream(datastream);
     Datastream createdDatastream = restClient.waitTillDatastreamIsInitialized(datastream.getName(), WAIT_TIMEOUT_MS);
-    LOG.info("Created Datastream : " + createdDatastream);
+    LOG.info("Created Datastream : {}", createdDatastream);
     datastream.setDestination(new DatastreamDestination());
     // server might have already set the destination so we need to unset it for comparison
     clearDatastreamDestination(Collections.singletonList(createdDatastream));
@@ -142,7 +142,7 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
   @Test(expectedExceptions = DatastreamAlreadyExistsException.class)
   public void testCreateDatastreamThatAlreadyExists() throws Exception {
     Datastream datastream = generateDatastream(1);
-    LOG.info("Datastream : " + datastream);
+    LOG.info("Datastream : {}", datastream);
     DatastreamRestClient restClient = createRestClient();
     restClient.createDatastream(datastream);
     restClient.createDatastream(datastream);
@@ -151,11 +151,11 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
   @Test
   public void testWaitTillDatastreamIsInitializedReturnsInitializedDatastream() throws Exception {
     Datastream datastream = generateDatastream(11);
-    LOG.info("Datastream : " + datastream);
+    LOG.info("Datastream : {}", datastream);
     DatastreamRestClient restClient = createRestClient();
     restClient.createDatastream(datastream);
     Datastream initializedDatastream = restClient.waitTillDatastreamIsInitialized(datastream.getName(), 60000);
-    LOG.info("Initialized Datastream : " + initializedDatastream);
+    LOG.info("Initialized Datastream : {}", initializedDatastream);
     Assert.assertNotEquals(initializedDatastream.getDestination().getConnectionString(), "");
     Assert.assertEquals(initializedDatastream.getDestination().getPartitions().intValue(), 1);
   }
@@ -181,10 +181,10 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
   }
 
   @Test
-  public void testGetAllDatastreams() throws Exception {
+  public void testGetAllDatastreams() {
     List<Datastream> datastreams =
         IntStream.range(100, 110).mapToObj(TestDatastreamRestClient::generateDatastream).collect(Collectors.toList());
-    LOG.info("Datastreams : " + datastreams);
+    LOG.info("Datastreams : {}", datastreams);
     DatastreamRestClient restClient = createRestClient();
 
     int initialSize = restClient.getAllDatastreams().size();
@@ -201,7 +201,7 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
     Assert.assertTrue(result.isPresent());
 
     List<Datastream> createdDatastreams = result.get();
-    LOG.info("Created Datastreams : " + createdDatastreams);
+    LOG.info("Created Datastreams : {}", createdDatastreams);
 
     clearDatastreamDestination(datastreams);
     clearDatastreamDestination(createdDatastreams);
@@ -213,7 +213,7 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
     int skip = 2;
     int count = 5;
     List<Datastream> paginatedCreatedDatastreams = restClient.getAllDatastreams(2, 5);
-    LOG.info("Paginated Datastreams : " + paginatedCreatedDatastreams);
+    LOG.info("Paginated Datastreams : {}", paginatedCreatedDatastreams);
 
     Assert.assertEquals(paginatedCreatedDatastreams.size(), count);
 
@@ -227,7 +227,7 @@ public class TestDatastreamRestClient extends TestRestliClientBase {
   @Test(expectedExceptions = DatastreamNotFoundException.class)
   public void testDeleteDatastream() throws Exception {
     Datastream datastream = generateDatastream(2);
-    LOG.info("Datastream : " + datastream);
+    LOG.info("Datastream : {}", datastream);
     DatastreamRestClient restClient = createRestClient();
     restClient.createDatastream(datastream);
     restClient.waitTillDatastreamIsInitialized(datastream.getName(), Duration.ofMinutes(2).toMillis());

--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
@@ -87,7 +87,7 @@ public class FileConnector implements Connector {
 
   @Override
   public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
-    LOG.info(String.format("onAssignmentChange called with datastream tasks %s ", tasks));
+    LOG.info("onAssignmentChange called with datastream tasks {}", tasks);
     Set<DatastreamTask> unassigned = new HashSet<>(_fileProcessors.keySet());
     unassigned.removeAll(tasks);
 

--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -101,7 +101,7 @@ class FileProcessor implements Runnable {
           builder.setSourceCheckpoint(lineNo.toString());
           _producer.send(builder.build(), (metadata, exception) -> {
             if (exception == null) {
-              LOG.info(String.format("Sending event:{%s} succeeded, metadata:{%s}", text, metadata));
+              LOG.info("Sending event:{} succeeded, metadata:{}", text, metadata);
             } else {
               LOG.error(String.format("Sending event:{%s} failed, metadata:{%s}", text, metadata), exception);
             }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -838,7 +838,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         throw new DatastreamRuntimeException(errMsg);
       }
       // if group ID is present in metadata, add it to properties even if present already.
-      logger.info("Found overridden group ID for Kafka datastream task: {} . Overridden group id: {} Datastreams: %s",
+      logger.info("Found overridden group ID for Kafka datastream task: {}. Overridden group id: {} Datastreams: {}",
           task.getId(), groupIds.toArray()[0], task.getDatastreams());
       return (String) groupIds.toArray()[0];
     }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -60,7 +60,7 @@ public class KafkaTransportProvider implements TransportProvider {
   }
 
   public KafkaTransportProvider(Properties props, String metricsNamesPrefix) {
-    LOG.info(String.format("Creating kafka transport provider with properties: %s", props));
+    LOG.info("Creating kafka transport provider with properties: {}", props);
     if (!props.containsKey(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG)) {
       String errorMessage = "Bootstrap servers are not set";
       ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, null);
@@ -122,7 +122,7 @@ public class KafkaTransportProvider implements TransportProvider {
       Validate.isTrue(record.getPartition().isPresent() || record.getPartitionKey().isPresent(),
           "Either partition or partitionKey needs to be set");
 
-      LOG.debug("Sending Datastream event record: %s", record);
+      LOG.debug("Sending Datastream event record: {}", record);
 
       for (Object event : record.getEvents()) {
         ProducerRecord<byte[], byte[]> outgoing;
@@ -158,7 +158,7 @@ public class KafkaTransportProvider implements TransportProvider {
       ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, e);
     }
 
-    LOG.debug("Done sending Datastream event record: %s", record);
+    LOG.debug("Done sending Datastream event record: {}", record);
   }
 
   @Override

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderAdmin.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderAdmin.java
@@ -149,7 +149,7 @@ public class KafkaTransportProviderAdmin implements TransportProviderAdmin {
       // Create only if it doesn't exist.
       if (!AdminUtils.topicExists(_zkUtils, topicName)) {
         int replicationFactor = Integer.parseInt(topicConfig.getProperty("replicationFactor", DEFAULT_REPLICATION_FACTOR));
-        LOG.info("Creating topic with name {} partitions={} with properties %s", topicName, numberOfPartitions,
+        LOG.info("Creating topic with name {} partitions={} with properties {}", topicName, numberOfPartitions,
                 topicConfig);
 
         // Add default retention if no topic-level retention is specified

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlConnector.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlConnector.java
@@ -128,9 +128,8 @@ public class MysqlConnector implements Connector {
       throw new DatastreamRuntimeException(msg, e);
     }
 
-    LOG.info(
-        String.format("Creating mysql replicator for DB: %s table: %s and binlogFolder: %s", source.getDatabaseName(),
-            source.getTableName(), binlogFolder));
+    LOG.info("Creating mysql replicator for DB: {} table: {} and binlogFolder: {}", source.getDatabaseName(),
+            source.getTableName(), binlogFolder);
     MysqlSourceBinlogRowEventFilter rowEventFilter =
         new MysqlSourceBinlogRowEventFilter(task.getDatastreamTaskName(), source.getDatabaseName(),
             source.isAllTables(), source.getTableName(), _dynamicMetricsManager);
@@ -144,7 +143,7 @@ public class MysqlConnector implements Connector {
   private MysqlReplicatorImpl createReplicatorForMysqlServer(DatastreamTask task) {
     MysqlSource source = parseMysqlSource(task);
 
-    LOG.info("Creating mysql replicator for DB: %s table: %s and mysql server: %s:%s", source.getDatabaseName(),
+    LOG.info("Creating mysql replicator for DB: {} table: {} and mysql server: {}:{}", source.getDatabaseName(),
         source.getTableName(), source.getHostName(), source.getPort());
 
     MysqlSourceBinlogRowEventFilter rowEventFilter =
@@ -212,12 +211,11 @@ public class MysqlConnector implements Connector {
   @Override
   public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
     if (Optional.ofNullable(tasks).isPresent()) {
-      LOG.info(String.format("onAssignmentChange called with datastream tasks %s ", tasks.toString()));
+      LOG.info("onAssignmentChange called with datastream tasks {} ", tasks);
       for (DatastreamTask task : tasks) {
         MysqlReplicator replicator = _mysqlProducers.get(task);
         if (replicator == null) {
-          LOG.info(String.format("New task {%s} assigned to the current instance, Creating mysql producer for ",
-              task.toString()));
+          LOG.info("New task {} assigned to the current instance, Creating mysql producer.", task);
           replicator = createReplicator(task);
         }
 
@@ -243,7 +241,7 @@ public class MysqlConnector implements Connector {
         _mysqlProducers.keySet().stream().filter(tasks::contains).collect(Collectors.toList());
 
     if (!reassignedTasks.isEmpty()) {
-      LOG.info("Tasks {%s} are reassigned from the current instance, Stopping the replicators", reassignedTasks);
+      LOG.info("Tasks {} are reassigned from the current instance, Stopping the replicators", reassignedTasks);
       for (DatastreamTask reassignedTask : reassignedTasks) {
         MysqlReplicator replicator = _mysqlProducers.get(reassignedTask);
         try {

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlSnapshotConnector.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/MysqlSnapshotConnector.java
@@ -87,7 +87,7 @@ public class MysqlSnapshotConnector implements Connector {
 
   @Override
   public void onAssignmentChange(List<DatastreamTask> tasks) {
-    LOG.info(String.format("Mysql snapshot connector is assigned tasks %s", tasks));
+    LOG.info("Mysql snapshot connector is assigned tasks {}", tasks);
     List<DatastreamTask> tasksAdded =
         tasks.stream().filter(x -> !_taskHandlers.containsKey(x)).collect(Collectors.toList());
     List<DatastreamTask> tasksRemoved =

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlBinlogEventListener.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlBinlogEventListener.java
@@ -213,7 +213,7 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
     }
 
     String[] tableNameParts = currFullDBTableName.split("[.]");
-    LOG.debug("File Number: %s, Position: %d, SCN = %d", _currFileName, (int) binlogEventHeader.getPosition(), _scn);
+    LOG.debug("File Number: {}, Position: {}, SCN = {}", _currFileName, (int) binlogEventHeader.getPosition(), _scn);
 
     List<ColumnInfo> columnMetadata = _tableInfoProvider.getColumnList(tableNameParts[0], tableNameParts[1]);
 
@@ -286,7 +286,7 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
       QueryEvent qe = (QueryEvent) event;
       String sql = qe.getSql().toString();
       if ("ROLLBACK".equalsIgnoreCase(sql)) {
-        LOG.debug("ROLLBACK sql: %s", sql);
+        LOG.debug("ROLLBACK sql: {}", sql);
         return true;
       }
     }
@@ -322,7 +322,7 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
 
       _producer.send(builder.build(), (metadata, exception) -> {
         if (exception == null) {
-          LOG.debug(String.format("Sending event succeeded, metadata:{%s}", metadata));
+          LOG.debug("Sending event succeeded, metadata: {}", metadata);
         } else {
           // TODO we need to handle this by closing the producer and moving to the old checkpoint.
           LOG.error(String.format("Sending event failed, metadata:{%s}", metadata), exception);
@@ -338,7 +338,7 @@ public class MysqlBinlogEventListener implements BinlogEventListener {
       QueryEvent qe = (QueryEvent) event;
       String sql = qe.getSql().toString();
       if ("COMMIT".equalsIgnoreCase(sql)) {
-        LOG.debug("COMMIT sql: %s", sql);
+        LOG.debug("COMMIT sql: {}", sql);
         return true;
       }
     } else if (event instanceof XidEvent) {

--- a/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlQueryUtils.java
+++ b/datastream-mysql-connector/src/main/java/com/linkedin/datastream/connectors/mysql/or/MysqlQueryUtils.java
@@ -12,7 +12,8 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.connectors.mysql.MysqlSource;
@@ -21,7 +22,7 @@ import com.linkedin.datastream.connectors.mysql.MysqlSource;
 // Not thread-safe
 public class MysqlQueryUtils {
   public static final String MODULE = MysqlQueryUtils.class.getName();
-  public static final Logger LOG = Logger.getLogger(MODULE);
+  public static final Logger LOG = LoggerFactory.getLogger(MODULE);
 
   // This query returns the "latest" binlog file only
   // mysql> show master status;
@@ -156,7 +157,7 @@ public class MysqlQueryUtils {
 
     String file = rs.getString(SN_SHOW_BINARY_LOGS_STMT_FILENAME_POSITION);
     String[] tok = file.split("\\.");
-    LOG.info(" The earliest binlog file available on master is : " + file);
+    LOG.info("The earliest binlog file available on master is : {}", file);
     int logId = new Integer(tok[tok.length - 1]);
     int offset = BINLOG_START_POS;
     return binlogPosition(logId, offset);
@@ -225,7 +226,7 @@ public class MysqlQueryUtils {
 
     String file = rs.getString(SN_STATUS_STMT_FILENAME_POSITION);
     String[] tok = file.split("\\.");
-    LOG.info(" The latest binlog file available on master is : " + file);
+    LOG.info("The latest binlog file available on master is : {}", file);
     int logId = new Integer(tok[tok.length - 1]);
     int offset = rs.getInt(SN_STATUS_STMT_FILEOFFSET_POSITION);
     return new BinlogPosition(file, binlogPosition(logId, offset));
@@ -352,7 +353,7 @@ public class MysqlQueryUtils {
       try {
         _conn.close();
       } catch (SQLException e) {
-        LOG.warn("failed to close mysql connection to " + _source.getHostName() + ":" + _source.getPort(), e);
+        LOG.warn("failed to close mysql connection to {}:{} ", _source.getHostName(), _source.getPort(), e);
         // ignore it and create a new connection
       }
       _conn = null;
@@ -369,11 +370,11 @@ public class MysqlQueryUtils {
     Statement stmt = null;
     ResultSet rs = null;
     try {
-      LOG.info("SQL about to execute in getColumnList: " + sql);
+      LOG.info("SQL about to execute in getColumnList: {}", sql);
       long timestampStart = System.currentTimeMillis();
       stmt = getConnection().createStatement();
       rs = stmt.executeQuery(sql);
-      LOG.info("Time taken to execute the query: " + (System.currentTimeMillis() - timestampStart) + "ms");
+      LOG.info("Time taken to execute the query: {} ms", System.currentTimeMillis() - timestampStart);
       List<ColumnInfo> result = new ArrayList<ColumnInfo>();
       while (rs.next()) {
         /*
@@ -415,11 +416,11 @@ public class MysqlQueryUtils {
     Statement stmt = null;
     ResultSet rs = null;
     try {
-      LOG.info("SQL about to execute in getKeyColumns: " + sql);
+      LOG.info("SQL about to execute in getKeyColumns: {}", sql);
       long timestampStart = System.currentTimeMillis();
       stmt = getConnection().createStatement();
       rs = stmt.executeQuery(sql);
-      LOG.info("Time taken to execute the query: " + (System.currentTimeMillis() - timestampStart) + "ms");
+      LOG.info("Time taken to execute the query: {} ms", System.currentTimeMillis() - timestampStart);
       List<String> result = new ArrayList<String>();
       while (rs.next()) {
         result.add(rs.getString(1));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -61,11 +61,11 @@ public class CachedDatastreamReader {
         Set<String> datastreamsRemoved = new HashSet<>(_datastreams.keySet());
         datastreamsRemoved.removeAll(_datastreamNames);
         if (!datastreamsRemoved.isEmpty()) {
-          LOG.info(String.format("Removing the deleted datastreams {%s} from cache", datastreamsRemoved));
+          LOG.info("Removing the deleted datastreams {} from cache", datastreamsRemoved);
           _datastreams.keySet().removeAll(datastreamsRemoved);
         }
 
-        LOG.debug("New datastream list in the cache: %s", _datastreamNames);
+        LOG.debug("New datastream list in the cache: {}", _datastreamNames);
       }
     });
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -60,15 +60,15 @@ public class ConnectorWrapper {
   }
 
   private void logApiStart(String method) {
-    _log.info(String.format("START: Connector::%s. Connector: %s, Instance: %s", method, _connectorType, _instanceName));
+    _log.info("START: Connector::{}. Connector: {}, Instance: {}", method, _connectorType, _instanceName);
     _startTime = System.currentTimeMillis();
     _lastError = null;
   }
 
   private void logApiEnd(String method) {
     _endTime = System.currentTimeMillis();
-    _log.info(String.format("END: Connector::%s. Connector: %s, Instance: %s, Duration: %d milliseconds", method,
-        _connectorType, _instanceName, _endTime - _startTime));
+    _log.info("END: Connector::{}. Connector: {}, Instance: {}, Duration: {} milliseconds", method,
+        _connectorType, _instanceName, _endTime - _startTime);
   }
 
   public void start(CheckpointProvider checkpointProvider) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -738,8 +738,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           // Set the datastream status as ready for use (both producing and consumption)
           ds.setStatus(DatastreamStatus.READY);
           if (!_adapter.updateDatastream(ds)) {
-            _log.warn(String.format("Failed to update datastream: %s after initializing, "
-                + "This datastream will not be scheduled for producing events ", ds.getName()));
+            _log.warn("Failed to update datastream: {} after initializing. This datastream will not be scheduled for "
+                + "producing events ", ds.getName());
             shouldRetry = true;
           }
         } catch (Exception e) {
@@ -1010,8 +1010,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     Validate.notEmpty(connectorName, "connectorName cannot be empty");
     Validate.notNull(connector, "Connector cannot be null");
 
-    _log.info(String.format("Add new connector of type %s, strategy %s with custom checkpointing %s to coordinator",
-        connectorName, strategy.getClass().getTypeName(), customCheckpointing));
+    _log.info("Add new connector of type {}, strategy {} with custom checkpointing {} to coordinator",
+        connectorName, strategy.getClass().getTypeName(), customCheckpointing);
 
     if (_connectors.containsKey(connectorName)) {
       String err = "A connector of type " + connectorName + " already exists.";

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -25,7 +25,7 @@ public class CoordinatorEventBlockingQueue {
   * @param event CoordinatorEvent event to add to the queue
   */
   public synchronized void put(CoordinatorEvent event) {
-    LOG.info(String.format("Queuing event %s to event queue", event.getType()));
+    LOG.info("Queuing event {} to event queue", event.getType());
     if (!_eventMap.containsKey(event.getType())) {
       // only insert if there isn't an event present in the queue with the same name
       boolean result = _eventQueue.offer(event);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -343,7 +343,7 @@ public class DatastreamServer {
       LOG.info("Starting CsvReporter in " + _csvMetricsDir);
       File csvDir = new File(_csvMetricsDir);
       if (!csvDir.exists()) {
-        LOG.info(String.format("csvMetricsDir %s doesn't exist, creating it.", _csvMetricsDir));
+        LOG.info("csvMetricsDir {} doesn't exist, creating it.", _csvMetricsDir);
         csvDir.mkdirs();
       }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -124,7 +124,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public static DatastreamTaskImpl fromJson(String json) {
     DatastreamTaskImpl task = JsonUtils.fromJson(json, DatastreamTaskImpl.class);
-    LOG.debug("Loaded existing DatastreamTask: %s", task);
+    LOG.debug("Loaded existing DatastreamTask: {}", task);
     return task;
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -127,7 +127,7 @@ public class EventProducer implements DatastreamEventProducer {
     _enablePerTopicMetrics =
         Boolean.parseBoolean(config.getProperty(CONFIG_ENABLE_PER_TOPIC_METRICS, Boolean.TRUE.toString()));
 
-    _logger.info(String.format("Created event producer with customCheckpointing=%s", customCheckpointing));
+    _logger.info("Created event producer with customCheckpointing={}", customCheckpointing);
 
     _dynamicMetricsManager = DynamicMetricsManager.getInstance();
     // provision some metrics to force them to create

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -54,8 +54,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
   @Override
   public Map<String, Set<DatastreamTask>> assign(List<DatastreamGroup> datastreams, List<String> instances,
       Map<String, Set<DatastreamTask>> currentAssignment) {
-    LOG.info(String.format("Assign called with datastreams: %s, instances: %s, currentAssignment: %s", datastreams,
-        instances, currentAssignment));
+    LOG.info("Assign called with datastreams: {}, instances: {}, currentAssignment: {}", datastreams,
+        instances, currentAssignment);
     // if there are no live instances, return empty assignment
     if (instances.size() == 0) {
       return new HashMap<>();
@@ -76,9 +76,9 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
       assignment.get(instanceName).add(datastreamTasks.get(i));
     }
 
-    LOG.info(String.format("Datastream Groups: %s, instances: %s, currentAssignment: %s, NewAssignment: %s",
+    LOG.info("Datastream Groups: {}, instances: {}, currentAssignment: {}, NewAssignment: {}",
         datastreams.stream().map(DatastreamGroup::getTaskPrefix).collect(Collectors.toList()), instances,
-        currentAssignment, assignment));
+        currentAssignment, assignment);
 
     return assignment;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerComponentHealthResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/diagnostics/ServerComponentHealthResources.java
@@ -67,7 +67,7 @@ public class ServerComponentHealthResources extends CollectionResourceTemplate<S
       @QueryParam("scope") String componentScope,  // Espresso, EspressoBootstrap and etc.
       @QueryParam("content") @Optional String componentInputs) {
 
-    LOG.info("Restli getAllStatus request with name: %s, type: %s and content: %s.", componentType, componentScope,
+    LOG.info("Restli getAllStatus request with name: {}, type: {} and content: {}.", componentType, componentScope,
         componentInputs);
     DiagnosticsAware component = getComponent(componentType, componentScope);
     if (component != null) {
@@ -88,7 +88,7 @@ public class ServerComponentHealthResources extends CollectionResourceTemplate<S
       @QueryParam("scope") String componentScope,
       @QueryParam("content") @Optional String componentInputs) {
 
-    LOG.info("Restli getStatus request with name: %s, type: %s and content: %s.", componentType, componentScope,
+    LOG.info("Restli getStatus request with name: {}, type: {} and content: {}.", componentType, componentScope,
         componentInputs);
 
     ServerComponentHealth serverComponentHealth = new ServerComponentHealth();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -344,7 +344,7 @@ public class ZkAdapter {
       List<String> deadTasks = allTasks.stream().filter(tasksToDelete::contains).collect(Collectors.toList());
 
       if (deadTasks.size() > 0) {
-        LOG.info(String.format("Cleaning up deprecated connector tasks: %s for connector: %s", deadTasks, connector));
+        LOG.info("Cleaning up deprecated connector tasks: {} for connector: {}", deadTasks, connector);
         for (String task : deadTasks) {
           deleteConnectorTask(connector, task);
         }
@@ -848,7 +848,7 @@ public class ZkAdapter {
     if (_zkclient.exists(lockPath)) {
       owner = _zkclient.ensureReadData(lockPath);
       if (owner.equals(_instanceName)) {
-        LOG.info(String.format("%s already owns the lock on %s", _instanceName, task));
+        LOG.info("{} already owns the lock on {}", _instanceName, task);
         return;
       }
 
@@ -857,7 +857,7 @@ public class ZkAdapter {
 
     if (!_zkclient.exists(lockPath)) {
       _zkclient.createEphemeral(lockPath, _instanceName);
-      LOG.info(String.format("%s successfully acquired the lock on %s", _instanceName, task));
+      LOG.info("{} successfully acquired the lock on {}", _instanceName, task);
     } else {
       String msg = String.format("%s failed to acquire task %s in %dms, current owner: %s", _instanceName, task,
           timeout.toMillis(), owner);
@@ -868,18 +868,18 @@ public class ZkAdapter {
   public void releaseTask(DatastreamTaskImpl task) {
     String lockPath = KeyBuilder.datastreamTaskLock(_cluster, task.getConnectorType(), task.getDatastreamTaskName());
     if (!_zkclient.exists(lockPath)) {
-      LOG.info(String.format("There is no lock on %s", task));
+      LOG.info("There is no lock on {}", task);
       return;
     }
 
     String owner = _zkclient.ensureReadData(lockPath);
     if (!owner.equals(_instanceName)) {
-      LOG.warn(String.format("%s does not have the lock on %s", _instanceName, task));
+      LOG.warn("{} does not have the lock on {}", _instanceName, task);
       return;
     }
 
     _zkclient.delete(lockPath);
-    LOG.info(String.format("%s successfully released the lock on %s", _instanceName, task));
+    LOG.info("{} successfully released the lock on {}", _instanceName, task);
   }
 
   /**
@@ -957,8 +957,8 @@ public class ZkAdapter {
     // due to datastream add or delete.
     @Override
     public void handleDataChange(String dataPath, Object data) throws Exception {
-      LOG.info(String.format("ZkBackedDMSDatastreamList::Received Data change notification on the path %s, data %s.",
-          dataPath, data.toString()));
+      LOG.info("ZkBackedDMSDatastreamList::Received Data change notification on the path {}, data {}.",
+          dataPath, data.toString());
       if (_listener != null) {
         _listener.onDatastreamAddOrDrop();
       }
@@ -1084,8 +1084,7 @@ public class ZkAdapter {
     // updated, but the list of tasks may remain the same
     @Override
     public void handleDataChange(String dataPath, Object data) throws Exception {
-      LOG.info(String.format("ZkBackedTaskListProvider::Received Data change notification on the path %s, data %s.",
-          dataPath, data));
+      LOG.info("ZkBackedTaskListProvider::Received Data change notification on the path {}, data {}.", dataPath, data);
       if (_listener != null && data != null && !data.toString().isEmpty()) {
         // only care about the data change when there is an update in the data node
         _listener.onDatastreamUpdate();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -877,7 +877,7 @@ public class TestCoordinator {
 
     List<String> sortedList = new ArrayList<>(instances);
     Collections.sort(sortedList);
-    LOG.info(String.format("Live instances %s", sortedList));
+    LOG.info("Live instances {}", sortedList);
 
     Assert.assertEquals(instances.size(), concurrencyLevel, String.format("Live instances %s", sortedList));
     zkClient.close();

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/TestEventProducingConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/TestEventProducingConnector.java
@@ -93,8 +93,7 @@ public class TestEventProducingConnector implements Connector {
 
   @Override
   public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
-    LOG.info(String.format("onAssignmentChange called with tasks %s, existing assignment %s", tasks,
-        _tasksAssigned.keySet()));
+    LOG.info("onAssignmentChange called with tasks {}, existing assignment {}", tasks, _tasksAssigned.keySet());
     for (DatastreamTask task : tasks) {
       if (_tasksAssigned.containsKey(task)) {
         continue;
@@ -109,7 +108,7 @@ public class TestEventProducingConnector implements Connector {
         _tasksAssigned.entrySet().stream().filter(x -> !tasks.contains(x.getKey())).collect(Collectors.toList());
 
     tasksToRemove.forEach((x) -> {
-      LOG.info(String.format("Task %s is reassigned from the current instance, cancelling the producer", x.getKey()));
+      LOG.info("Task {} is reassigned from the current instance, cancelling the producer", x.getKey());
       x.getValue().cancel(true);
       while (!x.getValue().isDone()) {
         Thread.yield();
@@ -117,7 +116,7 @@ public class TestEventProducingConnector implements Connector {
 
       _tasksAssigned.remove(x.getKey());
 
-      LOG.info(String.format("Producer corresponding to the task %s has been stopped", x.getKey()));
+      LOG.info("Producer corresponding to the task {} has been stopped", x.getKey());
     });
   }
 
@@ -196,7 +195,7 @@ public class TestEventProducingConnector implements Connector {
   @Override
   public void initializeDatastream(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
-    LOG.info(String.format("initialize called for datastream %s with datastreams %s", stream, allDatastreams));
+    LOG.info("initialize called for datastream {} with datastreams {}", stream, allDatastreams);
   }
 
   @Override

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/InMemoryTransportProvider.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/InMemoryTransportProvider.java
@@ -6,7 +6,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.server.api.transport.SendCallback;
@@ -14,7 +15,7 @@ import com.linkedin.datastream.server.api.transport.TransportProvider;
 
 
 public class InMemoryTransportProvider implements TransportProvider {
-  private static final Logger LOG = Logger.getLogger(InMemoryTransportProvider.class);
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryTransportProvider.class);
 
   public HashMap<String, Integer> getTopics() {
     return _topics;
@@ -42,7 +43,7 @@ public class InMemoryTransportProvider implements TransportProvider {
       _recordsReceived.put(connectionString, new ArrayList<>());
     }
 
-    LOG.info(String.format("Adding record with %d events to topic %s", record.getEvents().size(), topicName));
+    LOG.info("Adding record with {} events to topic {}", record.getEvents().size(), topicName);
 
     _recordsReceived.get(connectionString).add(record);
   }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/InMemoryTransportProviderAdmin.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/InMemoryTransportProviderAdmin.java
@@ -4,7 +4,8 @@ import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
@@ -19,7 +20,7 @@ public class InMemoryTransportProviderAdmin implements TransportProviderAdmin {
 
   }
 
-  private static final Logger LOG = Logger.getLogger(InMemoryTransportProviderAdminFactory.class);
+  private static final Logger LOG = LoggerFactory.getLogger(InMemoryTransportProviderAdminFactory.class);
   private static final int DEFAULT_NUMBER_PARTITIONS = 1;
 
   private static InMemoryTransportProvider _transportProvider = new InMemoryTransportProvider();
@@ -37,8 +38,7 @@ public class InMemoryTransportProviderAdmin implements TransportProviderAdmin {
     String topicName = datastream.getDestination().getConnectionString();
     int numberOfPartitions = datastream.getDestination().getPartitions();
     if (_transportProvider.getTopics().containsKey(topicName)) {
-      String msg = String.format("Topic %s already exists", topicName);
-      LOG.warn(msg);
+      LOG.warn("Topic {} already exists", topicName);
     }
     _transportProvider.addTopic(topicName, numberOfPartitions);
   }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/ListBackedTransportProvider.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/ListBackedTransportProvider.java
@@ -45,7 +45,7 @@ public class ListBackedTransportProvider implements TransportProvider {
 
   @Override
   public synchronized void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
-    LOG.info(String.format("send called on destination %s with %d events", destination, record.getEvents().size()));
+    LOG.info("send called on destination {} with {} events", destination, record.getEvents().size());
     _allEvents.add(record.getEvents());
     _allRecords.add(record);
   }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/RandomGenericRecordGenerator.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/event/generator/RandomGenericRecordGenerator.java
@@ -6,12 +6,13 @@ import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class RandomGenericRecordGenerator {
   public final static String MODULE = RandomGenericRecordGenerator.class.getName();
-  public final static Logger LOG = Logger.getLogger(MODULE);
+  public final static Logger LOG = LoggerFactory.getLogger(MODULE);
   Schema schema;
 
   /*


### PR DESCRIPTION
…use {}

Fix log lines like the following, and change others to use {} instead of String.format %s.

2018/09/05 19:52:38.536 INFO [KafkaMirrorMakerConnectorTask] [KafkaMirrorMaker task thread mm_prod-ltx1_queuing_prod-lor1_agg-queuing_e907aa95-be71-48ac-b7ae-c465be925e8e 22] [brooklin-service] [] Found overridden group ID for Kafka datastream task: e907aa95-be71-48ac-b7ae-c465be925e8e . Overridden group id: mm_prod-lor1_aggregate-queuing Datastreams: %s

2018/09/05 21:35:18.109 INFO [ServerComponentHealthResources] [qtp1152281446-94] [brooklin-service] [] Restli getStatus request with name: %s, type: %s and content: %s.