### PR TITLE
Bug fix with custom SerDe being overriden by kafka factory implementations

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConsumerFactoryImpl.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConsumerFactoryImpl.java
@@ -17,15 +17,15 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
  * A factory for creating Kafka {@link Consumer} instances
  */
 public class KafkaConsumerFactoryImpl implements KafkaConsumerFactory<byte[], byte[]> {
-  private static final String KEY_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
-  private static final String VAL_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+  private static final String DEFAULT_KEY_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+  private static final String DEFAULT_VAL_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
 
   /* Package Visible */
   static Properties addConsumerDefaultProperties(Properties properties) {
     properties.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-            KEY_DESERIALIZER);
+            DEFAULT_KEY_DESERIALIZER);
     properties.putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-            VAL_DESERIALIZER);
+            DEFAULT_VAL_DESERIALIZER);
     return properties;
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConsumerFactoryImpl.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConsumerFactoryImpl.java
@@ -17,10 +17,21 @@ import org.apache.kafka.common.serialization.ByteArrayDeserializer;
  * A factory for creating Kafka {@link Consumer} instances
  */
 public class KafkaConsumerFactoryImpl implements KafkaConsumerFactory<byte[], byte[]> {
+  private static final String KEY_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+  private static final String VAL_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+
+  /* Package Visible */
+  static Properties addConsumerDefaultProperties(Properties properties) {
+    properties.putIfAbsent(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+            KEY_DESERIALIZER);
+    properties.putIfAbsent(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+            VAL_DESERIALIZER);
+    return properties;
+  }
+
   @Override
   public Consumer<byte[], byte[]> createConsumer(Properties properties) {
-    properties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
-    properties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ByteArrayDeserializer.class.getCanonicalName());
+    addConsumerDefaultProperties(properties);
     return new KafkaConsumer<>(properties);
   }
 }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConsumerFactoryImpl.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConsumerFactoryImpl.java
