### PR TITLE
Various position tracker improvements

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -17,6 +17,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -167,7 +168,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _consumerMetrics = createKafkaBasedConnectorTaskMetrics(metricsPrefix, _datastreamName, _logger);
 
     _pollAttempts = new AtomicInteger();
-    _kafkaPositionTracker = Optional.ofNullable(createKafkaPositionTracker(config));
+    _kafkaPositionTracker = Optional.ofNullable(createKafkaPositionTracker(config.getKafkaPositionTrackerConfig()));
   }
 
   protected static String generateMetricsPrefix(String connectorName, String simpleClassName) {
@@ -957,19 +958,26 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
    * @param config the provided config
    * @return a KafkaPositionTracker if enabled in config, or null
    */
-  private KafkaPositionTracker createKafkaPositionTracker(KafkaBasedConnectorConfig config) {
-    if (config.getEnablePositionTracker()) {
-      // Change the consumer group id for our position tracker's consumer as we do not want the position tracker to
-      // be subscribing or assigning itself to any topics
+  private KafkaPositionTracker createKafkaPositionTracker(KafkaPositionTrackerConfig config) {
+    if (config.isEnablePositionTracker()) {
       Properties positionTrackerConsumerProps = new Properties(_consumerProps);
-      positionTrackerConsumerProps.remove(ConsumerConfig.GROUP_ID_CONFIG);
+
+      // Generate a random consumer group id for our position tracker's consumer as we do not want the position tracker
+      // to interfere with the task's consumer (can happen due to KAFKA-8350).
+      String positionTrackerGroupId = UUID.randomUUID().toString();
+      positionTrackerConsumerProps.put(ConsumerConfig.GROUP_ID_CONFIG, positionTrackerGroupId);
+
+      // Increase the request timeout of the position tracker's consumer as it may be asking for a large number of
+      // topics in its RPC calls.
+      positionTrackerConsumerProps.put(ConsumerConfig.REQUEST_TIMEOUT_MS_CONFIG,
+          String.valueOf(config.getBrokerRequestTimeout().toMillis()));
 
       return KafkaPositionTracker.builder()
           .withConnectorTaskStartTime(Instant.now())
           .withConsumerSupplier(() -> createKafkaConsumer(positionTrackerConsumerProps))
           .withDatastreamTask(_datastreamTask)
-          .withEnableBrokerOffsetFetcher(config.getEnableBrokerOffsetFetcher())
           .withIsConnectorTaskAlive(() -> !_shutdown && (_connectorTaskThread == null || _connectorTaskThread.isAlive()))
+          .withKafkaPositionTrackerConfig(config)
           .build();
     }
     return null;

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -19,6 +19,7 @@ import com.linkedin.datastream.common.VerifiableProperties;
 public class KafkaBasedConnectorConfig {
 
   public static final String DOMAIN_KAFKA_CONSUMER = "consumer";
+  public static final String DOMAIN_KAFKA_POSITION_TRACKER = "kafkaPositionTracker";
   public static final String CONFIG_COMMIT_INTERVAL_MILLIS = "commitIntervalMs";
   public static final String CONFIG_COMMIT_TIMEOUT_MILLIS = "commitTimeoutMs";
   public static final String CONFIG_POLL_TIMEOUT_MILLIS = "pollTimeoutMs";
@@ -29,8 +30,6 @@ public class KafkaBasedConnectorConfig {
   public static final String CONFIG_RETRY_SLEEP_DURATION_MILLIS = "retrySleepDurationMs";
   public static final String CONFIG_PAUSE_PARTITION_ON_ERROR = "pausePartitionOnError";
   public static final String CONFIG_PAUSE_ERROR_PARTITION_DURATION_MILLIS = "pauseErrorPartitionDurationMs";
-  public static final String CONFIG_ENABLE_POSITION_TRACKER = "enablePositionTracker";
-  public static final String CONFIG_ENABLE_BROKER_OFFSET_FETCHER = "enableBrokerOffsetFetcher";
   public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
   public static final String NON_GOOD_STATE_THRESHOLD_MILLIS = "nonGoodStateThresholdMs";
   public static final String PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = "processingDelayLogThreshold";
@@ -50,6 +49,7 @@ public class KafkaBasedConnectorConfig {
   private final Properties _consumerProps;
   private final VerifiableProperties _connectorProps;
   private final KafkaConsumerFactory<?, ?> _consumerFactory;
+  private final KafkaPositionTrackerConfig _kafkaPositionTrackerConfig;
 
   private final String _defaultKeySerde;
   private final String _defaultValueSerde;
@@ -61,8 +61,6 @@ public class KafkaBasedConnectorConfig {
   private final boolean _pausePartitionOnError;
   private final Duration _pauseErrorPartitionDuration;
   private final long _processingDelayLogThresholdMillis;
-  private final boolean _enablePositionTracker;
-  private final boolean _enableBrokerOffsetFetcher;
 
   private final int _daemonThreadIntervalSeconds;
   private final long _nonGoodStateThresholdMillis;
@@ -100,8 +98,6 @@ public class KafkaBasedConnectorConfig {
     _processingDelayLogThresholdMillis =
         verifiableProperties.getLong(PROCESSING_DELAY_LOG_THRESHOLD_MILLIS,
             DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS);
-    _enablePositionTracker = verifiableProperties.getBoolean(CONFIG_ENABLE_POSITION_TRACKER, true);
-    _enableBrokerOffsetFetcher = verifiableProperties.getBoolean(CONFIG_ENABLE_BROKER_OFFSET_FETCHER, true);
     _enablePartitionAssignment = verifiableProperties.getBoolean(ENABLE_PARTITION_ASSIGNMENT, Boolean.FALSE);
 
     String factory =
@@ -113,6 +109,9 @@ public class KafkaBasedConnectorConfig {
 
     _consumerProps = verifiableProperties.getDomainProperties(DOMAIN_KAFKA_CONSUMER);
     _connectorProps = verifiableProperties;
+
+    Properties kafkaPositionTrackerConfigProps = verifiableProperties.getDomainProperties(DOMAIN_KAFKA_POSITION_TRACKER);
+    _kafkaPositionTrackerConfig = new KafkaPositionTrackerConfig(kafkaPositionTrackerConfigProps);
   }
 
   public String getDefaultKeySerde() {
@@ -180,15 +179,11 @@ public class KafkaBasedConnectorConfig {
     return _processingDelayLogThresholdMillis;
   }
 
-  public boolean getEnablePositionTracker() {
-    return _enablePositionTracker;
-  }
-
-  public boolean getEnableBrokerOffsetFetcher() {
-    return _enableBrokerOffsetFetcher;
-  }
-
   public boolean getEnablePartitionAssignment() {
     return _enablePartitionAssignment;
+  }
+
+  public KafkaPositionTrackerConfig getKafkaPositionTrackerConfig() {
+    return _kafkaPositionTrackerConfig;
   }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -70,12 +70,12 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
     String bootstrapValue = csv.toString();
 
     Properties props = new Properties();
-    props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapValue);
-    props.put(ConsumerConfig.GROUP_ID_CONFIG, groupId);
-    props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); // auto-commits are unsafe
-    props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
-    props.put(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, connectionString.isSecure() ? "SSL" : "PLAINTEXT");
     props.putAll(consumerProps);
+    props.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapValue);
+    props.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG, groupId);
+    props.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false"); // auto-commits are unsafe
+    props.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "none");
+    props.putIfAbsent(CommonClientConfigs.SECURITY_PROTOCOL_CONFIG, connectionString.isSecure() ? "SSL" : "PLAINTEXT");
     return props;
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaPositionTrackerConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaPositionTrackerConfig.java
@@ -1,0 +1,136 @@
+/**
+ *  Copyright 2019 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.connectors.kafka;
+
+import java.time.Duration;
+import java.util.Properties;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.linkedin.datastream.common.VerifiableProperties;
+
+/**
+ * User configurable settings for an instance of KafkaPositionTracker.
+ */
+public class KafkaPositionTrackerConfig {
+
+  public static final String CONFIG_ENABLE_POSITION_TRACKER = "enablePositionTracker";
+  public static final String CONFIG_ENABLE_BROKER_OFFSET_FETCHER = "enableBrokerOffsetFetcher";
+  public static final String CONFIG_ENABLE_PARTITION_LEADERSHIP_CALCULATION = "enablePartitionLeadershipCalculation";
+  public static final String CONFIG_BROKER_REQUEST_TIMEOUT_MS = "brokerRequestTimeoutMs";
+  public static final String CONFIG_BROKER_OFFSETS_FETCH_INTERVAL_MS = "brokerOffsetsFetchIntervalMs";
+  public static final String CONFIG_CONSUMER_FAILED_DETECTION_THRESHOLD_MS = "consumerFailedDetectionThresholdMs";
+  public static final String CONFIG_BROKER_OFFSETS_FETCH_SIZE = "brokerOffsetsFetchSize";
+  public static final String CONFIG_PARTITION_LEADERSHIP_CALCULATION_FREQUENCY = "partitionLeadershipCalcuationFrequencyMs";
+
+  public static final Duration DEFAULT_BROKER_REQUEST_TIMEOUT = Duration.ofMinutes(5);
+  public static final Duration DEFAULT_BROKER_OFFSETS_FETCH_INTERVAL = Duration.ofSeconds(30);
+  public static final Duration DEFAULT_CONSUMER_FAILED_DETECTION_THRESHOLD = Duration.ofMinutes(30);
+  public static final int DEFAULT_BROKER_OFFSETS_FETCH_SIZE = 250;
+  public static final Duration DEFAULT_PARTITION_LEADERSHIP_CALCULATION_FREQUENCY = Duration.ofMinutes(5);
+
+  private final boolean _enablePositionTracker;
+  private final boolean _enableBrokerOffsetFetcher;
+  private final boolean _enablePartitionLeadershipCalculation;
+  private final Duration _brokerRequestTimeout;
+  private final Duration _brokerOffsetFetcherInterval;
+  private final Duration _consumerFailedDetectionThreshold;
+  private final int _brokerOffsetsFetchSize;
+  private final Duration _partitionLeadershipCalculationFrequency;
+
+  /**
+   * Constructor for KafkaPositionTrackerConfig.
+   * @param properties The configuration properties to use
+   */
+  public KafkaPositionTrackerConfig(@NotNull Properties properties) {
+    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    _enablePositionTracker = verifiableProperties.getBoolean(CONFIG_ENABLE_POSITION_TRACKER, true);
+    _enableBrokerOffsetFetcher = verifiableProperties.getBoolean(CONFIG_ENABLE_BROKER_OFFSET_FETCHER, true);
+    _enablePartitionLeadershipCalculation =
+        verifiableProperties.getBoolean(CONFIG_ENABLE_PARTITION_LEADERSHIP_CALCULATION, true);
+    long brokerRequestTimeoutMs = verifiableProperties.getLongInRange(CONFIG_BROKER_REQUEST_TIMEOUT_MS,
+        DEFAULT_BROKER_REQUEST_TIMEOUT.toMillis(), 0L, Long.MAX_VALUE);
+    _brokerRequestTimeout = Duration.ofMillis(brokerRequestTimeoutMs);
+    long brokerOffsetFetcherIntervalMs = verifiableProperties.getLongInRange(CONFIG_BROKER_OFFSETS_FETCH_INTERVAL_MS,
+        DEFAULT_BROKER_OFFSETS_FETCH_INTERVAL.toMillis(), 0L, Long.MAX_VALUE);
+    _brokerOffsetFetcherInterval = Duration.ofMillis(brokerOffsetFetcherIntervalMs);
+    long consumerFailedDetectionThresholdMs =
+        verifiableProperties.getLongInRange(CONFIG_CONSUMER_FAILED_DETECTION_THRESHOLD_MS,
+            DEFAULT_CONSUMER_FAILED_DETECTION_THRESHOLD.toMillis(), 0L, Long.MAX_VALUE);
+    _consumerFailedDetectionThreshold = Duration.ofMillis(consumerFailedDetectionThresholdMs);
+    _brokerOffsetsFetchSize = verifiableProperties.getIntInRange(CONFIG_BROKER_OFFSETS_FETCH_SIZE,
+        DEFAULT_BROKER_OFFSETS_FETCH_SIZE, 1, Integer.MAX_VALUE);
+    long partitionLeadershipCalculationFrequencyMs =
+        verifiableProperties.getLongInRange(CONFIG_PARTITION_LEADERSHIP_CALCULATION_FREQUENCY,
+            DEFAULT_PARTITION_LEADERSHIP_CALCULATION_FREQUENCY.toMillis(), 0L, Long.MAX_VALUE);
+    _partitionLeadershipCalculationFrequency = Duration.ofMillis(partitionLeadershipCalculationFrequencyMs);
+  }
+
+  /**
+   * True if we should be tracking the consumer and broker's offsets, false otherwise.
+   */
+  public boolean isEnablePositionTracker() {
+    return _enablePositionTracker;
+  }
+
+  /**
+   * True if we should spin up a separate Kafka consumer and thread to periodically query the broker for its latest
+   * offsets. Used to ensure that we are caught up broker consumption even if we haven't explicitly seen data for that
+   * partition. False otherwise.
+   */
+  public boolean isEnableBrokerOffsetFetcher() {
+    return _enableBrokerOffsetFetcher;
+  }
+
+  /**
+   * True if the broker offset fetcher should attempt to calculate partition leadership to improve broker query
+   * performance, false otherwise.
+   */
+  public boolean isEnablePartitionLeadershipCalculation() {
+    return _enablePartitionLeadershipCalculation;
+  }
+
+  /**
+   * The maximum duration that a consumer request is allowed to take before it times out.
+   */
+  @NotNull
+  public Duration getBrokerRequestTimeout() {
+    return _brokerRequestTimeout;
+  }
+
+  /**
+   * The frequency at which to fetch offsets from the broker.
+   */
+  @NotNull
+  public Duration getBrokerOffsetFetcherInterval() {
+    return _brokerOffsetFetcherInterval;
+  }
+
+  /**
+   * The maximum duration that the BrokerOffsetFetcher can go without any successes (indicating that the underlying
+   * consumer is faulty and should be fixed).
+   */
+  @NotNull
+  public Duration getConsumerFailedDetectionThreshold() {
+    return _consumerFailedDetectionThreshold;
+  }
+
+  /**
+   * The number of offsets to fetch from the broker per endOffsets() RPC call. This should be chosen to avoid timeouts
+   * (larger requests are more likely to cause timeouts).
+   */
+  public int getBrokerOffsetsFetchSize() {
+    return _brokerOffsetsFetchSize;
+  }
+
+  /**
+   * The frequency at which partition leadership is fetched from the Kafka cluster.
+   */
+  @NotNull
+  public Duration getPartitionLeadershipCalculationFrequency() {
+    return _partitionLeadershipCalculationFrequency;
+  }
+}

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -179,14 +179,13 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   protected Consumer<?, ?> createKafkaConsumer(Properties consumerProps) {
     Properties properties = new Properties();
     properties.putAll(consumerProps);
-    String bootstrapValue =
-        _mirrorMakerSource.getBrokers().stream().map(KafkaBrokerAddress::toString).collect(
-            Collectors.joining(KafkaConnectionString.BROKER_LIST_DELIMITER));
+    String bootstrapValue = _mirrorMakerSource.getBrokers().stream().map(KafkaBrokerAddress::toString)
+        .collect(Collectors.joining(KafkaConnectionString.BROKER_LIST_DELIMITER));
     properties.putIfAbsent(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapValue);
     properties.putIfAbsent(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG,
         Boolean.FALSE.toString()); // auto-commits are unsafe
     properties.putIfAbsent(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_EARLIEST);
-    properties.put(ConsumerConfig.GROUP_ID_CONFIG,
+    properties.putIfAbsent(ConsumerConfig.GROUP_ID_CONFIG,
         getMirrorMakerGroupId(_datastreamTask, _groupIdConstructor, _consumerMetrics, LOG));
     LOG.info("Creating Kafka consumer for task {} with properties {}", _datastreamTask, properties);
     return _consumerFactory.createConsumer(properties);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfigBuilder.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfigBuilder.java
@@ -13,12 +13,13 @@ import com.linkedin.datastream.common.VerifiableProperties;
 
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_COMMIT_INTERVAL_MILLIS;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_COMMIT_TIMEOUT_MILLIS;
-import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_ENABLE_POSITION_TRACKER;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_PAUSE_ERROR_PARTITION_DURATION_MILLIS;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_PAUSE_PARTITION_ON_ERROR;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_POLL_TIMEOUT_MILLIS;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_RETRY_COUNT;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_RETRY_SLEEP_DURATION_MILLIS;
+import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.DOMAIN_KAFKA_POSITION_TRACKER;
+import static com.linkedin.datastream.connectors.kafka.KafkaPositionTrackerConfig.CONFIG_ENABLE_POSITION_TRACKER;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -152,7 +153,7 @@ public class KafkaBasedConnectorConfigBuilder {
    * Enable/disable the position tracker
    */
   public KafkaBasedConnectorConfigBuilder setEnablePositionTracker(boolean enablePositionTracker) {
-    _properties.put(CONFIG_ENABLE_POSITION_TRACKER, enablePositionTracker);
+    _properties.put(DOMAIN_KAFKA_POSITION_TRACKER + "." + CONFIG_ENABLE_POSITION_TRACKER, enablePositionTracker);
     return this;
   }
 }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -280,7 +280,8 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
     final Optional<KafkaPositionTracker> kafkaPositionTracker = connectorTask.getKafkaPositionTracker();
     Assert.assertTrue(kafkaPositionTracker.isPresent());
     try (final Consumer<?, ?> consumer = kafkaPositionTracker.get().getConsumerSupplier().get()) {
-      kafkaPositionTracker.get().queryBrokerForLatestOffsets(consumer, Collections.singleton(new TopicPartition(topic, 0)));
+      kafkaPositionTracker.get().queryBrokerForLatestOffsets(consumer,
+          Collections.singleton(new TopicPartition(topic, 0)), Duration.ofSeconds(30));
     }
 
     // Test position data

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaPositionTracker.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaPositionTracker.java
@@ -111,6 +111,12 @@ public class TestKafkaPositionTracker {
           topicPartitionsRaw.stream().map(object -> (TopicPartition) object).collect(Collectors.toSet());
       return _state.getBrokerOffsets(topicPartitions);
     });
+    when(_consumer.endOffsets(anyCollectionOf(TopicPartition.class), any(Duration.class))).thenAnswer(invocation -> {
+      Collection<?> topicPartitionsRaw = invocation.getArgumentAt(0, Collection.class);
+      Set<TopicPartition> topicPartitions =
+          topicPartitionsRaw.stream().map(object -> (TopicPartition) object).collect(Collectors.toSet());
+      return _state.getBrokerOffsets(topicPartitions);
+    });
     when(_consumer.metrics()).thenAnswer(invocation -> _state.getMetricsConsumerLag(_state.getAllTopicPartitions())
         .entrySet()
         .stream()
@@ -284,7 +290,7 @@ public class TestKafkaPositionTracker {
   private void updateBrokerPositionData() {
     final KafkaPositionTracker positionTracker = _connectorTask.getKafkaPositionTracker()
         .orElseThrow(() -> new RuntimeException("Position tracker was not instantiated"));
-    positionTracker.queryBrokerForLatestOffsets(_consumer, _consumer.assignment());
+    positionTracker.queryBrokerForLatestOffsets(_consumer, _consumer.assignment(), Duration.ofSeconds(30));
   }
 
   /**


### PR DESCRIPTION
This change makes a few fixes:
1) The change in [PR#627](https://github.com/linkedin/brooklin/pull/627) did not take effect due to `AbstractKafkaBasedConnectorTask.createKafkaConsumer(Properties)` violating the principal of least surprise and applying overrides inconsistently (sometimes using put()/sometimes using putIfAbsent()). Implementations of the abstract method were changed so that overrides are respected.
2) The Kafka consumer's request timeout (as configured) could be lower than the position tracker class expected, causing a timeout exception to be thrown and the consumer to be needlessly aggressively destroyed/re-created. This sets the request timeout settings explicitly in the consumer properties and moves to the new Kafka 2.0 APIs which allow for a specific Duration to be provided.
3) The endOffsets() RPC call can be slowed down due to the consumer having to fan out its requests to the leader of each partition in the batch (each batch may require a response for up to 250 different brokers). The batching strategy is changed so that an RPC call will only be requested from a single broker at a time, which should improve performance.
4) The timeouts were being consistently hit in very, very large Kafka deployments and so were adjusted to be more lenient.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
