### PR TITLE
Refactor KMMConnector interface

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -402,4 +402,12 @@ public class DynamicMetricsManager {
     Validate.notNull(classSimpleName, "classSimpleName argument is null.");
     Validate.notNull(metricName, "metricName argument is null.");
   }
+
+  /**
+   * Get metricRegistry object, it allows other module like Kafka client to wire in the same metricRegistry
+   * @return
+   */
+  public MetricRegistry getMetricRegistry() {
+    return _metricRegistry;
+  }
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -405,7 +405,6 @@ public class DynamicMetricsManager {
 
   /**
    * Get metricRegistry object, it allows other module like Kafka client to wire in the same metricRegistry
-   * @return
    */
   public MetricRegistry getMetricRegistry() {
     return _metricRegistry;

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -58,6 +58,8 @@ import com.linkedin.datastream.server.DatastreamEventProducer;
 import com.linkedin.datastream.server.DatastreamProducerRecord;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskStatus;
+import com.linkedin.datastream.server.api.transport.SendCallback;
+
 
 /**
  * Base class for connector task, where the connector is Kafka-based. This base class provides basic structure for
@@ -226,7 +228,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
           } else {
             DatastreamProducerRecord datastreamProducerRecord = translate(record, readTime);
             int numBytes = record.serializedKeySize() + record.serializedValueSize();
-            sendDatastreamProducerRecord(datastreamProducerRecord, topicPartition, numBytes);
+            sendDatastreamProducerRecord(datastreamProducerRecord, topicPartition, numBytes, null);
           }
         } catch (Exception e) {
           _logger.warn("Got exception while sending record {}", record);
@@ -270,7 +272,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   }
 
   protected void sendDatastreamProducerRecord(DatastreamProducerRecord datastreamProducerRecord,
-      TopicPartition srcTopicPartition, int numBytes) {
+      TopicPartition srcTopicPartition, int numBytes, SendCallback sendCallback) {
     _producer.send(datastreamProducerRecord, ((metadata, exception) -> {
       if (exception != null) {
         _logger.warn("Detect exception being throw from callback for src partition: {} while sending producer "
@@ -278,6 +280,10 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         rewindAndPausePartitionOnException(srcTopicPartition, exception);
       } else {
         _consumerMetrics.updateBytesProcessedRate(numBytes);
+      }
+
+      if (sendCallback != null) {
+        sendCallback.onCompletion(metadata, exception);
       }
     }));
   }


### PR DESCRIPTION
There is a need for user to extend KMMConnector to put extra logic in the send callback. 
As a result, I refactor the interface and put the send callback in the method parameter.

The getter for metryRegistry is also added as there is also a need to get metryRegistry class when hooking up with other clients. 
