### PR TITLE
Default partition strategy always sends data to single partition

### DIFF
--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -118,8 +118,14 @@ public class KafkaTransportProvider implements TransportProvider {
     } else {
       // If the partition is not specified. We use the partitionKey as the key. Kafka will use the hash of that
       // to determine the partition. If partitionKey does not exist, use the key value.
-      keyValue = record.getPartitionKey().isPresent() ? record.getPartitionKey().get().getBytes() : keyValue;
-      return new ProducerRecord<>(topicName, keyValue, payloadValue);
+      ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topicName, payloadValue);
+
+      if (record.getPartitionKey().isPresent()) {
+        keyValue = record.getPartitionKey().get().getBytes();
+        producerRecord = new ProducerRecord<>(topicName, keyValue, payloadValue);
+      }
+
+      return producerRecord;
     }
   }
 
@@ -142,8 +148,11 @@ public class KafkaTransportProvider implements TransportProvider {
           LOG.error(errorMessage, e);
           throw new DatastreamRuntimeException(errorMessage, e);
         }
+        // Update topic-specific metrics and aggregate metrics
+        int numBytes = outgoing.key() != null ? outgoing.key().length : 0 + outgoing.value().length;
+
         _eventWriteRate.mark();
-        _eventByteWriteRate.mark(outgoing.key().length + outgoing.value().length);
+        _eventByteWriteRate.mark(numBytes);
 
         KafkaProducerWrapper<byte[], byte[]> producer =
             _producers.get(Math.abs(Objects.hash(outgoing.topic(), outgoing.partition())) % _producers.size());
@@ -157,8 +166,6 @@ public class KafkaTransportProvider implements TransportProvider {
           doOnSendCallback(record, onSendComplete, metadata, exception);
         });
 
-        // Update topic-specific metrics and aggregate metrics
-        int numBytes = outgoing.key().length + outgoing.value().length;
         _dynamicMetricsManager.createOrUpdateMeter(_metricsNamesPrefix, topicName, EVENT_WRITE_RATE,
             1);
         _dynamicMetricsManager.createOrUpdateMeter(_metricsNamesPrefix, topicName,

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -118,14 +118,8 @@ public class KafkaTransportProvider implements TransportProvider {
     } else {
       // If the partition is not specified. We use the partitionKey as the key. Kafka will use the hash of that
       // to determine the partition. If partitionKey does not exist, use the key value.
-      ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topicName, payloadValue);
-
-      if (record.getPartitionKey().isPresent()) {
-        keyValue = record.getPartitionKey().get().getBytes();
-        producerRecord = new ProducerRecord<>(topicName, keyValue, payloadValue);
-      }
-
-      return producerRecord;
+      keyValue = record.getPartitionKey().isPresent() ? record.getPartitionKey().get().getBytes() : null;
+      return new ProducerRecord<>(topicName, keyValue, payloadValue);
     }
   }
 
@@ -149,8 +143,8 @@ public class KafkaTransportProvider implements TransportProvider {
           throw new DatastreamRuntimeException(errorMessage, e);
         }
         // Update topic-specific metrics and aggregate metrics
-        int numBytes = outgoing.key() != null ? outgoing.key().length : 0 + outgoing.value().length;
-
+        int numBytes = (outgoing.key() != null ? outgoing.key().length : 0) + outgoing.value().length;
+        
         _eventWriteRate.mark();
         _eventByteWriteRate.mark(numBytes);
 


### PR DESCRIPTION
- if `system.destination.identityPartitioningEnabled` is disabled, the default partitioning applied in
`KafkaTransportProvider` is always sending data to a single partition.

- Based on this piece of code `return new ProducerRecord<>(topicName, partition.get(), keyValue, payloadValue);` the keyValue here is `new byte[0]` when no partition key is provided and it always translates to `partition 9`. 

- I believe if user hasn't provided a partition key, we should make the partition key `null` to make Kafka do default partitioning.

Above fix will make partition key as null when user hasn't provided a partition key to make Kafka go with default partitioning.
