### PR TITLE
Flag allowing to disable strict hostname check of kafka brokers

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -102,6 +102,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected final Duration _pauseErrorPartitionDuration;
   protected final long _processingDelayLogThresholdMillis;
   protected final Optional<Map<Integer, Long>> _startOffsets;
+  protected final boolean _strictHostCheck;
 
   protected volatile String _taskName;
   protected final DatastreamEventProducer _producer;
@@ -154,6 +155,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _maxRetryCount = config.getRetryCount();
     _pausePartitionOnError = config.getPausePartitionOnError();
     _pauseErrorPartitionDuration = config.getPauseErrorPartitionDuration();
+    config.getEnableStrictHostCheck();
     _startOffsets = Optional.ofNullable(_datastream.getMetadata().get(DatastreamMetadataConstants.START_POSITION))
         .map(json -> JsonUtils.fromJson(json, new TypeReference<Map<Integer, Long>>() {
         }));
@@ -161,6 +163,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _pollTimeoutMillis = config.getPollTimeoutMillis();
     _retrySleepDuration = config.getRetrySleepDuration();
     _commitTimeout = config.getCommitTimeout();
+    _strictHostCheck = config.getEnableStrictHostCheck();
     _consumerMetrics = createKafkaBasedConnectorTaskMetrics(metricsPrefix, _datastreamName, _logger);
 
     _pollAttempts = 0;

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -316,7 +316,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
     DatastreamSource source = datastream.getSource();
     String connectionString = source.getConnectionString();
 
