### PR TITLE
Add Checkstyle rules for ordering imports

### DIFF
--- a/checkstyle/checkstyle.xml
+++ b/checkstyle/checkstyle.xml
@@ -99,6 +99,16 @@ LinkedIn Java style.
     <!-- Eliminate unused imports -->
     <module name="UnusedImports"/>
 
+    <!-- Import ordering -->
+    <module name="ImportOrder">
+      <property name="groups" value="/^javax?\./,/^org\./,*,/^com\.linkedin\./" />
+      <property name="separated" value="true" />
+      <property name="ordered" value="true"/>
+      <property name="caseSensitive" value="true" />
+      <property name="sortStaticImportsAlphabetically" value="true"/>
+      <property name="option" value="bottom" />
+    </module>
+
     <!-- JAVADOC COMMENTS -->
 
     <!-- If you have a Javadoc comment, make sure it is properly formed -->

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DurableScheduledService.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DurableScheduledService.java
@@ -13,15 +13,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 
-import com.google.common.util.concurrent.AbstractScheduledService;
-import com.google.common.util.concurrent.Service;
-import com.google.errorprone.annotations.CanIgnoreReturnValue;
-
 import org.apache.commons.lang3.Validate;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.util.concurrent.AbstractScheduledService;
+import com.google.common.util.concurrent.Service;
+import com.google.errorprone.annotations.CanIgnoreReturnValue;
 
 
 /**

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/VerifiableProperties.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/VerifiableProperties.java
@@ -11,8 +11,8 @@ import java.util.Enumeration;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Properties;
-
 import java.util.stream.Collectors;
+
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileConnector.java
@@ -18,9 +18,10 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 
-import com.google.common.collect.ImmutableMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamRuntimeException;

--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -16,10 +16,10 @@ import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.google.common.io.CountingInputStream;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import com.google.common.io.CountingInputStream;
 
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.BrooklinEnvelopeMetadataConstants;

--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/diag/FilePositionKey.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/diag/FilePositionKey.java
@@ -6,8 +6,8 @@
 package com.linkedin.datastream.connectors.file.diag;
 
 import java.time.Instant;
-
 import java.util.Objects;
+
 import org.codehaus.jackson.annotate.JsonProperty;
 import org.codehaus.jackson.map.annotate.JsonDeserialize;
 import org.codehaus.jackson.map.annotate.JsonSerialize;

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -27,15 +27,15 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableMap;
-
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.jetbrains.annotations.NotNull;
 import org.slf4j.Logger;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableMap;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamConstants;

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
@@ -23,10 +23,10 @@ import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.JsonUtils;
 import com.linkedin.datastream.kafka.KafkaTransportProviderAdmin;
-import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
-import com.linkedin.datastream.server.assignment.BroadcastStrategy;
 import com.linkedin.datastream.server.Coordinator;
 import com.linkedin.datastream.server.SourceBasedDeduper;
+import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+import com.linkedin.datastream.server.assignment.BroadcastStrategy;
 import com.linkedin.datastream.testutil.BaseKafkaZkTest;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
 

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -37,7 +37,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
-
 import kafka.utils.ZkUtils;
 
 import com.linkedin.data.template.StringMap;
@@ -53,8 +52,8 @@ import com.linkedin.datastream.server.DatastreamEventProducer;
 import com.linkedin.datastream.server.DatastreamProducerRecord;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.server.zk.ZkAdapter;
-import com.linkedin.datastream.testutil.DatastreamEmbeddedZookeeperKafkaCluster;
 import com.linkedin.datastream.testutil.BaseKafkaZkTest;
+import com.linkedin.datastream.testutil.DatastreamEmbeddedZookeeperKafkaCluster;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaPositionTracker.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaPositionTracker.java
@@ -23,10 +23,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.stream.Collectors;
 
-import com.codahale.metrics.MetricRegistry;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Sets;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
@@ -41,6 +37,11 @@ import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
+
+import com.codahale.metrics.MetricRegistry;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTestUtils.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTestUtils.java
@@ -5,17 +5,14 @@
  */
 package com.linkedin.datastream.kafka;
 
+import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Collections;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.TimeoutException;
-
-import kafka.admin.AdminUtils;
-import kafka.utils.ZkUtils;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang.Validate;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
@@ -23,6 +20,9 @@ import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.TopicPartition;
+
+import kafka.admin.AdminUtils;
+import kafka.utils.ZkUtils;
 
 
 /**

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderAdmin.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderAdmin.java
@@ -32,9 +32,9 @@ import kafka.utils.ZkUtils;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
-import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.common.zk.ZkClient;

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderUtils.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderUtils.java
@@ -7,6 +7,7 @@ package com.linkedin.datastream.kafka;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/LiKafkaProducerFactory.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/LiKafkaProducerFactory.java
@@ -5,14 +5,16 @@
  */
 package com.linkedin.datastream.kafka.factory;
 
-import com.linkedin.datastream.common.VerifiableProperties;
-import com.linkedin.kafka.clients.producer.LiKafkaProducerConfig;
-import com.linkedin.kafka.clients.producer.LiKafkaProducerImpl;
 import java.util.Properties;
+
 import org.apache.commons.lang.Validate;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
+
+import com.linkedin.datastream.common.VerifiableProperties;
+import com.linkedin.kafka.clients.producer.LiKafkaProducerConfig;
+import com.linkedin.kafka.clients.producer.LiKafkaProducerImpl;
 
 
 /**

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/SimpleKafkaProducerFactory.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/SimpleKafkaProducerFactory.java
@@ -6,6 +6,7 @@
 package com.linkedin.datastream.kafka.factory;
 
 import java.util.Properties;
+
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;


### PR DESCRIPTION
Add Checkstyle rules to enforce the following (already adopted) ordering of imports:
```
import java.*
import javax.*
<blank line>
import org.*
<blank line>
import <anything-else>
<blank line>
import com.linkedin.*
<blank line>
static imports
```

Checkstyle reference for the `ImportOrder` module is located right [here](http://checkstyle.sourceforge.net/config_imports.html#ImportOrder).