### PR TITLE
Remove reference for DatastreamProducerRecord from the sendcallback

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -276,8 +276,9 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       TopicPartition srcTopicPartition, int numBytes, SendCallback sendCallback) {
     _producer.send(datastreamProducerRecord, ((metadata, exception) -> {
       if (exception != null) {
-        _logger.warn("Detect exception being throw from callback for src partition: {} while sending producer "
-          + "record, metadata: {}, exception: ", srcTopicPartition, metadata, exception);
+        String msg = String.format("Detect exception being thrown from callback for src partition: %s while "
+            + "sending, metadata: %s , exception: ", srcTopicPartition, metadata);
+        _logger.warn(msg, exception);
         rewindAndPausePartitionOnException(srcTopicPartition, exception);
       } else {
         _consumerMetrics.updateBytesProcessedRate(numBytes);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -277,7 +277,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _producer.send(datastreamProducerRecord, ((metadata, exception) -> {
       if (exception != null) {
         _logger.warn("Detect exception being throw from callback for src partition: {} while sending producer "
-          + "record: {}, exception: ", srcTopicPartition, datastreamProducerRecord, exception);
+          + "record, metadata: {}, exception: ", srcTopicPartition, metadata, exception);
         rewindAndPausePartitionOnException(srcTopicPartition, exception);
       } else {
         _consumerMetrics.updateBytesProcessedRate(numBytes);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -189,7 +189,8 @@ public class EventProducer implements DatastreamEventProducer {
           record.getDestination().orElse(_datastreamTask.getDatastreamDestination().getConnectionString());
       record.setEventsSendTimestamp(System.currentTimeMillis());
       _transportProvider.send(destination, record,
-          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record));
+          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record.getEventsSourceTimestamp(),
+              record.getEventsSendTimestamp().orElse(null)));
     } catch (Exception e) {
       String errorMessage = String.format("Failed send the event %s exception %s", record, e);
       _logger.warn(errorMessage, e);
@@ -223,14 +224,14 @@ public class EventProducer implements DatastreamEventProducer {
    * per DatastreamProducerRecord (i.e. by the number of events within the record), only increment all metrics by 1
    * to avoid overcounting.
    */
-  private void reportMetrics(DatastreamRecordMetadata metadata, DatastreamProducerRecord record) {
+  private void reportMetrics(DatastreamRecordMetadata metadata, Long eventSourceTimestamp, Long eventSendTimestamp) {
     // If per-topic metrics are enabled, use topic as key for metrics; else, use datastream name as the key
     String datastreamName = _datastreamTask.getDatastreams().get(0).getName();
     String topicOrDatastreamName = _enablePerTopicMetrics ? metadata.getTopic() : datastreamName;
     // Treat all events within this record equally (assume same timestamp)
-    if (record.getEventsSourceTimestamp() > 0) {
+    if (eventSourceTimestamp != null && eventSourceTimestamp > 0) {
       // Report availability metrics
-      long sourceToDestinationLatencyMs = System.currentTimeMillis() - record.getEventsSourceTimestamp();
+      long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventSourceTimestamp;
       // Using a time sliding window for reporting latency specifically.
       // Otherwise we report very stuck max value for slow source
       _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, topicOrDatastreamName,
@@ -267,21 +268,20 @@ public class EventProducer implements DatastreamEventProducer {
     }
 
     // Report the time it took to just send the events to destination
-    record.getEventsSendTimestamp().ifPresent(sendTimestamp -> {
-      long sendLatency = System.currentTimeMillis() - sendTimestamp;
+    if (eventSendTimestamp != null) {
+      long sendLatency = System.currentTimeMillis() - eventSendTimestamp;
       _dynamicMetricsManager.createOrUpdateHistogram(MODULE, topicOrDatastreamName, EVENTS_SEND_LATENCY_MS_STRING,
           sendLatency);
       _dynamicMetricsManager.createOrUpdateHistogram(MODULE, AGGREGATE, EVENTS_SEND_LATENCY_MS_STRING, sendLatency);
       _dynamicMetricsManager.createOrUpdateHistogram(MODULE, _datastreamTask.getConnectorType(),
           EVENTS_SEND_LATENCY_MS_STRING, sendLatency);
-    });
-
+    }
     _dynamicMetricsManager.createOrUpdateMeter(MODULE, AGGREGATE, EVENT_PRODUCE_RATE, 1);
     _dynamicMetricsManager.createOrUpdateMeter(MODULE, _datastreamTask.getConnectorType(), EVENT_PRODUCE_RATE, 1);
   }
 
   private void onSendCallback(DatastreamRecordMetadata metadata, Exception exception, SendCallback sendCallback,
-      DatastreamProducerRecord record) {
+      Long eventSourceTimestamp, Long eventSendTimestamp) {
 
     SendFailedException sendFailedException = null;
 
@@ -292,7 +292,7 @@ public class EventProducer implements DatastreamEventProducer {
     } else {
       // Report metrics
       checkpoint(metadata.getPartition(), metadata.getCheckpoint());
-      reportMetrics(metadata, record);
+      reportMetrics(metadata, eventSourceTimestamp, eventSendTimestamp);
     }
 
     // Inform the connector about the success or failure, In the case of failure,


### PR DESCRIPTION
Remove reference for datastream Producer Record from the send Callback
to mitigate BMM memory pressure.