### PR TITLE
Fix an issue which will cause an assignment fail if leader is changed

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 
 import org.apache.commons.lang.Validate;
 import org.codehaus.jackson.annotate.JsonIgnore;
+import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -74,6 +75,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
   private String _transportProviderName;
   private SerDeSet _destinationSerDes = new SerDeSet(null, null, null);
 
+  @TestOnly
   public DatastreamTaskImpl() {
     _partitions = new ArrayList<>();
   }
@@ -107,7 +109,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
         _partitions.add(0);
       }
     }
-
     LOG.info("Created new DatastreamTask " + this);
   }
 
@@ -180,10 +181,15 @@ public class DatastreamTaskImpl implements DatastreamTask {
    * between onAssignmentChange (because of datastream update for example). It's connector's
    * responsibility to re-fetch the datastream list even when it receives the exact same set
    * of datastream tasks.
+   *
+   * TODO: Datastream might be null if derived from zk or json, we need a better abstraction here
    */
   @JsonIgnore
   @Override
   public List<Datastream> getDatastreams() {
+    if (_datastreams == null || _datastreams.size() == 0) {
+      throw new IllegalArgumentException("Fetch datastream from zk stored task is not allowed");
+    }
     return Collections.unmodifiableList(_datastreams);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -149,7 +149,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
         // Look for tasks that can be move from the large instance to the small instance
         for (DatastreamTask task : new ArrayList<>(newAssignment.get(largeInstance))) {
           newAssignment.get(largeInstance).remove(task);
-          newAssignment.get(smallInstance).add(new DatastreamTaskImpl(task.getDatastreams()));
+          newAssignment.get(smallInstance).add(task);
           if (newAssignment.get(smallInstance).size() >= minTasksPerInstance
               || newAssignment.get(largeInstance).size() <= minTasksPerInstance + 1) {
             break;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -33,4 +33,15 @@ public class TestDatastreamTask {
     String json = JsonUtils.toJson(DatastreamTaskStatus.error("test msg"));
     JsonUtils.fromJson(json, DatastreamTaskStatus.class);
   }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testErrorFromZkJson() throws Exception {
+    Datastream stream = DatastreamTestUtils.createDatastream("dummy", "dummy", "dummy");
+    stream.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(stream));
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(stream));
+    String json = task.toJson();
+    DatastreamTaskImpl task2 = DatastreamTaskImpl.fromJson(json);
+    task2.getDatastreams();
+  }
 }


### PR DESCRIPTION
Fix an issue which will cause an assignment fail if leader is changed and the previous assignment is read from zk store

Test done with gradle build and unit test