@@ -1,0 +1,74 @@
+/**
+ *  Copyright 2019 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.connectors.kafka;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link KafkaConsumerFactoryImpl}
+ */
+public class TestKafkaConsumerFactoryImpl {
+    private static final String KEY_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+    private static final String VAL_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+
+    /**
+     * Assert if we are adding default properties
+     */
+    @Test
+    public void testDefaultConsumerConfig() {
+        Properties properties = new Properties();
+        properties.put("auto.offset.reset", "none");
+        properties.put("bootstrap.servers", "MyBroker:10251");
+        properties.put("enable.auto.commit", "false");
+        properties.put("group.id", "groupId");
+        properties.put("security.protocol", "SSL");
+        Properties actual = KafkaConsumerFactoryImpl.addConsumerDefaultProperties(properties);
+
+        Properties expected = new Properties();
+        expected.putAll(properties);
+        expected.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                KEY_DESERIALIZER);
+        expected.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                VAL_DESERIALIZER);
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    /**
+     * Assert if we are adding override for default properties
+     */
+    @Test
+    public void testOverrideDefaultConsumerConfigs() {
+        Properties properties = new Properties();
+        properties.put("auto.offset.reset", "none");
+        properties.put("bootstrap.servers", "MyBroker:10251");
+        properties.put("enable.auto.commit", "false");
+        properties.put("group.id", "groupId");
+        properties.put("security.protocol", "SSL");
+
+        Properties additionalProperties = new Properties();
+        additionalProperties.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "my.custom.deserializer");
+        additionalProperties.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "my.custom.deserializer");
+        additionalProperties.putAll(properties);
+        Properties actual = KafkaConsumerFactoryImpl.addConsumerDefaultProperties(additionalProperties);
+
+        Properties expected = new Properties();
+        expected.putAll(properties);
+        expected.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                "my.custom.deserializer");
+        expected.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                "my.custom.deserializer");
+
+        Assert.assertEquals(actual, expected);
+    }
+}

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConsumerFactoryImpl.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConsumerFactoryImpl.java
@@ -16,8 +16,8 @@ import org.testng.annotations.Test;
  * Tests for {@link KafkaConsumerFactoryImpl}
  */
 public class TestKafkaConsumerFactoryImpl {
-    private static final String KEY_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
-    private static final String VAL_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+    private static final String DEFAULT_KEY_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
+    private static final String DEFAULT_VAL_DESERIALIZER = ByteArrayDeserializer.class.getCanonicalName();
 
     /**
      * Assert if we are adding default properties
@@ -35,9 +35,9 @@ public class TestKafkaConsumerFactoryImpl {
         Properties expected = new Properties();
         expected.putAll(properties);
         expected.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
-                KEY_DESERIALIZER);
+                DEFAULT_KEY_DESERIALIZER);
         expected.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
-                VAL_DESERIALIZER);
+                DEFAULT_VAL_DESERIALIZER);
 
         Assert.assertEquals(actual, expected);
     }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/SimpleKafkaProducerFactory.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/SimpleKafkaProducerFactory.java
@@ -17,13 +17,13 @@ import org.apache.kafka.common.serialization.ByteArraySerializer;
  * Factory class for SimpleKafkaProducerFactory
  */
 public class SimpleKafkaProducerFactory implements KafkaProducerFactory<byte[], byte[]> {
-  private static final String KEY_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
-  private static final String VAL_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+  private static final String DEFAULT_KEY_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+  private static final String DEFAULT_VAL_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
 
   /* Package Visible */
   static Properties addProducerDefaultProperties(Properties properties) {
-    properties.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KEY_SERIALIZER);
-    properties.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, VAL_SERIALIZER);
+    properties.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, DEFAULT_KEY_SERIALIZER);
+    properties.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, DEFAULT_VAL_SERIALIZER);
     return properties;
   }
 

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/SimpleKafkaProducerFactory.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/factory/SimpleKafkaProducerFactory.java
@@ -10,20 +10,26 @@ import java.util.Properties;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
 
 
 /**
  * Factory class for SimpleKafkaProducerFactory
  */
 public class SimpleKafkaProducerFactory implements KafkaProducerFactory<byte[], byte[]> {
-  private static final String KEY_SERIALIZER = "org.apache.kafka.common.serialization.ByteArraySerializer";
-  private static final String VAL_SERIALIZER = "org.apache.kafka.common.serialization.ByteArraySerializer";
+  private static final String KEY_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+  private static final String VAL_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+
+  /* Package Visible */
+  static Properties addProducerDefaultProperties(Properties properties) {
+    properties.putIfAbsent(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KEY_SERIALIZER);
+    properties.putIfAbsent(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, VAL_SERIALIZER);
+    return properties;
+  }
 
   @Override
   public Producer<byte[], byte[]> createProducer(Properties transportProps) {
-    transportProps.setProperty(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, KEY_SERIALIZER);
-    transportProps.setProperty(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, VAL_SERIALIZER);
-
+    addProducerDefaultProperties(transportProps);
     return new KafkaProducer<>(transportProps);
   }
 }

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/factory/TestSimpleKafkaProducerFactory.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/factory/TestSimpleKafkaProducerFactory.java
@@ -16,8 +16,8 @@ import org.testng.annotations.Test;
  * Tests for {@link com.linkedin.datastream.kafka.factory.SimpleKafkaProducerFactory}
  */
 public class TestSimpleKafkaProducerFactory {
-    private static final String KEY_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
-    private static final String VAL_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+    private static final String DEFAULT_KEY_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+    private static final String DEFAULT_VAL_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
 
     /**
      * Assert if we are adding default properties
@@ -32,9 +32,9 @@ public class TestSimpleKafkaProducerFactory {
         Properties expected = new Properties();
         expected.putAll(properties);
         expected.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
-                KEY_SERIALIZER);
+                DEFAULT_KEY_SERIALIZER);
         expected.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
-                VAL_SERIALIZER);
+                DEFAULT_VAL_SERIALIZER);
 
         Assert.assertEquals(actual, expected);
     }

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/factory/TestSimpleKafkaProducerFactory.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/factory/TestSimpleKafkaProducerFactory.java
@@ -1,0 +1,69 @@
+/**
+ *  Copyright 2019 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.kafka.factory;
+
+import java.util.Properties;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link com.linkedin.datastream.kafka.factory.SimpleKafkaProducerFactory}
+ */
+public class TestSimpleKafkaProducerFactory {
+    private static final String KEY_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+    private static final String VAL_SERIALIZER = ByteArraySerializer.class.getCanonicalName();
+
+    /**
+     * Assert if we are adding default properties
+     */
+    @Test
+    public void testDefaultProducerConfig() {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "MyBroker:10251");
+        properties.put("security.protocol", "SSL");
+        Properties actual = SimpleKafkaProducerFactory.addProducerDefaultProperties(properties);
+
+        Properties expected = new Properties();
+        expected.putAll(properties);
+        expected.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                KEY_SERIALIZER);
+        expected.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                VAL_SERIALIZER);
+
+        Assert.assertEquals(actual, expected);
+    }
+
+    /**
+     * Assert if we are adding override for default properties
+     */
+    @Test
+    public void testOverrideDefaultProducerConfigs() {
+        Properties properties = new Properties();
+        properties.put("bootstrap.servers", "MyBroker:10251");
+        properties.put("security.protocol", "SSL");
+
+        Properties additionalProperties = new Properties();
+        additionalProperties.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "my.custom.serializer");
+        additionalProperties.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "my.custom.serializer");
+        additionalProperties.putAll(properties);
+        Properties actual = SimpleKafkaProducerFactory.addProducerDefaultProperties(additionalProperties);
+
+        Properties expected = new Properties();
+        expected.putAll(properties);
+        expected.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                "my.custom.serializer");
+        expected.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                "my.custom.serializer");
+
+        Assert.assertEquals(actual, expected);
+    }
+
+}


### PR DESCRIPTION
We are running `KafkaMirrorMakerConnector` and noticed that the values we provide as part of  `value.serializer` in transporter config and `value.deserializer` in connector config is not getting reflected in the Kafka consumer/producer client instantiations. 

This is because user provided custom Kafka deserializer or serializer in connector/transporter configs is overwritten in the the Kafka consumer & producer factory implementations.

This PR is a simple fix: 
- Made changes to add `value.serializer` only if absent in `KafkaProducerFactory` implementation
- Made changes to add `value.deserializer` only if absent in `KafkaProducerFactory` implementation
- Added some unit tests around these factory implementation for future proofing.

Above fix will enable users to provide Kafka custom SerDe's as part of their connector/transporter configurations.
