### PR TITLE
Add PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,7 @@
+Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
+For reporting security issues and contributing security fixes,  
+please, email security@linkedin.com instead, as described in  
+the contribution guidelines.
+
+Please, take a minute to review the contribution guidelines at:  
+https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md


### PR DESCRIPTION
Add PR template as recommended in [LinkedIn open-sourcing guidelines]( https://iwww.corp.linkedin.com/wiki/cf/display/TOOLS/Security+disclosure#Securitydisclosure-Example:addinganissuetemplate).