### PR TITLE
Fix some Kafka-based connector metrics

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
@@ -215,12 +215,14 @@ public class CommonConnectorMetrics {
       super.deregister();
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, REBALANCE_RATE);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, STUCK_PARTITIONS);
+      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, NUM_PARTITIONS);
     }
 
     @Override
     protected void deregisterAggregates() {
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, AGGREGATE, REBALANCE_RATE);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, AGGREGATE, STUCK_PARTITIONS);
+      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, AGGREGATE, NUM_PARTITIONS);
       AGGREGATED_NUM_STUCK_PARTITIONS.remove(_className);
       AGGREGATED_NUM_PARTITIONS.remove(_className);
     }


### PR DESCRIPTION
A few issues with Kafka-based connector metrics:

1. Paused partition metrics were not resetting in some cases. For example, if a partition is auto-paused but gets revoked from the task (due to Kafka rebalance), the metric won't be updated. Another example is if a partition is auto-paused AND manually paused, the auto-paused count metric does not update.

2. Connector tasks will call KafkaBasedConnectorTaskMetrics.deregister() before closing. In deregister() we should NOT de-register the aggregate metrics. Instead, we should only decrement them by the values held by the particular connector task being closed.

3. A new 3rd reason for auto-pausing partition has been introduced (due to waiting for destination topic to be created). This was not accounted for in the auto-paused partition count metric calculation.