-    KafkaConnectionString parsed = KafkaConnectionString.valueOf(connectionString);
+    KafkaConnectionString parsed = KafkaConnectionString.valueOf(connectionString, _config.getEnableStrictHostCheck());
 
     try (Consumer<?, ?> consumer = KafkaConnectorTask.createConsumer(_config.getConsumerFactory(),
         _config.getConsumerProps(), "KafkaConnectorPartitionFinder", parsed)) {

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -34,6 +34,7 @@ public class KafkaBasedConnectorConfig {
   public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
   public static final String NON_GOOD_STATE_THRESHOLD_MILLIS = "nonGoodStateThresholdMs";
   public static final String PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = "processingDelayLogThreshold";
+  public static final String CONFIG_ENABLE_STRICT_HOST_CHECK = "enableStrictHostCheck";
   public static final long DEFAULT_NON_GOOD_STATE_THRESHOLD_MILLIS = Duration.ofMinutes(10).toMillis();
   public static final long MIN_NON_GOOD_STATE_THRESHOLD_MILLIS = Duration.ofMinutes(1).toMillis();
 
@@ -61,6 +62,7 @@ public class KafkaBasedConnectorConfig {
   private final long _processingDelayLogThresholdMillis;
   private final boolean _enablePositionTracker;
   private final boolean _enableBrokerOffsetFetcher;
+  private final boolean _enableStrictHostCheck;
 
   private final int _daemonThreadIntervalSeconds;
   private final long _nonGoodStateThresholdMillis;
@@ -99,6 +101,7 @@ public class KafkaBasedConnectorConfig {
             DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS);
     _enablePositionTracker = verifiableProperties.getBoolean(CONFIG_ENABLE_POSITION_TRACKER, true);
     _enableBrokerOffsetFetcher = verifiableProperties.getBoolean(CONFIG_ENABLE_BROKER_OFFSET_FETCHER, true);
+    _enableStrictHostCheck = verifiableProperties.getBoolean(CONFIG_ENABLE_STRICT_HOST_CHECK, true);
 
     String factory =
         verifiableProperties.getString(CONFIG_CONSUMER_FACTORY_CLASS, KafkaConsumerFactoryImpl.class.getName());
@@ -182,5 +185,9 @@ public class KafkaBasedConnectorConfig {
 
   public boolean getEnableBrokerOffsetFetcher() {
     return _enableBrokerOffsetFetcher;
+  }
+
+  public boolean getEnableStrictHostCheck() {
+    return _enableStrictHostCheck;
   }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectionString.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectionString.java
@@ -86,7 +86,7 @@ public class KafkaConnectionString {
    * @param connectionString
    *  connection string in the form kafka://[host1:port1,host2:port2...]/topicName
    */
-  public static KafkaConnectionString valueOf(String connectionString) throws IllegalArgumentException {
+  public static KafkaConnectionString valueOf(String connectionString, boolean strictHostCheck) throws IllegalArgumentException {
     if (connectionString == null) {
       badArg(connectionString);
     }
@@ -110,7 +110,7 @@ public class KafkaConnectionString {
       badArg(connectionString);
     }
     str = str.substring(0, topicIndex);
-    List<KafkaBrokerAddress> brokers = parseBrokers(str);
+    List<KafkaBrokerAddress> brokers = parseBrokers(str, strictHostCheck);
     return new KafkaConnectionString(brokers, topicName, isSecure);
   }
 
@@ -119,14 +119,14 @@ public class KafkaConnectionString {
    * @param brokersValue
    *  example: [host1:port1,host2,port2]
    */
-  public static List<KafkaBrokerAddress> parseBrokers(String brokersValue) {
+  public static List<KafkaBrokerAddress> parseBrokers(String brokersValue, boolean strictHostCheck) {
     String[] hosts = brokersValue.split("\\s*,\\s*");
     if (hosts.length < 1) {
       badArg(brokersValue);
     }
     List<KafkaBrokerAddress> brokers = new ArrayList<>(hosts.length);
     for (String host : hosts) {
-      brokers.add(KafkaBrokerAddress.valueOf(host));
+      brokers.add(KafkaBrokerAddress.valueOf(host, strictHostCheck));
     }
     return brokers;
   }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -42,7 +42,7 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
   private static final Logger LOG = LoggerFactory.getLogger(KafkaConnectorTask.class);
 
   private KafkaConnectionString _srcConnString =
-      KafkaConnectionString.valueOf(_datastreamTask.getDatastreamSource().getConnectionString());
+      KafkaConnectionString.valueOf(_datastreamTask.getDatastreamSource().getConnectionString(), _strictHostCheck);
   private final KafkaConsumerFactory<?, ?> _consumerFactory;
 
   GroupIdConstructor _groupIdConstructor;
@@ -87,7 +87,7 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
   @Override
   protected void consumerSubscribe() {
     KafkaConnectionString srcConnString =
-        KafkaConnectionString.valueOf(_datastreamTask.getDatastreamSource().getConnectionString());
+        KafkaConnectionString.valueOf(_datastreamTask.getDatastreamSource().getConnectionString(), _strictHostCheck);
     _consumer.subscribe(Collections.singletonList(srcConnString.getTopicName()), this);
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaGroupIdConstructor.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaGroupIdConstructor.java
@@ -16,6 +16,7 @@ import com.linkedin.datastream.server.DatastreamTask;
 public class KafkaGroupIdConstructor implements GroupIdConstructor {
 
   private final boolean _isGroupIdHashingEnabled;
+  private final boolean _isStrictHostCheckingEnabled;
   private final String _clusterName;
 
   /**
@@ -26,9 +27,10 @@ public class KafkaGroupIdConstructor implements GroupIdConstructor {
    *                    cluster where corresponding datastream server is running. The cluster name is used in
    *                    generating group ID if isGroupIdHashingEnabled argument is set to true.
    */
-  public KafkaGroupIdConstructor(boolean isGroupIdHashingEnabled, String clusterName) {
+  public KafkaGroupIdConstructor(boolean isGroupIdHashingEnabled, String clusterName, boolean isStrictHostCheckingEnabled) {
     _isGroupIdHashingEnabled = isGroupIdHashingEnabled;
     _clusterName = clusterName;
+    _isStrictHostCheckingEnabled = isStrictHostCheckingEnabled;
   }
 
   @Override
@@ -36,7 +38,7 @@ public class KafkaGroupIdConstructor implements GroupIdConstructor {
     if (_isGroupIdHashingEnabled) {
       return constructGroupId(DatastreamUtils.getTaskPrefix(datastream), _clusterName);
     } else {
-      return constructGroupId(KafkaConnectionString.valueOf(datastream.getSource().getConnectionString()),
+      return constructGroupId(KafkaConnectionString.valueOf(datastream.getSource().getConnectionString(), _isStrictHostCheckingEnabled),
           datastream.getDestination().getConnectionString());
     }
   }
@@ -46,7 +48,7 @@ public class KafkaGroupIdConstructor implements GroupIdConstructor {
     if (_isGroupIdHashingEnabled) {
       return constructGroupId(task.getTaskPrefix(), _clusterName);
     } else {
-      return constructGroupId(KafkaConnectionString.valueOf(task.getDatastreamSource().getConnectionString()),
+      return constructGroupId(KafkaConnectionString.valueOf(task.getDatastreamSource().getConnectionString(), _isStrictHostCheckingEnabled),
           task.getDatastreamDestination().getConnectionString());
     }
   }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
@@ -82,7 +82,8 @@ public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
     }
 
     // verify that the source regular expression can be compiled
-    KafkaConnectionString connectionString = KafkaConnectionString.valueOf(stream.getSource().getConnectionString());
+    KafkaConnectionString connectionString = KafkaConnectionString.valueOf(stream.getSource().getConnectionString(),
+            _config.getEnableStrictHostCheck());
     try {
       Pattern pattern = Pattern.compile(connectionString.getTopicName());
       LOG.info("Successfully compiled topic name pattern {}", pattern);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -121,7 +121,8 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       boolean isFlushlessModeEnabled, GroupIdConstructor groupIdConstructor) {
     super(config, task, LOG, generateMetricsPrefix(connectorName, CLASS_NAME));
     _consumerFactory = config.getConsumerFactory();
-    _mirrorMakerSource = KafkaConnectionString.valueOf(_datastreamTask.getDatastreamSource().getConnectionString());
+    _mirrorMakerSource = KafkaConnectionString.valueOf(_datastreamTask.getDatastreamSource().getConnectionString(),
+            config.getEnableStrictHostCheck());
 
     _isFlushlessModeEnabled = isFlushlessModeEnabled;
     _isIdentityMirroringEnabled = KafkaMirrorMakerDatastreamMetadata.isIdentityPartitioningEnabled(_datastream);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -125,7 +125,7 @@ public class TestAbstractKafkaConnector {
     public TestKafkaConnector(boolean restartThrows, Properties props) {
       super("test", props, new KafkaGroupIdConstructor(
           Boolean.parseBoolean(props.getProperty(IS_GROUP_ID_HASHING_ENABLED, Boolean.FALSE.toString())),
-          "TestkafkaConnectorCluster"), "TestkafkaConnectorCluster", LOG);
+          "TestkafkaConnectorCluster", true), "TestkafkaConnectorCluster", LOG);
       _restartThrows = restartThrows;
     }
 

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaBasedConnectorConfig.java
@@ -42,7 +42,7 @@ public class TestKafkaBasedConnectorConfig {
 
     // verify that config entries are propagated to connectorTask
     Properties taskProps = KafkaConnectorTask.getKafkaConsumerProperties(configProps, "groupId",
-        KafkaConnectionString.valueOf("kafkassl://somewhere:777/topic"));
+        KafkaConnectionString.valueOf("kafkassl://somewhere:777/topic", true));
     Assert.assertEquals(taskProps.getProperty("someProperty"), "someValue");
     Assert.assertEquals(taskProps.getProperty("someProperty1"), "someValue1");
     Assert.assertEquals(taskProps.getProperty("someProperty2"), "someValue2");

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaBrokerAddress.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaBrokerAddress.java
@@ -49,6 +49,16 @@ public class TestKafkaBrokerAddress {
     KafkaBrokerAddress.valueOf("somewhere:65536");
   }
 
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testParseInvalidHostname() {
+    KafkaBrokerAddress.valueOf("abc-abc.invalid-tld:666");
+  }
+
+  @Test
+  public void testParseInvalidHostnameWithoutStrictHostnameCheck() {
+    Assert.assertEquals(new KafkaBrokerAddress("abc-abc.invalid-tld", 666), KafkaBrokerAddress.valueOf("abc-abc.invalid-tld:666", false));
+  }
+
   @Test
   public void testParseMaxPort() {
     Assert.assertEquals(new KafkaBrokerAddress("linkedin.com", 65535), KafkaBrokerAddress.valueOf("linkedin.com:65535"));

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectionString.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectionString.java
@@ -19,42 +19,47 @@ public class TestKafkaConnectionString {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseNull() {
-    KafkaConnectionString.valueOf(null);
+    KafkaConnectionString.valueOf(null, true);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseEmpty() {
-    KafkaConnectionString.valueOf("  \t  \r\n  \r");
+    KafkaConnectionString.valueOf("  \t  \r\n  \r", true);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseNoPrefix() {
-    KafkaConnectionString.valueOf("hostname:666/topic");
+    KafkaConnectionString.valueOf("hostname:666/topic", true);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseWrongPrefix() {
-    KafkaConnectionString.valueOf("notKafka://hostname:666/topic");
+    KafkaConnectionString.valueOf("notKafka://hostname:666/topic", true);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseNoHost() {
-    KafkaConnectionString.valueOf("kafka://:666/topic");
+    KafkaConnectionString.valueOf("kafka://:666/topic", true);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseNoPort() {
-    KafkaConnectionString.valueOf("kafka://acme.com/topic");
+    KafkaConnectionString.valueOf("kafka://acme.com/topic", true);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseEmptyTopic() {
-    KafkaConnectionString.valueOf("kafka://acme.com/  ");
+    KafkaConnectionString.valueOf("kafka://acme.com/  ", true);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseNoTopic() {
-    KafkaConnectionString.valueOf("kafka://acme.com");
+    KafkaConnectionString.valueOf("kafka://acme.com", true);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testInvalidHostName() {
+    KafkaConnectionString.valueOf("kafka://abc-def.invalid-tld:666", true);
   }
 
   @Test
@@ -62,7 +67,7 @@ public class TestKafkaConnectionString {
     Assert.assertEquals(
         new KafkaConnectionString(Collections.singletonList(new KafkaBrokerAddress("somewhere", 666)),
             "topic", false),
-        KafkaConnectionString.valueOf("kafka://somewhere:666/topic"));
+        KafkaConnectionString.valueOf("kafka://somewhere:666/topic", true));
   }
 
   @Test
@@ -70,8 +75,16 @@ public class TestKafkaConnectionString {
     Assert.assertEquals(
         new KafkaConnectionString(Collections.singletonList(new KafkaBrokerAddress("somewhere", 666)),
             "topic", true),
-        KafkaConnectionString.valueOf("kafkassl://somewhere:666/topic"));
+        KafkaConnectionString.valueOf("kafkassl://somewhere:666/topic", true));
   }
+
+  @Test
+  public void testInvalidHostNameWithStrictHostCheckDisabled() {
+    Assert.assertEquals(
+        new KafkaConnectionString(Collections.singletonList(new KafkaBrokerAddress("abc-def.invalid-tld", 666)),
+            "topic", false),
+        KafkaConnectionString.valueOf("kafka://abc-def.invalid-tld:666/topic", false));
+}
 
   @Test
   public void testMultipleBrokers() {
@@ -84,24 +97,24 @@ public class TestKafkaConnectionString {
             "topic",
             false
         ),
-        KafkaConnectionString.valueOf("kafka://somewhere:666,somewhereElse:667/topic")
+        KafkaConnectionString.valueOf("kafka://somewhere:666,somewhereElse:667/topic", true)
     );
   }
 
   @Test
   public void testBrokerListSorting() {
-    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafka://a:667,b:665,a:666/topic");
+    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafka://a:667,b:665,a:666/topic", true);
     Assert.assertEquals(connectionString.toString(), "kafka://a:666,a:667,b:665/topic");
   }
 
   @Test
   public void testSslBrokerListSorting() {
-    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafkassl://a:667,b:665,a:666/topic");
+    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafkassl://a:667,b:665,a:666/topic", true);
     Assert.assertEquals(connectionString.toString(), "kafkassl://a:666,a:667,b:665/topic");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testMultipleBrokersNoPort() {
-    KafkaConnectionString.valueOf("kafka://somewhere:666,somewhereElse/topic");
+    KafkaConnectionString.valueOf("kafka://somewhere:666,somewhereElse/topic", true);
   }
 }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
@@ -140,7 +140,7 @@ public class TestKafkaConnector extends BaseKafkaZkTest {
 
     String clusterName = "testGroupIdAssignment";
     KafkaGroupIdConstructor groupIdConstructor =
-        new KafkaGroupIdConstructor(isGroupIdHashingEnabled, "testGroupIdAssignment");
+        new KafkaGroupIdConstructor(isGroupIdHashingEnabled, "testGroupIdAssignment", true);
 
     String topicName1 = "topic1";
     String topicName2 = "topic2";

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -109,7 +109,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
 
   @Test
   public void testKafkaGroupId() throws Exception {
-    KafkaGroupIdConstructor groupIdConstructor = new KafkaGroupIdConstructor(false, "testCluster");
+    KafkaGroupIdConstructor groupIdConstructor = new KafkaGroupIdConstructor(false, "testCluster", true);
     String topic = "MyTopicForGrpId";
     Datastream datastream1 = getDatastream(_broker, topic);
     Datastream datastream2 = getDatastream(_broker, topic);
@@ -320,7 +320,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
     TopicPartition topicPartition = new TopicPartition("pizza1", 0);
     KafkaConnectorTask connectorTask = spy(new KafkaConnectorTask(new KafkaBasedConnectorConfigBuilder()
         .setPausePartitionOnError(true).setPauseErrorPartitionDuration(Duration.ofDays(1)).build(), task, "",
-        new KafkaGroupIdConstructor(false, "testCluster")));
+        new KafkaGroupIdConstructor(false, "testCluster", true)));
 
     Map<TopicPartition, List<ConsumerRecord<Object, Object>>> records =  new HashMap<>();
     records.put(topicPartition, ImmutableList.of(
@@ -352,7 +352,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
   public void testConsumerProperties() {
     Properties overrides = new Properties();
     String groupId = "groupId";
-    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafka://MyBroker:10251/MyTopic");
+    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafka://MyBroker:10251/MyTopic", true);
     Properties actual = KafkaConnectorTask.getKafkaConsumerProperties(overrides, groupId, connectionString);
 
     Properties expected = new Properties();
@@ -369,7 +369,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
   public void testSslConsumerProperties() {
     Properties overrides = new Properties();
     String groupId = "groupId";
-    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafkassl://MyBroker:10251/MyTopic");
+    KafkaConnectionString connectionString = KafkaConnectionString.valueOf("kafkassl://MyBroker:10251/MyTopic", true);
     Properties actual = KafkaConnectorTask.getKafkaConsumerProperties(overrides, groupId, connectionString);
 
     Properties expected = new Properties();
@@ -480,7 +480,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
       throws InterruptedException {
 
     KafkaConnectorTask connectorTask = new KafkaConnectorTask(connectorConfig, task, "",
-        new KafkaGroupIdConstructor(false, "testCluster"));
+        new KafkaGroupIdConstructor(false, "testCluster", true));
 
     Thread t = new Thread(connectorTask, "connector thread");
     t.setDaemon(true);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaPositionTracker.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaPositionTracker.java
@@ -407,7 +407,7 @@ public class TestKafkaPositionTracker {
         .setConsumerFactory(_factory)
         .build();
     KafkaConnectorTask connectorTask = new KafkaConnectorTask(connectorConfig, _datastreamTask, "",
-        new KafkaGroupIdConstructor(false, "testCluster"));
+        new KafkaGroupIdConstructor(false, "testCluster", true));
     final Thread consumerThread = new Thread(connectorTask, "Consumer Thread");
     consumerThread.setDaemon(true);
     consumerThread.setUncaughtExceptionHandler((t, e) -> LOG.error("Got uncaught exception in consumer thread", e));

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -188,7 +188,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         .build();
 
     KafkaMirrorMakerConnectorTask connectorTask = new KafkaMirrorMakerConnectorTask(
-        connectorConfig, task, "", false, new KafkaGroupIdConstructor(false, "testCluster"));
+        connectorConfig, task, "", false, new KafkaGroupIdConstructor(false, "testCluster", true));
 
     KafkaMirrorMakerConnectorTestUtils.createKafkaMirrorMakerConnectorTask(task);
     KafkaMirrorMakerConnectorTestUtils.runKafkaMirrorMakerConnectorTask(connectorTask);
@@ -236,7 +236,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         .build();
 
     KafkaMirrorMakerConnectorTask connectorTask = new KafkaMirrorMakerConnectorTask(
-        connectorConfig, task, "", true, new KafkaGroupIdConstructor(false, "test"));
+        connectorConfig, task, "", true, new KafkaGroupIdConstructor(false, "test", true));
 
     KafkaMirrorMakerConnectorTestUtils.runKafkaMirrorMakerConnectorTask(connectorTask);
 


### PR DESCRIPTION
Currently in brooklin Kafka broker hostnames should pass Apache Commons `DomainValidator` validation. There are companies on the market (including mine ;) ) which for historical reasons have their internal hostnames with, for example, invalid or non-existing TLD. 

I understand that this check may be required for security reasons for example but, on the other hand, it would be great to have an option to disable it. This PR is all about it ;) 

One thing I also changed is removing redundant hostname validation in `KafkaBrokerAddress` constructor. Objects of this class are constructed in `valueOf` method only (and in tests) which perform validation itself. If you want me to revert this piece of code I have to mention that it will be needed to add third parameter to the constructor which allows me to pass it to `validateHostname` method and so on :) 

I'm open to all suggestions :) 