### PR TITLE
Fix test flake in TestAbstractKafkaConnector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -67,7 +67,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
   public static final String IS_GROUP_ID_HASHING_ENABLED = "isGroupIdHashingEnabled";
 
   private static final Duration CANCEL_TASK_TIMEOUT = Duration.ofSeconds(30);
-  static final Duration MIN_INITIAL_DELAY = Duration.ofMinutes(2);
+  static final Duration MIN_DAEMON_THREAD_STARTUP_DELAY = Duration.ofMinutes(2);
 
 
   protected final String _connectorName;
@@ -257,7 +257,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
   @VisibleForTesting
   long getThreadDelayTimeInSecond(OffsetDateTime now, int daemonThreadIntervalSeconds) {
     long truncatedTimestamp = now.truncatedTo(ChronoUnit.HOURS).toEpochSecond();
-    long minDelay = Math.min(MIN_INITIAL_DELAY.getSeconds(), daemonThreadIntervalSeconds);
+    long minDelay = Math.min(MIN_DAEMON_THREAD_STARTUP_DELAY.getSeconds(), daemonThreadIntervalSeconds);
     while ((truncatedTimestamp - now.toEpochSecond()) < minDelay) {
       truncatedTimestamp += daemonThreadIntervalSeconds;
     }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -65,7 +65,7 @@ public class TestAbstractKafkaConnector {
     Duration threadDelay = Duration.ofMinutes(5);
 
     // The value of min initial delay means that we must wait at least this long in all circumstances before firing
-    Duration minDelay = AbstractKafkaConnector.MIN_INITIAL_DELAY;
+    Duration minDelay = AbstractKafkaConnector.MIN_DAEMON_THREAD_STARTUP_DELAY;
 
     // Period to test
     Duration testPeriod = Duration.ofDays(1).plusHours(2); // This should be long enough to handle all edge cases


### PR DESCRIPTION
This fixes a test flake in TestAbstractKafkaConnector that has affected a number of recent CI executions:
- https://circleci.com/gh/linkedin/brooklin/1803
- https://circleci.com/gh/linkedin/brooklin/1801
- https://circleci.com/gh/linkedin/brooklin/1789
- etc...

The bug is triggered when the test is run near UTC midnight with the following output:
```
Gradle suite > Gradle test > com.linkedin.datastream.connectors.kafka.TestAbstractKafkaConnector.testCalculateThreadStartDelay FAILED
    java.time.DateTimeException: Invalid value for HourOfDay (valid values 0 - 23): 24
        at java.time.temporal.ValueRange.checkValidValue(ValueRange.java:311)
        at java.time.temporal.ChronoField.checkValidValue(ChronoField.java:703)
        at java.time.LocalTime.of(LocalTime.java:339)
        at java.time.LocalDateTime.of(LocalDateTime.java:362)
        at java.time.OffsetDateTime.of(OffsetDateTime.java:306)
        at com.linkedin.datastream.connectors.kafka.TestAbstractKafkaConnector.testCalculateThreadStartDelay(TestAbstractKafkaConnector.java:67)
```

This occurs due to the hour value not being modded with 24 to ensure that it conforms to what the API expects.

However, even with _this_ bug fixed, it looks like there is likely another bug causing testCalculateThreadStartDelay() to fail in certain conditions, but the output of the test is insufficient to track down what exactly the edge case might be.

This change rewrites the test, adds test failure messages to provide insight if the test ever fails in the future, increases test coverage, and lightly refactors `AbstractKafkaConnector.getThreadDelayTimeInSecond(...)` to make it more testable.