### PR TITLE
Fix a bug in moving partition when there is a paused instance

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
@@ -163,6 +163,20 @@ public class TestZookeeperBackedDatastreamStore {
     _store.updatePartitionAssignments(ds.getName(), ds, targetAssignment, true);
   }
 
+  @Test
+  public void testUpdatePartitionAssignmentsWithPausedInstances() throws Exception {
+    String datastreamGroupName = "dg1";
+    Datastream ds = generateDatastream(0);
+    ds.setMetadata(new StringMap());
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, datastreamGroupName);
+    String clusterName = "testcluster";
+
+    HostTargetAssignment targetAssignment = new HostTargetAssignment(ImmutableList.of("p-0", "p-1"), "instance1");
+    _zkClient.ensurePath(KeyBuilder.instance(clusterName, "instance1-0000"));
+    _zkClient.ensurePath(KeyBuilder.instance(clusterName, "PAUSED_INSTANCE"));
+    _store.updatePartitionAssignments(ds.getName(), ds, targetAssignment, true);
+  }
+
   /**
    * Test invalid parameters or data on DatastreamStore
    */

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -1057,7 +1057,10 @@ public class ZkAdapter {
     return String.format("%s-%s", hostname, instanceName);
   }
 
-  private static String parseHostnameFromZkInstance(String instance) {
+  /**
+   * Parse the Zk instance (ex. hostname-0000) into hostname
+   */
+  public static String parseHostnameFromZkInstance(String instance) {
     return instance.substring(0, instance.lastIndexOf('-'));
   }
 


### PR DESCRIPTION
Filter the instances which is not properly formatted and the PAUSED_INSTANCE when we verifying the hostname during partition movement.