### PR TITLE
Fix cast issue for early JDK 8 implementations

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaPositionTracker.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaPositionTracker.java
@@ -278,7 +278,7 @@ public class KafkaPositionTracker implements Closeable {
     @Nullable final MetricName metricName = Optional.ofNullable(_metricNameCache.get(topicPartition))
         .orElseGet(() -> tryCreateMetricName(topicPartition, metrics.keySet()).orElse(null));
     return Optional.ofNullable(metricName)
-        .map(metrics::get)
+        .map(name -> (Metric) metrics.get(name))
         .map(Metric::metricValue)
         .filter(value -> value instanceof Double)
         .map(value -> ((Double) value).longValue());


### PR DESCRIPTION
Some out-of-date JDK implementations (say Oracle JDK 8u5) are unable to resolve an implicit cast when compiling the project. This was resolved later in Oracle JDK (by at least 8u40).

This change makes the cast explicit to provide compile support for old Oracle JDK implementations.