### PR TITLE
Fix the datastream state for multiple tasks, and the connector validation

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
@@ -171,6 +171,11 @@ public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
   }
 
   @Override
+  public boolean isPartitionManagementSupported() {
+    return _enablePartitionAssignment;
+  }
+
+  @Override
   public void stop() {
     super.stop();
     _shutdown = true;
@@ -213,7 +218,7 @@ public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
     if (_partitionChangeCallback == null) {
       throw new DatastreamRuntimeException("Partition change callback is not defined");
     }
-    
+
     LOG.info("handleDatastream: original datastream groups: {}, received datastream group {}",
         _partitionDiscoveryThreadMap.keySet(), datastreamGroups);
 

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -89,6 +89,20 @@ public interface Connector extends MetricsAware, DatastreamChangeListener {
   }
 
   /**
+   * Returns whether Brooklin should manage partition assignment
+   *
+   * Brooklin allows the partitions to be managed and assigned by the upstream source (ex. Kafka) or
+   * Brooklin itself. This tells if Brooklin should manage the partition for this connector
+   *
+   * @return
+   *  true if the connector relies on Brooklin to manage partitions
+   *  false if this connector relies on the source (ex. Kafka) to manage and assign partitions
+   */
+  default boolean isPartitionManagementSupported() {
+    return false;
+  }
+
+  /**
    * Compute the topic name, the default implement is based on datastream name and current time.
    * @param datastream the current assignment.
    */

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/DatastreamChangeListener.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/DatastreamChangeListener.java
@@ -48,4 +48,18 @@ public interface DatastreamChangeListener {
   default Map<String, Optional<DatastreamGroupPartitionsMetadata>> getDatastreamPartitions() {
     return new HashMap<>();
   }
+
+  /**
+   * Get if Brooklin can manage partitions the for this connector.
+   *
+   * Brooklin allows the partitions to be managed and assigned by the upstream source (ex. Kafka) or
+   * the Brooklin itself. This tells if the Brooklin should manage the partition for this connector
+   *
+   * @eturn
+   *  true if the connector relies on Brooklin to management partitions
+   *  false if this connector relies on the source (ex. Kafka) to management and assign partitions
+   */
+  default boolean isPartitionManagementSupported() {
+    return false;
+  }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/DatastreamChangeListener.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/DatastreamChangeListener.java
@@ -48,18 +48,4 @@ public interface DatastreamChangeListener {
   default Map<String, Optional<DatastreamGroupPartitionsMetadata>> getDatastreamPartitions() {
     return new HashMap<>();
   }
-
-  /**
-   * Get if Brooklin can manage partitions the for this connector.
-   *
-   * Brooklin allows the partitions to be managed and assigned by the upstream source (ex. Kafka) or
-   * the Brooklin itself. This tells if the Brooklin should manage the partition for this connector
-   *
-   * @eturn
-   *  true if the connector relies on Brooklin to management partitions
-   *  false if this connector relies on the source (ex. Kafka) to management and assign partitions
-   */
-  default boolean isPartitionManagementSupported() {
-    return false;
-  }
 }

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -725,9 +725,13 @@ public class TestCoordinator {
           _callbackThread.interrupt();
         }
       }
+
+      @Override
+      public boolean isPartitionManagementSupported() {
+        return true;
+      }
     };
   }
-
 
   private Map<String, List<Connector>> collectDatastreamAssignment(List<TestHookConnector> connectors) {
     Map<String, List<Connector>> datastreamMap = new HashMap<>();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1343,10 +1343,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
       Connector connectorInstance = connectorInfo.getConnector().getConnectorInstance();
 
-      // connectorInstance.getDatastreamPartitions() will contain the datastream group as key as long as this datastream
-      // is active and leader has assigned the datastream to the connector, regardless of the state of partition listener
-      // As a result, we can use this the key from this map to verify if the partition assignment is supported.
-      if (!(connectorInstance.getDatastreamPartitions().containsKey(DatastreamUtils.getGroupName(datastream)))) {
+      if (!connectorInstance.isPartitionManagementSupported()) {
         String msg = String.format("Partition assignment is not managed by connector, datastream %s",
             datastream.getName());
         _log.error(msg);


### PR DESCRIPTION
Fix the following issues

1) Correctly return the datastream state for all tasks under a single connector rather just return first of them. This will allow us to catch all the assignments correctly.

2) Fix an issue when validating if the connector should support the partition assignment. The original validation can only work on the leader but we should be able to validate in any instance which receives this request. 
