### PR TITLE
dbFieldType should reflect actual Oracle column type instead of avro …

### DIFF
--- a/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/avrogenerator/TestOraclePrimitive.java
@@ -57,13 +57,76 @@ public class TestOraclePrimitive {
     Assert.assertEquals(primitive.getMetadata(), "dbFieldType=VARCHAR2;nullable=Y;");
 
     primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NULLABLE, 10, 10);
-    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=DOUBLE;nullable=Y;numberScale=10;numberPrecision=10;");
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=Y;numberScale=10;numberPrecision=10;");
 
     primitive = new OraclePrimitiveType("NUMBER", DatabaseSource.TableMetadata.NOT_NULLABLE, -127, 0);
     Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=N;numberScale=-127;numberPrecision=0;");
 
     primitive = new OraclePrimitiveType("TIMESTAMP", DatabaseSource.TableMetadata.NULLABLE, -127, 0);
     Assert.assertEquals(primitive.getMetadata(), "dbFieldType=TIMESTAMP;nullable=Y;");
+  }
+
+  @Test
+  public void testNumberFieldMappings() {
+    // NUMBER with scale > 0 and scale <= 6 should resolve to Avro float
+    OraclePrimitiveType primitive = new OraclePrimitiveType(Types.NUMBER.name(), DatabaseSource.TableMetadata.NULLABLE, 4, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=Y;numberScale=4;numberPrecision=0;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.FLOAT.getAvroType());
+
+    // NUMBER with scale > 0 and scale <= 17 should resolve to Avro double
+    primitive = new OraclePrimitiveType(Types.NUMBER.name(), DatabaseSource.TableMetadata.NULLABLE, 16, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=Y;numberScale=16;numberPrecision=0;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.DOUBLE.getAvroType());
+
+    // NUMBER with precision > 9 and scale <= 0 should resolve to Avro long
+    primitive = new OraclePrimitiveType(Types.NUMBER.name(), DatabaseSource.TableMetadata.NULLABLE, 0, 10);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=Y;numberScale=0;numberPrecision=10;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.LONG.getAvroType());
+
+    // NUMBER with precision <= 9 and scale <= 0 should resolve to Avro int
+    primitive = new OraclePrimitiveType(Types.NUMBER.name(), DatabaseSource.TableMetadata.NULLABLE, 0, 3);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=Y;numberScale=0;numberPrecision=3;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.INTEGER.getAvroType());
+
+    // NUMBER with scale == 0 and scale <= 0 should resolve to Avro string
+    primitive = new OraclePrimitiveType(Types.NUMBER.name(), DatabaseSource.TableMetadata.NULLABLE, 0, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=NUMBER;nullable=Y;numberScale=0;numberPrecision=0;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.NUMBER.getAvroType());
+
+    // FLOAT should resolve to Avro float
+    primitive = new OraclePrimitiveType(Types.FLOAT.name(), DatabaseSource.TableMetadata.NULLABLE, 126, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=FLOAT;nullable=Y;numberScale=126;numberPrecision=0;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.FLOAT.getAvroType());
+
+    // DOUBLE should resolve to Avro double
+    primitive = new OraclePrimitiveType(Types.DOUBLE.name(), DatabaseSource.TableMetadata.NULLABLE, 12, 0);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=DOUBLE;nullable=Y;numberScale=12;numberPrecision=0;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.DOUBLE.getAvroType());
+
+    // LONG should resolve to Avro long
+    primitive = new OraclePrimitiveType(Types.LONG.name(), DatabaseSource.TableMetadata.NULLABLE, 0, 10);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=LONG;nullable=Y;numberScale=0;numberPrecision=10;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.LONG.getAvroType());
+
+    // INTEGER should resolve to Avro integer
+    primitive = new OraclePrimitiveType(Types.INTEGER.name(), DatabaseSource.TableMetadata.NULLABLE, 0, 7);
+    Assert.assertEquals(primitive.getMetadata(), "dbFieldType=INTEGER;nullable=Y;numberScale=0;numberPrecision=7;");
+    Assert.assertEquals(primitive.getAvroFieldName(), Types.INTEGER.getAvroType());
+  }
+
+  @Test
+  public void testFieldMappings() {
+    OraclePrimitiveType primitive;
+    for (Types type : Types.values()) {
+      // skip NUMBER fields as they require separate validation for scale, precision, and mapping logic
+      if (OraclePrimitiveType.NUMBER_CLASSIFICATION.contains(type.name())) {
+        continue;
+      }
+
+      primitive = new OraclePrimitiveType(type.name(), DatabaseSource.TableMetadata.NULLABLE, 0, 0);
+      Assert.assertEquals(primitive.getAvroFieldName(), type.getAvroType());
+      Assert.assertEquals(primitive.getMetadata(), "dbFieldType=" + type.name() + ";nullable=Y;");
+    }
   }
 
   @Test


### PR DESCRIPTION
…type for NUMBER

Currently if the schema generator sees a NUMBER field, it tries to convert it to Avro double, integer, long, or float based on the logic:

If scale > 0 and scale <= 6 , use float
If scale > 0 and scale <= 17, use double
If scale > 0 and scale > 17, throw exception
If precision == 0 and scale <= 0, use string
If precision > 9 and scale <= 0, use long
If precision <= 9 and scale <= 0, use int

It generates metadata about what the original Oracle column type was, in case downstream wants to use a different mapping. This PR makes the metadata for dbFieldType truly reflect the original column type. Before this PR, the dbFieldType was being set to the _resolved_ Avro type.

Before: NUMBER with scale=4 generates dbFieldType=FLOAT,numberScale=4
After: NUMBER with scale=4 generates dbFieldType=NUMBER,numberScale=4
