### PR TITLE
trim out task mapping information in the log file

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -125,7 +125,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public static DatastreamTaskImpl fromJson(String json) {
     DatastreamTaskImpl task = JsonUtils.fromJson(json, DatastreamTaskImpl.class);
-    LOG.debug("Loaded existing DatastreamTask: {}", task);
+    LOG.info("Loaded existing DatastreamTask: {}", task);
     return task;
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -41,8 +41,8 @@ public class BroadcastStrategy implements AssignmentStrategy {
       Map<String, Set<DatastreamTask>> currentAssignment) {
 
     int totalAssignedTasks = currentAssignment.values().stream().mapToInt(Set::size).sum();
-    LOG.info("Trying to assign {} datastreams {} to {} instances {} and the current assignment of {} tasks total is: {}",
-        datastreams.size(), datastreams, instances.size(), instances, totalAssignedTasks, currentAssignment);
+    LOG.info("Assigning {} datastreams to {} instances with {} tasks", datastreams.size(), instances.size(),
+        totalAssignedTasks);
 
     Map<String, Set<DatastreamTask>> newAssignment = new HashMap<>();
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -68,8 +68,8 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
       Map<String, Set<DatastreamTask>> currentAssignment) {
 
     int totalAssignedTasks = currentAssignment.values().stream().mapToInt(Set::size).sum();
-    LOG.info("Trying to assign {} datastreams {} to {} instances {} and the current assignment of {} tasks total is: {}",
-        datastreams.size(), datastreams, instances.size(), instances, totalAssignedTasks, currentAssignment);
+    LOG.info("Begin assign {} datastreams to {} instances with {} tasks", datastreams.size(), instances.size(),
+        totalAssignedTasks);
 
     if (instances.isEmpty()) {
       // Nothing to do.
@@ -162,7 +162,8 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
     }
 
     // STEP4: Format the result with the right data structure.
-    LOG.info("New assignment is {}", newAssignment);
+    LOG.info("Assignment completed");
+    LOG.debug("New assignment is {}", newAssignment);
 
     // STEP5: Some Sanity Checks, to detect missing tasks.
     sanityChecks(datastreams, instances, newAssignment);


### PR DESCRIPTION
stop printing the entire mapping information in the log to make it more readable