### PR TITLE
Fix a bug when putting an event with metadata in event queue

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -9,8 +9,8 @@ package com.linkedin.datastream.server;
 /**
  * Represents different event types inside {@link Coordinator}.
  *
- * CoordinatorEvent will be deduped in the event queue based on the event type
- * However, any event with eventMetadata will not get deduped
+ * CoordinatorEvent will be deduped in the event queue {@link CoordinatorEventBlockingQueue}
+ * based on the event type. However, any event with eventMetadata will not get deduped
  */
 public class CoordinatorEvent {
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -8,6 +8,9 @@ package com.linkedin.datastream.server;
 
 /**
  * Represents different event types inside {@link Coordinator}.
+ *
+ * CoordinatorEvent will be deduped in the event queue based on the event type
+ * However, any event with eventMetadata will not get deduped
  */
 public class CoordinatorEvent {
 
@@ -35,7 +38,8 @@ public class CoordinatorEvent {
   public static final CoordinatorEvent HEARTBEAT_EVENT = new CoordinatorEvent(EventType.HEARTBEAT);
   protected final EventType _eventType;
 
-  // metadata can be used by for the event, it can be null
+  // metadata can be used by for the event, it can be null.
+  // The event with metadata will not get deduped
   protected final Object _eventMetadata;
 
   private CoordinatorEvent(EventType eventType) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -46,8 +46,11 @@ public class CoordinatorEventBlockingQueue {
       }
     }
 
-    // always overwrite the event in the map
-    _eventMap.put(event.getType(), event);
+    // we put into the eventMap for dedup only if there is no metadata
+    if (event.getEventMetadata() == null) {
+      _eventMap.put(event.getType(), event);
+    }
+
     LOG.debug("Event queue size %d", _eventQueue.size());
     notify();
   }
@@ -71,7 +74,8 @@ public class CoordinatorEventBlockingQueue {
     if (queuedEvent != null) {
       LOG.info("De-queuing event " + queuedEvent.getType());
       LOG.debug("Event queue size: %d", _eventQueue.size());
-      return _eventMap.remove(queuedEvent.getType());
+      _eventMap.remove(queuedEvent.getType());
+      return queuedEvent;
     }
 
     return null;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -1,0 +1,47 @@
+/**
+ *  Copyright 2019 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TestCoordinatorEventBlockingQueue {
+
+  @Test
+  public void testHappyPath() throws Exception{
+    CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue();
+    eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+  }
+
+
+  @Test
+  public void testEventWithMetadata() throws Exception{
+    CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue();
+    eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test2"));
+    eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
+    Assert.assertEquals((String)eventBlockingQueue.take().getEventMetadata(), "test1");
+    Assert.assertEquals((String)eventBlockingQueue.take().getEventMetadata(), "test1");
+    Assert.assertEquals((String)eventBlockingQueue.take().getEventMetadata(), "test2");
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+  }
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -8,11 +8,13 @@ package com.linkedin.datastream.server;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-
+/**
+ * Tests for {@link CoordinatorEventBlockingQueue}
+ */
 public class TestCoordinatorEventBlockingQueue {
 
   @Test
-  public void testHappyPath() throws Exception{
+  public void testHappyPath() throws Exception {
     CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue();
     eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
@@ -26,7 +28,7 @@ public class TestCoordinatorEventBlockingQueue {
 
 
   @Test
-  public void testEventWithMetadata() throws Exception{
+  public void testEventWithMetadata() throws Exception {
     CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue();
     eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
@@ -37,11 +39,11 @@ public class TestCoordinatorEventBlockingQueue {
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
-    
+
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.LEADER_DO_ASSIGNMENT_EVENT);
-    Assert.assertEquals((String)eventBlockingQueue.take().getEventMetadata(), "test1");
-    Assert.assertEquals((String)eventBlockingQueue.take().getEventMetadata(), "test1");
-    Assert.assertEquals((String)eventBlockingQueue.take().getEventMetadata(), "test2");
+    Assert.assertEquals((String) eventBlockingQueue.take().getEventMetadata(), "test1");
+    Assert.assertEquals((String) eventBlockingQueue.take().getEventMetadata(), "test1");
+    Assert.assertEquals((String) eventBlockingQueue.take().getEventMetadata(), "test2");
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
   }
 }


### PR DESCRIPTION
CoordinateEvents are getting deduped in the CoordinatorEventBlockingQueue based on the type. However, events with metadata shouldn't been deduped just based on the type. This change fixes the issue by only deduping the events with metadata. 

Going forward, we can consider dedup for eventMetadata as well. But this will requires eventMetadata object to implemented a proper hashcode logic.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
