### PR TITLE
Fix a race condition in retrying the partition assignment

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -209,9 +209,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   // make sure the scheduled retries are not duplicated
   private final AtomicBoolean leaderDoAssignmentScheduled = new AtomicBoolean(false);
 
-  // make sure the scheduled retries are not duplicated
-  private final AtomicBoolean leaderPartitionAssignmentScheduled = new AtomicBoolean(false);
-
   private final Map<String, SerdeAdmin> _serdeAdmins = new HashMap<>();
   private final Map<String, Authorizer> _authorizers = new HashMap<>();
   private volatile boolean _shutdown = false;
@@ -1036,10 +1033,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         newAssignmentsByInstance.put(key, new ArrayList<>(assignmentByInstance.get(key)));
       }
       _adapter.updateAllAssignments(newAssignmentsByInstance);
-      _log.info("Partition assignment completed: datastreamGroup, assignment {} ", assignmentByInstance);
+      _log.info("Partition assignment completed: datastreamGroup {}, assignment {} ", datastreamGroupName,
+          assignmentByInstance);
       succeeded = true;
     } catch (Exception ex) {
-      _log.info("Partition assignment failed, Exception: ", ex);
+      _log.warn("Partition assignment failed, Exception: ", ex);
       succeeded = false;
     }
     // schedule retry if failure
@@ -1047,13 +1045,15 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       _adapter.cleanupOldUnusedTasks(previousAssignmentByInstance, newAssignmentsByInstance);
       updateCounterForMaxPartitionInTask(newAssignmentsByInstance);
       _dynamicMetricsManager.createOrUpdateMeter(MODULE, NUM_PARTITION_ASSIGNMENTS, 1);
-    } else if (!leaderPartitionAssignmentScheduled.get()) {
-      _log.info("Schedule retry for leader assigning tasks");
+    } else {
       _dynamicMetricsManager.createOrUpdateMeter(MODULE, "handleLeaderPartitionAssignment", NUM_RETRIES, 1);
-      leaderPartitionAssignmentScheduled.set(true);
       _executor.schedule(() -> {
+        _log.warn("Retry scheduled for leader partition assignment, dg {}", datastreamGroupName);
+        // We need to schedule both LEADER_DO_ASSIGNMENT and leader partition assignment in case the tasks are
+        // not locked because the assigned instance is dead. As we use a sticky assignment, the leader do assignment
+        // shouldn't generate too much extra costs
+        _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent());
         _eventQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent(datastreamGroupName));
-        leaderPartitionAssignmentScheduled.set(false);
       }, _config.getRetryIntervalMs(), TimeUnit.MILLISECONDS);
     }
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -155,7 +155,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
    * @param partitionsV2 new partitions for this task
    */
   public DatastreamTaskImpl(DatastreamTaskImpl predecessor, Collection<String> partitionsV2) {
-    if (!predecessor.isLocked() && !predecessor.getPartitionsV2().isEmpty()) {
+    if (!predecessor.isLocked()) {
       throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, "
           + "the previous assignment has not been picked up");
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -388,7 +388,7 @@ public class ZkAdapter {
   }
 
   private void deleteConnectorTask(String connector, String taskName) {
-    LOG.info("Trying to delete task" + taskName);
+    LOG.info("Trying to delete task " + taskName);
     String path = KeyBuilder.connectorTask(_cluster, connector, taskName);
     if (_zkclient.exists(path) && !_zkclient.deleteRecursive(path)) {
       // Ignore such failure for now
@@ -848,8 +848,7 @@ public class ZkAdapter {
         previousAssignmentByInstance.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
     List<DatastreamTask> unusedTasks =
         oldTasks.stream().filter(x -> !newTasks.contains(x)).collect(Collectors.toList());
-    LOG.warn("Deleting the unused tasks {} found between previous {} and new assignment {}. ", unusedTasks,
-        previousAssignmentByInstance, newAssignmentsByInstance);
+    LOG.info("Deleting the unused tasks {} ", unusedTasks);
 
     // Delete the connector tasks.
     unusedTasks.forEach(t -> deleteConnectorTask(t.getConnectorType(), t.getDatastreamTaskName()));


### PR DESCRIPTION
Fix the followings
1. a race condition in retrying partition assignment when multiple datastreams were scheduled to retry at the same time
2. remove a quick path to skip lock checking for dummy tasks, which may potentially introduce race conditions
