### PR TITLE
Disable all position tracker activity when enableLatestBrokerOffsetsF…

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -33,7 +33,7 @@ public class KafkaBasedConnectorConfig {
   public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
   public static final String NON_GOOD_STATE_THRESHOLD_MS = "nonGoodStateThresholdMs";
   public static final String PROCESSING_DELAY_LOG_THRESHOLD_MS = "processingDelayLogThreshold";
-  public static final String CONFIG_ENABLE_LATEST_BROKER_OFFSETS_FETCHER = "enableLatestBrokerOffsetsFetcher";
+  public static final String CONFIG_ENABLE_KAFKA_POSITION_TRACKER = "enableKafkaPositionTracker";
   public static final long DEFAULT_NON_GOOD_STATE_THRESHOLD_MS = Duration.ofMinutes(10).toMillis();
   public static final long MIN_NON_GOOD_STATE_THRESHOLD_MS = Duration.ofMinutes(1).toMillis();
 
@@ -60,7 +60,7 @@ public class KafkaBasedConnectorConfig {
 
   private final int _daemonThreadIntervalSeconds;
   private final long _nonGoodStateThresholdMs;
-  private final boolean _enableLatestBrokerOffsetsFetcher;
+  private final boolean _enableKafkaPositionTracker;
 
   public KafkaBasedConnectorConfig(Properties properties) {
     VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
@@ -86,8 +86,8 @@ public class KafkaBasedConnectorConfig {
             MIN_NON_GOOD_STATE_THRESHOLD_MS, Long.MAX_VALUE);
     _processingDelayLogThresholdMs =
         verifiableProperties.getLong(PROCESSING_DELAY_LOG_THRESHOLD_MS, DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MS);
-    _enableLatestBrokerOffsetsFetcher =
-        verifiableProperties.getBoolean(CONFIG_ENABLE_LATEST_BROKER_OFFSETS_FETCHER, Boolean.FALSE);
+    _enableKafkaPositionTracker =
+        verifiableProperties.getBoolean(CONFIG_ENABLE_KAFKA_POSITION_TRACKER, Boolean.FALSE);
 
     String factory =
         verifiableProperties.getString(CONFIG_CONSUMER_FACTORY_CLASS, KafkaConsumerFactoryImpl.class.getName());
@@ -120,7 +120,7 @@ public class KafkaBasedConnectorConfig {
     _daemonThreadIntervalSeconds = DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS;
     _nonGoodStateThresholdMs = DEFAULT_NON_GOOD_STATE_THRESHOLD_MS;
     _processingDelayLogThresholdMs = DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MS;
-    _enableLatestBrokerOffsetsFetcher = false;
+    _enableKafkaPositionTracker = true;
   }
 
   public String getDefaultKeySerde() {
@@ -181,7 +181,7 @@ public class KafkaBasedConnectorConfig {
     return _processingDelayLogThresholdMs;
   }
 
-  public boolean enableLatestBrokerOffsetsFetcher() {
-    return _enableLatestBrokerOffsetsFetcher;
+  public boolean enableKafkaPositionTracker() {
+    return _enableKafkaPositionTracker;
   }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaPositionTracker.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaPositionTracker.java
@@ -43,7 +43,7 @@ import com.linkedin.datastream.common.diag.PhysicalSources;
  * This information can then be used to provide diagnostic and analytic information about our position on the Kafka
  * topic (e.g. Do we have more messages to consume? Are we stuck or are we making progress?).
  */
-public class  KafkaPositionTracker {
+public class KafkaPositionTracker {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaPositionTracker.class);
 
@@ -106,80 +106,76 @@ public class  KafkaPositionTracker {
    * Constructor for a KafkaPositionTracker.
    *
    * @param connectorTaskName the name of the connector task this task is for
-   * @param enableBrokerOffsetFetcher If true, then we will periodically fetch query Kafka via RPC for its latest
-   *                                  available offsets. If false, then this feature will not operate.
    * @param isConnectorTaskAlive A supplier that determines if the connector task this task is for is alive. If it is
    *                             not, then we should stop.
    * @param consumerSupplier a consumer supplier that is suitable for querying the brokers that the connector task is
    *                         talking to
    */
-  public KafkaPositionTracker(final String connectorTaskName, final boolean enableBrokerOffsetFetcher,
-      final Supplier<Boolean> isConnectorTaskAlive, final Supplier<Consumer<?, ?>> consumerSupplier) {
-    LOG.info("Creating KafkaPositionTracker for {} with offset fetching set to {}", connectorTaskName,
-        enableBrokerOffsetFetcher);
+  public KafkaPositionTracker(final String connectorTaskName, final Supplier<Boolean> isConnectorTaskAlive,
+      final Supplier<Consumer<?, ?>> consumerSupplier) {
+    LOG.info("Creating KafkaPositionTracker for {}", connectorTaskName);
     _connectorTaskName = connectorTaskName;
     _positionsInitialized = false;
-    if (enableBrokerOffsetFetcher) {
-      _offsetsFetcherService = new DurableScheduledService(_connectorTaskName, OFFSETS_FETCH_INTERVAL,
-          LAST_CONSUMER_RPC_TERMINATED_TIMEOUT) {
-        private Consumer<?, ?> _consumer;
+    _offsetsFetcherService = new DurableScheduledService(_connectorTaskName, OFFSETS_FETCH_INTERVAL,
+        LAST_CONSUMER_RPC_TERMINATED_TIMEOUT) {
+      private Consumer<?, ?> _consumer;
 
-        @Override
-        protected void startUp() {
-          _consumer = consumerSupplier.get();
+      @Override
+      protected void startUp() {
+        _consumer = consumerSupplier.get();
+      }
+
+      @Override
+      protected void runOneIteration() {
+        if (!_positionsInitialized) {
+          _positionsInitialized = initializePositions(_consumer, _assignedPartitions);
+          return;
         }
 
-        @Override
-        protected void runOneIteration() {
-          if (!_positionsInitialized) {
-            _positionsInitialized = initializePositions(_consumer, _assignedPartitions);
-            return;
-          }
+        final Instant currentTime = Instant.now();
 
-          final Instant currentTime = Instant.now();
+        // We want to update only those partitions which are assigned to us and haven't been updated in our fetch
+        // interval.
+        final Set<TopicPartition> partitionsNeedingUpdate = _assignedPartitions.stream()
+            .filter(tp -> Optional.ofNullable(_offsetPositions.get(tp.toString()))
+                .map(PhysicalSourcePosition::getSourceQueriedTimeMs)
+                .map(Instant::ofEpochMilli)
+                .orElse(Instant.EPOCH)
+                .isBefore(currentTime.minus(OFFSETS_FETCH_INTERVAL)))
+            .collect(Collectors.toSet());
 
-          // We want to update only those partitions which are assigned to us and haven't been updated in our fetch
-          // interval.
-          final Set<TopicPartition> partitionsNeedingUpdate = _assignedPartitions.stream()
-              .filter(tp -> Optional.ofNullable(_offsetPositions.get(tp.toString()))
-                  .map(PhysicalSourcePosition::getSourceQueriedTimeMs)
-                  .map(Instant::ofEpochMilli)
-                  .orElse(Instant.EPOCH)
-                  .isBefore(currentTime.minus(OFFSETS_FETCH_INTERVAL)))
-              .collect(Collectors.toSet());
-
-          // If we are caught up on all partitions, there is no need to make any RPC calls.
-          if (partitionsNeedingUpdate.isEmpty()) {
-            return;
-          }
-
-          LOG.debug("Detected that the following partitions would benefit from broker endOffsets RPC: {}",
-              partitionsNeedingUpdate);
-
-          try {
-            updateLatestBrokerOffsetsByRpc(_consumer, partitionsNeedingUpdate, currentTime.toEpochMilli());
-          } catch (Exception e) {
-            // If we run into an exception, we should crash and allow ourselves to be revived by the
-            // DurableScheduledService
-            LOG.warn("Failed to update broker end offsets via RPC.", e);
-            throw e;
-          }
+        // If we are caught up on all partitions, there is no need to make any RPC calls.
+        if (partitionsNeedingUpdate.isEmpty()) {
+          return;
         }
 
-        @Override
-        protected void shutDown() {
-          if (_consumer != null) {
-            _consumer.close();
-          }
-        }
+        LOG.debug("Detected that the following partitions would benefit from broker endOffsets RPC: {}",
+            partitionsNeedingUpdate);
 
-        @Override
-        protected boolean hasLeaked() {
-          return !isConnectorTaskAlive.get();
+        try {
+          updateLatestBrokerOffsetsByRpc(_consumer, partitionsNeedingUpdate, currentTime.toEpochMilli());
+        } catch (Exception e) {
+          // If we run into an exception, we should crash and allow ourselves to be revived by the
+          // DurableScheduledService
+          LOG.warn("Failed to update broker end offsets via RPC.", e);
+          throw e;
         }
-      };
-      _offsetsFetcherService.startAsync();
-    }
+      }
+
+      @Override
+      protected void shutDown() {
+        if (_consumer != null) {
+          _consumer.close();
+        }
+      }
+
+      @Override
+      protected boolean hasLeaked() {
+        return !isConnectorTaskAlive.get();
+      }
+    };
+
+    _offsetsFetcherService.startAsync();
   }
 
   /**

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -235,7 +235,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
             consumerPosition, lastRecordTime));
 
     long postProductionTime = System.currentTimeMillis();
-    connectorTask._kafkaPositionTracker.updateLatestBrokerOffsetsByRpc(connectorTask._consumer,
+    connectorTask._kafkaPositionTracker.get().updateLatestBrokerOffsetsByRpc(connectorTask._consumer,
         connectorTask._consumerAssignment, postProductionTime);
 
     consumerPosition = getConsumerPositionFromPositionResponse(connectorTask.getPositionResponse(), datastream.getName(),

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestPositionResponse.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestPositionResponse.java
@@ -178,7 +178,7 @@ public class TestPositionResponse {
     _state.allowNextPoll();
     PollUtils.poll(() -> false, POLL_PERIOD_MS, POLL_TIMEOUT_MS);
     long currentTime = System.currentTimeMillis();
-    _consumer._kafkaPositionTracker.updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
+    _consumer._kafkaPositionTracker.get().updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
         _state.getAllTopicPartitions(), currentTime);
     DatastreamPositionResponse response = _consumer.getPositionResponse();
 
@@ -230,7 +230,7 @@ public class TestPositionResponse {
     _state.allowNextPoll();
     PollUtils.poll(() -> false, POLL_PERIOD_MS, POLL_TIMEOUT_MS);
     long currentTime = System.currentTimeMillis();
-    _consumer._kafkaPositionTracker.updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
+    _consumer._kafkaPositionTracker.get().updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
         _state.getAllTopicPartitions(), currentTime);
     response = _consumer.getPositionResponse();
 
@@ -280,7 +280,7 @@ public class TestPositionResponse {
     _state.allowNextPoll();
     PollUtils.poll(() -> false, POLL_PERIOD_MS, POLL_TIMEOUT_MS);
     long currentTime = System.currentTimeMillis();
-    _consumer._kafkaPositionTracker.updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
+    _consumer._kafkaPositionTracker.get().updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
         _state.getAllTopicPartitions(), currentTime);
     response = _consumer.getPositionResponse();
 
@@ -332,7 +332,7 @@ public class TestPositionResponse {
     PollUtils.poll(() -> false, POLL_PERIOD_MS, POLL_TIMEOUT_MS);
 
     long currentTime = System.currentTimeMillis();
-    _consumer._kafkaPositionTracker.updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
+    _consumer._kafkaPositionTracker.get().updateLatestBrokerOffsetsByRpc(_factory.createConsumer(null),
         _state.getAllTopicPartitions(), currentTime);
     response = _consumer.getPositionResponse();
 


### PR DESCRIPTION
…etcher is false

Disable all KafkaPositionTracker activity when broker offsets fetcher is disabled. The assumption is that doing the bookkeeping for consumer positions is useless when broker offsets are not being fetched anyways.
