### PR TITLE
Add custom checkpoint datastream metadata field to override connector level custom checkpoint

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -104,4 +104,9 @@ public class DatastreamMetadataConstants {
    * Key to set consumer group ID of the datastream.
    */
   public static final String GROUP_ID = "group.id";
+
+  /**
+   * Datastream override for custom checkpointing. This overrides the connector level flag if present.
+   */
+  public static final String CUSTOM_CHECKPOINT = "system.customCheckpoint";
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -621,21 +621,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _cpProvider.unassignDatastreamTask(t);
   }
 
-  private boolean getCustomCheckpointing(DatastreamTask task) {
-    boolean customCheckpointing = _connectors.get(task.getConnectorType()).isCustomCheckpointing();
-
-    Datastream datastream = task.getDatastreams().get(0);
-    if (datastream.hasMetadata()
-        && datastream.getMetadata().containsKey(DatastreamMetadataConstants.CUSTOM_CHECKPOINT)) {
-      customCheckpointing = Boolean.valueOf(
-          datastream.getMetadata().get(DatastreamMetadataConstants.CUSTOM_CHECKPOINT));
-      _log.info(String.format("Custom checkpointing overridden by metadata to be: %b for datastream: %s",
-          customCheckpointing, datastream));
-    }
-
-    return customCheckpointing;
-  }
-
   private void initializeTask(DatastreamTask task) {
     DatastreamTaskImpl taskImpl = (DatastreamTaskImpl) task;
     assignSerdes(taskImpl);
@@ -649,6 +634,21 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     taskImpl.setEventProducer(producer);
     Map<Integer, String> checkpoints = producer.loadCheckpoints(task);
     taskImpl.setCheckpoints(checkpoints);
+  }
+
+  private boolean getCustomCheckpointing(DatastreamTask task) {
+    boolean customCheckpointing = _connectors.get(task.getConnectorType()).isCustomCheckpointing();
+
+    Datastream datastream = task.getDatastreams().get(0);
+    if (datastream.hasMetadata()
+        && datastream.getMetadata().containsKey(DatastreamMetadataConstants.CUSTOM_CHECKPOINT)) {
+      customCheckpointing = Boolean.valueOf(
+          datastream.getMetadata().get(DatastreamMetadataConstants.CUSTOM_CHECKPOINT));
+      _log.info(String.format("Custom checkpointing overridden by metadata to be: %b for datastream: %s",
+          customCheckpointing, datastream));
+    }
+
+    return customCheckpointing;
   }
 
   private void assignSerdes(DatastreamTaskImpl datastreamTask) {


### PR DESCRIPTION
Add a custom checkpoint datastream metadata field which can be used to override
the connector level custom checkpoint flag.
