### PR TITLE
Fix updateDatastreams validation to consider taskPrefix instead of de…

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -211,11 +211,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
     // a group partially
     Set<String> updatedStreams = datastreamMap.keySet();
     Datastream updatedStream = datastreamsToUpdate.get(0);
-    Set<String> existingStreams = _store.getAllDatastreams().map(ds -> _store.getDatastream(ds)).filter(ds ->
-        ds.hasConnectorName() && ds.getConnectorName().equals(updatedStream.getConnectorName())
-               && ds.hasDestination() && updatedStream.getDestination().equals(ds.getDestination())
-               && ds.hasStatus() && ds.getStatus() != DatastreamStatus.DELETING).map(Datastream::getName)
-        .collect(Collectors.toSet());
+    Set<String> existingStreams =
+        getGroupedDatastreams(updatedStream).stream().map(Datastream::getName).collect(Collectors.toSet());
     if (!updatedStreams.equals(existingStreams)) {
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, CALL_ERROR, 1);
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST,

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -454,6 +454,7 @@ public class TestDatastreamResources {
 
     // Create another datastream that gets deduped to datastream1.
     Datastream originalDatastream2 = generateDatastream(2);
+    originalDatastream2.getDestination().setConnectionString("a different destination");
     final Datastream datastream2 = createAndWaitUntilInitialized(resource, originalDatastream2);
 
     // Update metadata for all streams in the group. It is up to the connector to validate if metadata updates are


### PR DESCRIPTION
…stination as dupe

Comparing taskPrefix is a better way to check if 2 datastreams are in the same group. Destination should not be used for this, since destinations could be same for 2 MirrorMaker streams even though they are distinct, non-dupe streams.