### PR TITLE
Update Datastream client creation code to take httpConfigs with value…

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
@@ -78,7 +78,7 @@ public final class BaseRestClientFactory<T> {
    *                   {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
    * @return instance of the BaseRestClient
    */
-  public synchronized T getClient(String uri, Map<String, String> httpConfig) {
+  public synchronized T getClient(String uri, Map<String, Object> httpConfig) {
     T client = getOverride(uri);
     if (client == null) {
       client = createClient(getRestClient(uri, httpConfig));
@@ -94,7 +94,7 @@ public final class BaseRestClientFactory<T> {
    * @param clientConfig custom config for the DatastreamRestClient
    * @return instance of the BaseRestClient which takes in clientConfig as a parameter in the constructor
    */
-  public synchronized T getClient(String uri, Map<String, String> httpConfig, Properties clientConfig) {
+  public synchronized T getClient(String uri, Map<String, Object> httpConfig, Properties clientConfig) {
     T client = getOverride(uri);
     if (client == null) {
       client = createClient(getRestClient(uri, httpConfig), clientConfig);
@@ -132,7 +132,7 @@ public final class BaseRestClientFactory<T> {
     return _overrides.getOrDefault(uri, null);
   }
 
-  private static String getKey(String uri, Map<String, String> httpConfig) {
+  private static String getKey(String uri, Map<String, Object> httpConfig) {
     return String.format("%s-%d", uri, httpConfig.hashCode());
   }
 
@@ -168,7 +168,7 @@ public final class BaseRestClientFactory<T> {
         .build();
   }
 
-  private RestClient getRestClient(String uri, Map<String, String> httpConfig) {
+  private RestClient getRestClient(String uri, Map<String, Object> httpConfig) {
     String canonicalUri = RestliUtils.sanitizeUri(uri);
     RestClient restClient;
     String key = getKey(uri, httpConfig);

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
@@ -44,7 +44,7 @@ public final class DatastreamRestClientFactory {
    * @param clientConfig custom config for the DatastreamRestClient.
    *                     Supported config entries can be found in {@link DatastreamRestClient}
    */
-  public static DatastreamRestClient getClient(String dmsUri, Map<String, String> httpConfig, Properties clientConfig) {
+  public static DatastreamRestClient getClient(String dmsUri, Map<String, Object> httpConfig, Properties clientConfig) {
     return FACTORY.getClient(dmsUri, httpConfig, clientConfig);
   }
 
@@ -55,7 +55,7 @@ public final class DatastreamRestClientFactory {
    * @param httpConfig custom config for HTTP client, please find the configs in
    *                   {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
    */
-  public static DatastreamRestClient getClient(String dmsUri, Map<String, String> httpConfig) {
+  public static DatastreamRestClient getClient(String dmsUri, Map<String, Object> httpConfig) {
     return FACTORY.getClient(dmsUri, httpConfig);
   }
 

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
@@ -32,7 +32,7 @@ public final class ServerComponentHealthRestClientFactory {
   public static ServerComponentHealthRestClient getClient(String dmsUri) {
     // A ServerComponentHealth response can be very large if Brooklin is responsible for lots of partitions.
     // These defaults should accommodate almost all use cases.
-    final Map<String, String> properties = new HashMap<>();
+    final Map<String, Object> properties = new HashMap<>();
     properties.put(HttpClientFactory.HTTP_MAX_RESPONSE_SIZE, "256000000"); // 256 MB
     properties.put(HttpClientFactory.HTTP_REQUEST_TIMEOUT, "10000"); // 10 seconds
 
@@ -46,7 +46,7 @@ public final class ServerComponentHealthRestClientFactory {
    * @param httpConfig custom config for HTTP client, please find the configs in
    *                   {@link com.linkedin.r2.transport.http.client.HttpClientFactory}
    */
-  public static ServerComponentHealthRestClient getClient(String dmsUri, Map<String, String> httpConfig) {
+  public static ServerComponentHealthRestClient getClient(String dmsUri, Map<String, Object> httpConfig) {
     return FACTORY.getClient(dmsUri, httpConfig);
   }
 


### PR DESCRIPTION
Update Datastream client creation code to take httpConfigs with value as an object instead of string.

Testing: ./gradlew build