### PR TITLE
pause datastream only if it doesn't contain DatastreamTransientException

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamTransientException.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamTransientException.java
@@ -1,0 +1,24 @@
+package com.linkedin.datastream.common;
+
+/**
+ * Transient datastream exception, it indicates no need to pause the datastream
+ */
+public class DatastreamTransientException extends DatastreamRuntimeException {
+  private static final long serialVersionUID = 1;
+
+  public DatastreamTransientException() {
+    super();
+  }
+
+  public DatastreamTransientException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public DatastreamTransientException(String message) {
+    super(message);
+  }
+
+  public DatastreamTransientException(Throwable cause) {
+    super(cause);
+  }
+}


### PR DESCRIPTION
Producer needs the ability to distinguish exceptions that need to pause the datatsream and the exception that doesn't need to pause the datastream. This will allow datastream handle transport provider issue like Kafka illegalState 