### PR TITLE
fix a race condition in handleChangeAssignment

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -119,7 +119,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
   protected abstract AbstractKafkaBasedConnectorTask createKafkaBasedConnectorTask(DatastreamTask task);
 
   @Override
-  public void onAssignmentChange(List<DatastreamTask> tasks) {
+  public synchronized void onAssignmentChange(List<DatastreamTask> tasks) {
     _logger.info("onAssignmentChange called with tasks {}", tasks);
 
     HashSet<DatastreamTask> toCancel = new HashSet<>(_runningTasks.keySet());

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -149,7 +149,6 @@ public class DatastreamServer {
     }
 
     CoordinatorConfig coordinatorConfig = new CoordinatorConfig(properties);
-    coordinatorConfig.setAssignmentChangeThreadPoolThreadCount(connectorTypes.size());
 
     LOG.info("Setting up DMS endpoint server.");
     ZkClient zkClient = new ZkClient(coordinatorConfig.getZkAddress(), coordinatorConfig.getZkSessionTimeout(),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -19,11 +19,10 @@ import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -178,7 +177,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private final Map<String, TransportProviderAdmin> _transportProviderAdmins = new HashMap<>();
   private final CoordinatorEventBlockingQueue _eventQueue;
   private final CoordinatorEventProcessor _eventThread;
-  private final ThreadPoolExecutor _assignmentChangeThreadPool;
+  private final Map<String, ExecutorService> _assignmentChangeThreadPool = new ConcurrentHashMap<>();
   private final String _clusterName;
   private final CoordinatorConfig _config;
   private final ZkAdapter _adapter;
@@ -245,10 +244,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _dynamicMetricsManager.registerGauge(MODULE, NUM_PAUSED_DATASTREAMS_GROUPS, () -> _pausedDatastreamsGroups.get());
     _dynamicMetricsManager.registerGauge(MODULE, IS_LEADER, () -> getIsLeader().getAsBoolean() ? 1 : 0);
 
-    // Creating a separate thread pool for making the onAssignmentChange calls to the connector
-    _assignmentChangeThreadPool = new ThreadPoolExecutor(config.getAssignmentChangeThreadPoolThreadCount(),
-        config.getAssignmentChangeThreadPoolThreadCount(), 10, TimeUnit.SECONDS, new LinkedBlockingQueue<>());
-
     VerifiableProperties coordinatorProperties = new VerifiableProperties(_config.getConfigProperties());
 
     _eventProducerConfig = coordinatorProperties.getDomainProperties(EVENT_PRODUCER_CONFIG_DOMAIN);
@@ -270,6 +265,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     for (String connectorType : _connectors.keySet()) {
       ConnectorInfo connectorInfo = _connectors.get(connectorType);
       ConnectorWrapper connector = connectorInfo.getConnector();
+
+      // Creating a separate thread pool for making the onAssignmentChange calls to the connector
+      _assignmentChangeThreadPool.put(connectorType, Executors.newSingleThreadExecutor());
 
       // populate the instanceName. We only know the instance name after _adapter.connect()
       connector.setInstanceName(getInstanceName());
@@ -567,7 +565,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       addedTasks.stream().filter(t -> t.getEventProducer() == null).forEach(this::initializeTask);
 
       // Dispatch the onAssignmentChange to the connector in a separate thread.
-      return _assignmentChangeThreadPool.submit(() -> {
+      return _assignmentChangeThreadPool.get(connectorType).submit(() -> {
         try {
           connector.onAssignmentChange(assignment);
           // Unassign tasks with producers

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -23,7 +23,6 @@ public final class CoordinatorConfig {
   public static final String CONFIG_ZK_CONNECTION_TIMEOUT = PREFIX + "zkConnectionTimeout";
   public static final String CONFIG_RETRY_INTERVAL = PREFIX + "retryIntervalMs";
   public static final String CONFIG_HEARTBEAT_PERIOD_MS = PREFIX + "heartbeatPeriodMs";
-  public static final String CONFIG_DEFAULT_ASSIGNMENT_THREAD_COUNT = PREFIX + "assignmentChangeThreadCount";
 
   private final String _cluster;
   private final String _zkAddress;
@@ -35,7 +34,9 @@ public final class CoordinatorConfig {
   private final long _heartbeatPeriodMs;
   private final String _defaultTransportProviderName;
 
-  private int _assignmentChangeThreadPoolThreadCount;
+  // As handleChangeAssignment currently uses a thread pool, there is a race condition that the previous assignment
+  // may actually process later than the new assignment. As a result, the size of thread pool is set to 1
+  private int _assignmentChangeThreadPoolThreadCount = 1;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -52,7 +53,6 @@ public final class CoordinatorConfig {
     _retryIntervalMs = _properties.getInt(CONFIG_RETRY_INTERVAL, 1000 /* 1 second */);
     _heartbeatPeriodMs = _properties.getLong(CONFIG_HEARTBEAT_PERIOD_MS, Duration.ofMinutes(1).toMillis());
     _defaultTransportProviderName = _properties.getString(CONFIG_DEFAULT_TRANSPORT_PROVIDER, "");
-    _assignmentChangeThreadPoolThreadCount = _properties.getInt(CONFIG_DEFAULT_ASSIGNMENT_THREAD_COUNT, 1);
   }
 
   public Properties getConfigProperties() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -34,10 +34,6 @@ public final class CoordinatorConfig {
   private final long _heartbeatPeriodMs;
   private final String _defaultTransportProviderName;
 
-  // As handleChangeAssignment currently uses a thread pool, there is a race condition that the previous assignment
-  // may actually process later than the new assignment. As a result, the size of thread pool is set to 1
-  private int _assignmentChangeThreadPoolThreadCount = 1;
-
   /**
    * Construct an instance of CoordinatorConfig
    * @param config configuration properties to load
@@ -77,10 +73,6 @@ public final class CoordinatorConfig {
 
   public int getRetryIntervalMs() {
     return _retryIntervalMs;
-  }
-
-  public int getAssignmentChangeThreadPoolThreadCount() {
-    return _assignmentChangeThreadPoolThreadCount;
   }
 
   public String getDefaultTransportProviderName() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -23,6 +23,7 @@ public final class CoordinatorConfig {
   public static final String CONFIG_ZK_CONNECTION_TIMEOUT = PREFIX + "zkConnectionTimeout";
   public static final String CONFIG_RETRY_INTERVAL = PREFIX + "retryIntervalMs";
   public static final String CONFIG_HEARTBEAT_PERIOD_MS = PREFIX + "heartbeatPeriodMs";
+  public static final String CONFIG_DEFAULT_ASSIGNMENT_THREAD_COUNT = PREFIX + "assignmentChangeThreadCount";
 
   private final String _cluster;
   private final String _zkAddress;
@@ -34,7 +35,7 @@ public final class CoordinatorConfig {
   private final long _heartbeatPeriodMs;
   private final String _defaultTransportProviderName;
 
-  private int _assignmentChangeThreadPoolThreadCount = 3;
+  private int _assignmentChangeThreadPoolThreadCount;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -51,6 +52,7 @@ public final class CoordinatorConfig {
     _retryIntervalMs = _properties.getInt(CONFIG_RETRY_INTERVAL, 1000 /* 1 second */);
     _heartbeatPeriodMs = _properties.getLong(CONFIG_HEARTBEAT_PERIOD_MS, Duration.ofMinutes(1).toMillis());
     _defaultTransportProviderName = _properties.getString(CONFIG_DEFAULT_TRANSPORT_PROVIDER, "");
+    _assignmentChangeThreadPoolThreadCount = _properties.getInt(CONFIG_DEFAULT_ASSIGNMENT_THREAD_COUNT, 1);
   }
 
   public Properties getConfigProperties() {
@@ -79,10 +81,6 @@ public final class CoordinatorConfig {
 
   public int getAssignmentChangeThreadPoolThreadCount() {
     return _assignmentChangeThreadPoolThreadCount;
-  }
-
-  public void setAssignmentChangeThreadPoolThreadCount(int count) {
-    _assignmentChangeThreadPoolThreadCount = count;
   }
 
   public String getDefaultTransportProviderName() {


### PR DESCRIPTION
As handleChangeAssignment currently uses a thread pool, there is a race condition that
the previous assignment may actually process later than the new assignment. This will make
the follower instances don't contain the latest assignment from Zookeeper. The lack of synchronization in handleAssignmentChange may also end up creating unmonitored consumer, causing a rebalance issue. This fix set the thread pool size to 1 as default to avoid above issues.



Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
