### PR TITLE
Add ability to extend TableMetadata to provide custom metadata

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/DatabaseSource.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/avrogenerator/DatabaseSource.java
@@ -1,7 +1,9 @@
 package com.linkedin.datastream.avrogenerator;
 
 import java.sql.SQLException;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.jetbrains.annotations.NotNull;
@@ -226,6 +228,13 @@ public abstract class DatabaseSource {
 
     public int getScale() {
       return _scale;
+    }
+
+    /**
+     * @return a map of K,V pairs to include in the field metadata, besides the default fields included in this class
+     */
+    public Map<String, String> getMetadataMap() {
+      return Collections.emptyMap();
     }
   }
 }

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestFieldMetadata.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestFieldMetadata.java
@@ -1,5 +1,6 @@
 package com.linkedin.datastream.avrogenerator;
 
+import java.util.Map;
 import java.util.Optional;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -16,7 +17,6 @@ public class TestFieldMetadata {
     String meta = "dbFieldName=AUTHOR;dbFieldPosition=26;dbFieldType=NVARCHAR2;";
 
     FieldMetadata fieldMetadata = FieldMetadata.fromString(meta);
-
     Assert.assertEquals(fieldMetadata.getDbFieldName(), "AUTHOR", "Incorrectly parsed dbFieldName");
     Assert.assertEquals(fieldMetadata.getDbFieldPosition(), 26, "Incorrectly parsed dbFieldPosition");
     Assert.assertEquals(fieldMetadata.getDbFieldType(), Types.NVARCHAR2, "Incorrectly parsed dbFieldType");
@@ -26,7 +26,6 @@ public class TestFieldMetadata {
     // with precision and scale
     meta = "dbFieldName=WEIGHT;dbFieldPosition=1;dbFieldType=FLOAT;numberScale=2;numberPrecision=3;";
     fieldMetadata = FieldMetadata.fromString(meta);
-
     Assert.assertEquals(fieldMetadata.getDbFieldName(), "WEIGHT", "Incorrectly parsed dbFieldName");
     Assert.assertEquals(fieldMetadata.getDbFieldPosition(), 1, "Incorrectly parsed dbFieldPosition");
     Assert.assertEquals(fieldMetadata.getDbFieldType(), Types.FLOAT, "Incorrectly parsed dbFieldType");
@@ -36,8 +35,18 @@ public class TestFieldMetadata {
     meta = "dbFieldName=ARTICLE;dbFieldPosition=1;dbFieldType=LONG RAW;";
     fieldMetadata = FieldMetadata.fromString(meta);
     Assert.assertEquals(fieldMetadata.getDbFieldType(), Types.LONG_RAW, "Incorrectly parsed dbFieldType");
+
+    // with extra metadata
+    meta = "dbFieldName=WEIGHT;dbFieldPosition=1;dbFieldType=FLOAT;numberScale=2;numberPrecision=3;extraMetadataField=long";
+    fieldMetadata = FieldMetadata.fromString(meta);
+    Assert.assertEquals(fieldMetadata.getDbFieldName(), "WEIGHT", "Incorrectly parsed dbFieldName");
+    Map<String, String> map = FieldMetadata.parseMetadata(meta);
+    Assert.assertEquals("WEIGHT", map.get("dbFieldName"));
+    Assert.assertEquals("long", map.get("extraMetadataField"));
   }
 
+
+  @Test
   public void testFromStringNegative() throws Exception {
     String meta;
     FieldMetadata fieldMetadata;

--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
@@ -1,7 +1,9 @@
 package com.linkedin.datastream.avrogenerator;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import org.jetbrains.annotations.NotNull;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -72,5 +74,32 @@ public class TestOraclePrimitive {
 
     Assert.assertEquals(types[0], "null");
     Assert.assertEquals(types[1], "long");
+  }
+
+  @Test
+  public void testTableMetadataWithMetadataMap() {
+    DatabaseSource.TableMetadata tableMetadata =
+        new TestTableMetadata("NUMBER", "VALUE", DatabaseSource.TableMetadata.NOT_NULLABLE, 0, 0, "long");
+    OraclePrimitiveType primitive =
+        new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NOT_NULLABLE, 0, 0, tableMetadata);
+    Assert.assertEquals(primitive.getMetadata(),
+        "dbFieldType=NUMBER;nullable=N;numberScale=0;numberPrecision=0;extraMetaField=long;");
+  }
+
+  public class TestTableMetadata extends DatabaseSource.TableMetadata {
+    public static final String EXTRA_META_FIELD = "extraMetaField";
+    private final Map<String, String> _metaMap;
+
+    public TestTableMetadata(@NotNull String colTypeName, @NotNull String colName, @NotNull String nullable,
+        int precision, int scale, String extraMetaField) {
+      super(colTypeName, colName, nullable, precision, scale);
+      _metaMap = new HashMap<>();
+      _metaMap.put(EXTRA_META_FIELD, extraMetaField);
+    }
+
+    @Override
+    public Map<String, String> getMetadataMap() {
+      return _metaMap;
+    }
   }
 }


### PR DESCRIPTION
TableMetadata now exposes a method so that users of SchemaGenerator can inject metadata into the schema.