### PR TITLE
Update aggregate gauge metrics on deregister in CommonConnectorMetrics

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
@@ -217,10 +217,25 @@ public class CommonConnectorMetrics {
 
     @Override
     public void deregister() {
+      long numStuckPartitions = _numStuckPartitions.get();
+      long numPartitions = _numPartitions.get();
+
       super.deregister();
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, REBALANCE_RATE);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, STUCK_PARTITIONS);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, NUM_PARTITIONS);
+
+      // Aggregate gauage metrics should only reflect values for valid registered local metrics. When deregistering
+      // metrics, subtract their values from aggregate metrics.
+      AtomicLong aggregatedNumStuckPartitions = AGGREGATED_NUM_STUCK_PARTITIONS.get(_className);
+      if (aggregatedNumStuckPartitions != null) {
+        aggregatedNumStuckPartitions.getAndAdd(-numStuckPartitions);
+      }
+
+      AtomicLong aggregatedNumPartitions = AGGREGATED_NUM_PARTITIONS.get(_className);
+      if (aggregatedNumPartitions != null) {
+        aggregatedNumPartitions.getAndAdd(-numPartitions);
+      }
     }
 
     @Override

--- a/datastream-common/src/test/java/com/linkedin/datastream/connectors/TestCommonConnectorMetrics.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/connectors/TestCommonConnectorMetrics.java
@@ -215,6 +215,18 @@ public class TestCommonConnectorMetrics {
     metrics1.createPartitionMetrics();
     metrics2.createPartitionMetrics();
 
+    metrics1.updateNumPartitions(15);
+    metrics2.updateNumPartitions(10);
+
+    Assert.assertEquals((long) ((Gauge) _metricsManager.getMetric(CLASS_NAME + DELIMITED_AGGREGATE
+        + CommonConnectorMetrics.PartitionMetrics.NUM_PARTITIONS)).getValue(), 25);
+
+    metrics1.updateStuckPartitions(10);
+    metrics2.updateStuckPartitions(15);
+
+    Assert.assertEquals((long) ((Gauge) _metricsManager.getMetric(CLASS_NAME + DELIMITED_AGGREGATE
+        + CommonConnectorMetrics.PartitionMetrics.STUCK_PARTITIONS)).getValue(), 25);
+
     Assert.assertNotNull(_metricsManager.getMetric(String.join(".", CLASS_NAME, "aggregate", "stuckPartitions")));
     Assert.assertNotNull(_metricsManager.getMetric(String.join(".", CLASS_NAME, CONSUMER1_NAME, "stuckPartitions")));
     Assert.assertNotNull(_metricsManager.getMetric(String.join(".", CLASS_NAME, CONSUMER2_NAME, "stuckPartitions")));
@@ -222,6 +234,13 @@ public class TestCommonConnectorMetrics {
     metrics1.deregisterMetrics();
     Assert.assertNotNull(_metricsManager.getMetric(String.join(".", CLASS_NAME, "aggregate", "stuckPartitions")));
     Assert.assertNull(_metricsManager.getMetric(String.join(".", CLASS_NAME, CONSUMER1_NAME, "stuckPartitions")));
+
+    // Aggregate metrics' value should be only reflect value of valid registered metrics. Any metrics that have been
+    // deregistered should be subtracted from aggregate metrics.
+    Assert.assertEquals((long) ((Gauge) _metricsManager.getMetric(CLASS_NAME + DELIMITED_AGGREGATE
+        + CommonConnectorMetrics.PartitionMetrics.NUM_PARTITIONS)).getValue(), 10);
+    Assert.assertEquals((long) ((Gauge) _metricsManager.getMetric(CLASS_NAME + DELIMITED_AGGREGATE
+        + CommonConnectorMetrics.PartitionMetrics.STUCK_PARTITIONS)).getValue(), 15);
 
     metrics2.deregisterMetrics();
     Assert.assertNull(_metricsManager.getMetric(String.join(".", CLASS_NAME, "aggregate", "stuckPartitions")));


### PR DESCRIPTION
Deregistering local gauage metrics should update aggregate gauge metrics in CommonConnectorMetrics so that aggregate metrics only hold values for registered metrics.

Testing done: ./gradlew build
Added test case to confirm that deregistering metrics updates the aggregate metrics.