### PR TITLE
Remove group id from KafkaPositionTracker's consumer

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -955,9 +955,14 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
    */
   private KafkaPositionTracker createKafkaPositionTracker(KafkaBasedConnectorConfig config) {
     if (config.getEnablePositionTracker()) {
+      // Change the consumer group id for our position tracker's consumer as we do not want the position tracker to
+      // be subscribing or assigning itself to any topics
+      Properties positionTrackerConsumerProps = new Properties(_consumerProps);
+      positionTrackerConsumerProps.remove(ConsumerConfig.GROUP_ID_CONFIG);
+
       return KafkaPositionTracker.builder()
           .withConnectorTaskStartTime(Instant.now())
-          .withConsumerSupplier(() -> createKafkaConsumer(_consumerProps))
+          .withConsumerSupplier(() -> createKafkaConsumer(positionTrackerConsumerProps))
           .withDatastreamTask(_datastreamTask)
           .withEnableBrokerOffsetFetcher(config.getEnableBrokerOffsetFetcher())
           .withIsConnectorTaskAlive(() -> !_shutdown && (_connectorTaskThread == null || _connectorTaskThread.isAlive()))


### PR DESCRIPTION
It appears that if the KafkaPositionTracker's consumer shares a group id with the datastream task's consumer, it is possible to run into a [Kafka bug](https://issues.apache.org/jira/browse/KAFKA-7263).

Regardless, it is reasonably defensive to remove the group id for the position tracker's consumer as it does not need to subscribe to or assign itself topics.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
