### PR TITLE
Periodically log number of records processed even if count is 0

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -296,11 +296,14 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
           _startedLatch.countDown();
         }
 
+        int recordsPolled = 0;
         if (records != null && !records.isEmpty()) {
           Instant readTime = Instant.now();
           processRecords(records, readTime);
-          trackEventsProcessedProgress(records.count());
+          recordsPolled = records.count();
         }
+        trackEventsProcessedProgress(recordsPolled);
+
       } // end while loop
 
       // shutdown


### PR DESCRIPTION
Before, we were only printing the log only if events polled was greater than 0. It is useful to periodically print the number of records processed, even when no new events were polled. Now, we will see logs like:

"Processed 0 records in 63 seconds for datastream testDatastream"