### PR TITLE
Refactor DatastreamTaskImpl to provide better abstraction

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -1,17 +1,14 @@
 package com.linkedin.datastream.server;
 
-import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.UUID;
 
 import org.apache.commons.lang.Validate;
-import org.codehaus.jackson.annotate.JsonIgnore;
 import org.jetbrains.annotations.TestOnly;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -22,7 +19,6 @@ import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.JsonUtils;
-import com.linkedin.datastream.common.LogUtils;
 import com.linkedin.datastream.serde.SerDeSet;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 
@@ -38,9 +34,9 @@ import com.linkedin.datastream.server.zk.ZkAdapter;
  * Datastream object, DatastreamTask also contains a key-value store Properties. This allows the assignment
  * strategy to attach extra parameters.
  *
- * <p>DatastreamTask has a unique name called _datastreamtaskName. This is used as the znode name in zookeeper
- * This should be unique for each instance of DatastreamTask, especially in the case when a Datastream is
- * split into multiple DatastreamTasks. This is because we will have a state associated with each DatastreamTask.
+ * <p>DatatsteamTask consists of two parts, one is InternalDatastreamTask, which is stored into zookeeper, and
+ * the other stats variable which are volatile and may be gone during leader change</p>
+ *
  *
  */
 public class DatastreamTaskImpl implements DatastreamTask {
@@ -50,34 +46,17 @@ public class DatastreamTaskImpl implements DatastreamTask {
   private static final String STATUS = "STATUS";
   private volatile List<Datastream> _datastreams;
 
+  private final InternalDatastreamTask _internalDatastreamTask;
+
   private HashMap<Integer, String> _checkpoints = new HashMap<>();
-
-  // connector type. Type of the connector to be used for reading the change capture events
-  // from the source, e.g. Oracle-Change, Espresso-Change, Oracle-Bootstrap, Espresso-Bootstrap,
-  // Mysql-Change etc..
-  private String _connectorType;
-
-  // The Id of the datastream task. It is a string that will represent one assignable element of
-  // datastream. By default, the value is empty string, representing that the DatastreamTask is by default
-  // mapped to one Datastream. Each of the _id value will be represented in zookeeper
-  // under /{cluster}/connectors/{connectorType}/{datastream}/{id}.
-  private String _id = "";
-
-  private String _taskPrefix;
-
-  // List of partitions the task covers.
-  private List<Integer> _partitions;
-
   private ZkAdapter _zkAdapter;
-
-  private Map<String, String> _properties = new HashMap<>();
   private DatastreamEventProducer _eventProducer;
   private String _transportProviderName;
   private SerDeSet _destinationSerDes = new SerDeSet(null, null, null);
 
   @TestOnly
   public DatastreamTaskImpl() {
-    _partitions = new ArrayList<>();
+    _internalDatastreamTask = new InternalDatastreamTask();
   }
 
   public DatastreamTaskImpl(List<Datastream> datastreams) {
@@ -89,29 +68,45 @@ public class DatastreamTaskImpl implements DatastreamTask {
     Validate.notNull(id, "null id");
 
     Datastream datastream = datastreams.get(0);
-    _connectorType = datastream.getConnectorName();
-    _transportProviderName = datastream.getTransportProviderName();
-    _datastreams = datastreams;
-    _taskPrefix = datastream.getMetadata().get(DatastreamMetadataConstants.TASK_PREFIX);
-    _id = id;
-    _partitions = new ArrayList<>();
+    String taskPrefix = datastream.getMetadata().get(DatastreamMetadataConstants.TASK_PREFIX);
+    List<Integer> defaultPartitions = new ArrayList<>();
     if (partitions != null && partitions.size() > 0) {
-      _partitions.addAll(partitions);
+      defaultPartitions.addAll(partitions);
     } else {
       // Add [0, N) if source has N partitions
       // Or add a default partition 0 otherwise
       if (datastream.hasSource() && datastream.getSource().hasPartitions()) {
         int numPartitions = datastream.getSource().getPartitions();
         for (int i = 0; i < numPartitions; i++) {
-          _partitions.add(i);
+          defaultPartitions.add(i);
         }
       } else {
-        _partitions.add(0);
+        defaultPartitions.add(0);
       }
     }
-    LOG.info("Created new DatastreamTask " + this);
+    _transportProviderName = datastream.getTransportProviderName();
+    _internalDatastreamTask = new InternalDatastreamTask(id, datastream.getConnectorName(), taskPrefix, defaultPartitions);
+    LOG.info("Created new DatastreamTask ", _internalDatastreamTask.toString());
+    _datastreams = datastreams;
   }
 
+  public DatastreamTaskImpl(InternalDatastreamTask internalDatastreamTask, List<Datastream> datastreams) {
+    Validate.notEmpty(datastreams, "empty datastream");
+    Datastream datastream = datastreams.get(0);
+    String taskPrefix = datastream.getMetadata().get(DatastreamMetadataConstants.TASK_PREFIX);
+    if (!taskPrefix.equals(internalDatastreamTask.getTaskPrefix())) {
+      LOG.warn("datastream prefix doesn't match to the task got from zk");
+    }
+    _internalDatastreamTask = internalDatastreamTask;
+    _datastreams = datastreams;
+    _transportProviderName = _datastreams.get(0).getTransportProviderName();
+    _internalDatastreamTask.setConnectorType(_datastreams.get(0).getConnectorName());
+  }
+
+  public DatastreamTaskImpl(InternalDatastreamTask internalDatastreamTask, List<Datastream> datastreams, ZkAdapter zkAdapter) {
+    this(internalDatastreamTask, datastreams);
+    _zkAdapter = zkAdapter;
+  }
   /**
    * @return the prefix of the task names that will be created for this datastream.
    */
@@ -119,58 +114,21 @@ public class DatastreamTaskImpl implements DatastreamTask {
     return datastream.getName();
   }
 
-  /**
-   * Construct DatastreamTask from json string
-   * @param  json JSON string of the task
-   */
-  public static DatastreamTaskImpl fromJson(String json) {
-    DatastreamTaskImpl task = JsonUtils.fromJson(json, DatastreamTaskImpl.class);
-    LOG.debug("Loaded existing DatastreamTask: {}", task);
-    return task;
-  }
-
-  /**
-   * @return DatastreamTask serialized as JSON
-   * @throws IOException
-   */
-  public String toJson() throws IOException {
-    return JsonUtils.toJson(this);
-  }
-
-  @JsonIgnore
-  public String getDatastreamTaskName() {
-    return _id.equals("") ? _taskPrefix : _taskPrefix + "_" + _id;
-  }
-
-  @JsonIgnore
   @Override
   public boolean isUserManagedDestination() {
     return DatastreamUtils.isUserManagedDestination(_datastreams.get(0));
   }
 
-  @JsonIgnore
   @Override
   public DatastreamSource getDatastreamSource() {
     return _datastreams.get(0).getSource();
   }
 
-  @JsonIgnore
   @Override
   public DatastreamDestination getDatastreamDestination() {
     return _datastreams.get(0).getDestination();
   }
 
-  public void setPartitions(List<Integer> partitions) {
-    Validate.notNull(partitions);
-    _partitions = partitions;
-  }
-
-  @Override
-  public List<Integer> getPartitions() {
-    return _partitions;
-  }
-
-  @JsonIgnore
   @Override
   public Map<Integer, String> getCheckpoints() {
     return _checkpoints;
@@ -181,15 +139,9 @@ public class DatastreamTaskImpl implements DatastreamTask {
    * between onAssignmentChange (because of datastream update for example). It's connector's
    * responsibility to re-fetch the datastream list even when it receives the exact same set
    * of datastream tasks.
-   *
-   * TODO: Datastream might be null if derived from zk or json, we need a better abstraction here
    */
-  @JsonIgnore
   @Override
   public List<Datastream> getDatastreams() {
-    if (_datastreams == null || _datastreams.size() == 0) {
-      throw new IllegalArgumentException("Fetch datastream from zk stored task is not allowed");
-    }
     return Collections.unmodifiableList(_datastreams);
   }
 
@@ -197,7 +149,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
   public void acquire(Duration timeout) {
     Validate.notNull(_zkAdapter, "Task is not properly initialized for processing.");
     try {
-      _zkAdapter.acquireTask(this, timeout);
+      _zkAdapter.acquireTask(this.getInternalTask(), timeout);
     } catch (Exception e) {
       LOG.error("Failed to acquire task: " + this, e);
       setStatus(DatastreamTaskStatus.error("Acquire failed, exception: " + e));
@@ -208,17 +160,16 @@ public class DatastreamTaskImpl implements DatastreamTask {
   @Override
   public void release() {
     Validate.notNull(_zkAdapter, "Task is not properly initialized for processing.");
-    _zkAdapter.releaseTask(this);
+    _zkAdapter.releaseTask(this.getInternalTask());
   }
 
   public void setDatastreams(List<Datastream> datastreams) {
     _datastreams = datastreams;
     // destination and connector type should be immutable
     _transportProviderName = _datastreams.get(0).getTransportProviderName();
-    _connectorType = _datastreams.get(0).getConnectorName();
+    _internalDatastreamTask.setConnectorType(_datastreams.get(0).getConnectorName());
   }
 
-  @JsonIgnore
   public DatastreamEventProducer getEventProducer() {
     return _eventProducer;
   }
@@ -231,8 +182,19 @@ public class DatastreamTaskImpl implements DatastreamTask {
     _destinationSerDes = destination;
   }
 
+  @Override
   public String getConnectorType() {
-    return _connectorType;
+    return _internalDatastreamTask.getConnectorType();
+  }
+
+  @Override
+  public String getId() {
+    return _internalDatastreamTask.getId();
+  }
+
+  @Override
+  public String getDatastreamTaskName() {
+    return _internalDatastreamTask.getDatastreamTaskName();
   }
 
   @Override
@@ -240,57 +202,42 @@ public class DatastreamTaskImpl implements DatastreamTask {
     return _transportProviderName;
   }
 
-  public void setTransportProviderName(String transportProviderName) {
-    _transportProviderName = transportProviderName;
+  @Override
+  public List<Integer> getPartitions() {
+    return _internalDatastreamTask.getPartitions();
   }
 
-  public void setConnectorType(String connectorType) {
-    _connectorType = connectorType;
-  }
-
-  public void setId(String id) {
-    _id = id;
-  }
-
-  public String getId() {
-    return _id;
-  }
-
+  @Override
   public String getTaskPrefix() {
-    return _taskPrefix;
+    return _internalDatastreamTask.getTaskPrefix();
   }
 
-  public void setTaskPrefix(String taskPrefix) {
-    _taskPrefix = taskPrefix;
+  public InternalDatastreamTask getInternalTask() {
+    return _internalDatastreamTask;
   }
 
-  @JsonIgnore
   @Override
   public String getState(String key) {
-    return _zkAdapter.getDatastreamTaskStateForKey(this, key);
+    return _zkAdapter.getDatastreamTaskStateForKey(_internalDatastreamTask, key);
   }
 
-  @JsonIgnore
   @Override
   public void saveState(String key, String value) {
     Validate.notEmpty(key, "Key cannot be null or empty");
     Validate.notEmpty(value, "value cannot be null or empty");
-    _zkAdapter.setDatastreamTaskStateForKey(this, key, value);
+    _zkAdapter.setDatastreamTaskStateForKey(_internalDatastreamTask, key, value);
   }
 
-  @JsonIgnore
   @Override
   public SerDeSet getDestinationSerDes() {
     return _destinationSerDes;
   }
 
-  @JsonIgnore
   @Override
   public void setStatus(DatastreamTaskStatus status) {
     saveState(STATUS, JsonUtils.toJson(status));
   }
 
-  @JsonIgnore
   @Override
   public DatastreamTaskStatus getStatus() {
     String statusStr = getState(STATUS);
@@ -309,20 +256,17 @@ public class DatastreamTaskImpl implements DatastreamTask {
       return false;
     }
     DatastreamTaskImpl task = (DatastreamTaskImpl) o;
-    return Objects.equals(_connectorType, task._connectorType) && Objects.equals(_id, task._id) && Objects.equals(
-        _taskPrefix, task._taskPrefix) && Objects.equals(_partitions, task._partitions);
+    return this.getInternalTask().equals(task.getInternalTask());
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_connectorType, _id, _taskPrefix, _partitions);
+    return this.getInternalTask().hashCode();
   }
 
   @Override
   public String toString() {
-    // toString() is mainly for logging purpose, feel free to modify the content/format
-    return String.format("%s(%s), partitions=%s", getDatastreamTaskName(), _connectorType,
-        LogUtils.logNumberArrayInRange(_partitions));
+    return this.getInternalTask().toString();
   }
 
   public void setZkAdapter(ZkAdapter adapter) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/InternalDatastreamTask.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/InternalDatastreamTask.java
@@ -1,0 +1,132 @@
+package com.linkedin.datastream.server;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang.Validate;
+import org.codehaus.jackson.annotate.JsonIgnore;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.linkedin.datastream.common.JsonUtils;
+import com.linkedin.datastream.common.LogUtils;
+
+/**
+ * This is a json serializable datastream task which can be stored into zookeeper
+ *
+ *  <p>InternalDatastreamTask has a unique name from getDatastreamTaskName. This is used as the znode name in zookeeper
+ *  This should be unique for each instance of DatastreamTask, especially in the case when a Datastream is
+ *  split into multiple DatastreamTasks. This is because we will have a state associated with each DatastreamTask.
+ *
+ */
+public class InternalDatastreamTask {
+
+  private static final Logger LOG = LoggerFactory.getLogger(InternalDatastreamTask.class.getName());
+
+  // connector type. Type of the connector to be used for reading the change capture events
+  // from the source, e.g. Oracle-Change, Espresso-Change, Oracle-Bootstrap, Espresso-Bootstrap,
+  // Mysql-Change etc..
+  private String _connectorType;
+
+  // The Id of the datastream task. It is a string that will represent one assignable element of
+  // datastream. By default, the value is empty string, representing that the DatastreamTask is by default
+  // mapped to one Datastream. Each of the _id value will be represented in zookeeper
+  // under /{cluster}/connectors/{connectorType}/{datastream}/{id}.
+  private String _id = "";
+
+  private String _taskPrefix;
+
+  // List of partitions the task covers.
+  private List<Integer> _partitions;
+
+  // constructor for json serialization
+  public InternalDatastreamTask() {
+
+  }
+
+  public InternalDatastreamTask(String id, String connectorType, String taskPrefix, List<Integer> partitions) {
+    _id = id;
+    _connectorType = connectorType;
+    _taskPrefix = taskPrefix;
+    _partitions = partitions;
+  }
+
+  /**
+   * Construct InternalDatastreamTask from json string
+   * @param  json JSON string of the task
+   */
+  public static InternalDatastreamTask fromJson(String json) {
+    InternalDatastreamTask task = JsonUtils.fromJson(json, InternalDatastreamTask.class);
+    LOG.debug("Loaded existing DatastreamTask: {}", task);
+    return task;
+  }
+
+  /**
+   * @return InternalDatastreamTask serialized as JSON
+   */
+  public String toJson() {
+    return JsonUtils.toJson(this);
+  }
+
+  @JsonIgnore
+  public String getDatastreamTaskName() {
+    return _id.equals("") ? _taskPrefix : _taskPrefix + "_" + _id;
+  }
+
+  public void setPartitions(List<Integer> partitions) {
+    Validate.notNull(partitions);
+    _partitions = partitions;
+  }
+
+  public List<Integer> getPartitions() {
+    return _partitions;
+  }
+
+  public String getConnectorType() {
+    return _connectorType;
+  }
+
+  public void setConnectorType(String connectorType) {
+    _connectorType = connectorType;
+  }
+
+  public void setId(String id) {
+    _id = id;
+  }
+
+  public String getId() {
+    return _id;
+  }
+
+  public String getTaskPrefix() {
+    return _taskPrefix;
+  }
+
+  public void setTaskPrefix(String taskPrefix) {
+    _taskPrefix = taskPrefix;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    InternalDatastreamTask task = (InternalDatastreamTask) o;
+    return Objects.equals(_connectorType, task._connectorType) && Objects.equals(_id, task._id) && Objects.equals(
+        _taskPrefix, task._taskPrefix) && Objects.equals(_partitions, task._partitions);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_connectorType, _id, _taskPrefix, _partitions);
+  }
+
+  @Override
+  public String toString() {
+    // toString() is mainly for logging purpose, feel free to modify the content/format
+    return String.format("%s(%s), partitions=%s", getDatastreamTaskName(), _connectorType,
+        LogUtils.logNumberArrayInRange(_partitions));
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/providers/ZookeeperCheckpointProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/providers/ZookeeperCheckpointProvider.java
@@ -21,6 +21,7 @@ import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.DatastreamTask;
+import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 
 
@@ -83,7 +84,7 @@ public class ZookeeperCheckpointProvider implements CheckpointProvider {
       long startTime = System.currentTimeMillis();
       Map<Integer, String> checkpoints = mergeAndGetSafeCheckpoints(task, taskMap);
 
-      _zkAdapter.setDatastreamTaskStateForKey(task, CHECKPOINT_KEY_NAME, JsonUtils.toJson(checkpoints));
+      _zkAdapter.setDatastreamTaskStateForKey(((DatastreamTaskImpl) task).getInternalTask(), CHECKPOINT_KEY_NAME, JsonUtils.toJson(checkpoints));
       _dynamicMetricsManager.createOrUpdateMeter(MODULE, NUM_CHECKPOINT_COMMITS, 1);
       _dynamicMetricsManager.createOrUpdateHistogram(MODULE, CHECKPOINT_COMMIT_LATENCY_MS,
           System.currentTimeMillis() - startTime);
@@ -132,7 +133,7 @@ public class ZookeeperCheckpointProvider implements CheckpointProvider {
   }
 
   private Map<Integer, String> getCheckpoint(DatastreamTask task) {
-    String checkpoint = _zkAdapter.getDatastreamTaskStateForKey(task, CHECKPOINT_KEY_NAME);
+    String checkpoint = _zkAdapter.getDatastreamTaskStateForKey(((DatastreamTaskImpl) task).getInternalTask(), CHECKPOINT_KEY_NAME);
     if (StringUtils.isNotBlank(checkpoint)) {
       return JsonUtils.fromJson(checkpoint, _hashMapTypeReference);
     } else {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -325,8 +325,6 @@ public class TestCoordinator {
     //    Assert.assertEquals(zkClient.readData(datastream1CounterPath), "2");
     //    Assert.assertEquals(zkClient.readData(datastream2CounterPath), "1");
     //
-    Thread.sleep(1000 * 60);
-
     //
     // clean up
     //

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -19,9 +19,10 @@ public class TestDatastreamTask {
     stream.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(stream));
 
     DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(stream));
-    String json = task.toJson();
+    String json = task.getInternalTask().toJson();
 
-    DatastreamTaskImpl task2 = DatastreamTaskImpl.fromJson(json);
+    InternalDatastreamTask internalDatastreamTask = InternalDatastreamTask.fromJson(json);
+    DatastreamTaskImpl task2 = new DatastreamTaskImpl(internalDatastreamTask, Collections.singletonList(stream));
 
     Assert.assertEquals(task2.getTaskPrefix(), stream.getName());
     Assert.assertTrue(task2.getDatastreamTaskName().contains(stream.getName()));
@@ -32,16 +33,5 @@ public class TestDatastreamTask {
   public void testTaskStatusJsonIO() {
     String json = JsonUtils.toJson(DatastreamTaskStatus.error("test msg"));
     JsonUtils.fromJson(json, DatastreamTaskStatus.class);
-  }
-
-  @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testErrorFromZkJson() throws Exception {
-    Datastream stream = DatastreamTestUtils.createDatastream("dummy", "dummy", "dummy");
-    stream.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(stream));
-
-    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(stream));
-    String json = task.toJson();
-    DatastreamTaskImpl task2 = DatastreamTaskImpl.fromJson(json);
-    task2.getDatastreams();
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
@@ -67,17 +67,17 @@ public class TestZookeeperCheckpointProvider {
     Datastream ds1 = generateDatastream(1);
     ds1.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(ds1));
     DatastreamTaskImpl datastreamTask1 = new DatastreamTaskImpl(Collections.singletonList(ds1));
-    datastreamTask1.setId("dt1");
+    datastreamTask1.getInternalTask().setId("dt1");
 
     Datastream ds2 = generateDatastream(2);
     ds2.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(ds1));
     DatastreamTaskImpl datastreamTask2 = new DatastreamTaskImpl(Collections.singletonList(ds2));
-    datastreamTask2.setId("dt2");
+    datastreamTask2.getInternalTask().setId("dt2");
 
     checkpointProvider.updateCheckpoint(datastreamTask1, 0, "checkpoint1");
     checkpointProvider.updateCheckpoint(datastreamTask2, 0, "checkpoint2");
 
-    adapter.setDatastreamTaskStateForKey(datastreamTask1, ZookeeperCheckpointProvider.CHECKPOINT_KEY_NAME, "");
+    adapter.setDatastreamTaskStateForKey(datastreamTask1.getInternalTask(), ZookeeperCheckpointProvider.CHECKPOINT_KEY_NAME, "");
     checkpointProvider.unassignDatastreamTask(datastreamTask1);
 
     Map<Integer, String> commitedCheckpoints1 = checkpointProvider.getSafeCheckpoints(datastreamTask1);
@@ -94,10 +94,10 @@ public class TestZookeeperCheckpointProvider {
     adapter.connect();
     ZookeeperCheckpointProvider checkpointProvider = new ZookeeperCheckpointProvider(adapter);
     DatastreamTaskImpl datastreamTask1 = new DatastreamTaskImpl(Collections.singletonList(generateDatastream(1)));
-    datastreamTask1.setId("dt1");
+    datastreamTask1.getInternalTask().setId("dt1");
 
     DatastreamTaskImpl datastreamTask2 = new DatastreamTaskImpl(Collections.singletonList(generateDatastream(2)));
-    datastreamTask2.setId("dt2");
+    datastreamTask2.getInternalTask().setId("dt2");
 
     checkpointProvider.updateCheckpoint(datastreamTask1, 0, "checkpoint1");
     checkpointProvider.updateCheckpoint(datastreamTask2, 0, "checkpoint2");


### PR DESCRIPTION
Refactor DatastreamTaskImpl into two parts, one is InteralDatastreamTask which can be stored and retrieved from zk, and other volatile fields such as datastreams which are decorated and maintained by Coordintor. The Zk adaptor is only responsible for storing info related to InternalDatastreamTask

passed unit test