### PR TITLE
Replace SlidingTimeWindowReservoir with SlidingTimeWindowArrayReservoir and reduce Histogram time

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.SlidingTimeWindowReservoir;
+import com.codahale.metrics.SlidingTimeWindowArrayReservoir;
 import com.codahale.metrics.Timer;
 
 
@@ -328,7 +328,7 @@ public class DynamicMetricsManager {
   // This function should only be called after "checkCache". So using "synchronized" shouldn't be a problem. The race
   // will only happen briefly after the process starts and before the cache is populated.
   private synchronized Histogram registerAndGetSlidingWindowHistogram(String fullMetricName, long windowTimeMs) {
-    Histogram histogram = new Histogram(new SlidingTimeWindowReservoir(windowTimeMs, TimeUnit.MILLISECONDS));
+    Histogram histogram = new Histogram(new SlidingTimeWindowArrayReservoir(windowTimeMs, TimeUnit.MILLISECONDS));
     try {
       return _metricRegistry.register(fullMetricName, histogram);
     } catch (IllegalArgumentException e) {
@@ -340,7 +340,7 @@ public class DynamicMetricsManager {
 
   /**
    * Update the histogram (or creates it if it does not exist) for the specified key/metricName pair by the given value.
-   * If the histogram does not exist, create one using {@link SlidingTimeWindowReservoir} with the specified window
+   * If the histogram does not exist, create one using {@link SlidingTimeWindowArrayReservoir} with the specified window
    * time in ms. This can be useful for certain metrics that don't want to use the
    * default {@link com.codahale.metrics.ExponentiallyDecayingReservoir}
    * @param classSimpleName the simple name of the underlying class

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -70,7 +70,7 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String AGGREGATE = "aggregate";
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_SLA_MS = "60000"; // 1 minute
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS = "180000"; // 3 minutes
-  private static final long LATENCY_SLIDING_WINDOW_LENGTH_MS = Duration.ofMinutes(5).toMillis();
+  private static final long LATENCY_SLIDING_WINDOW_LENGTH_MS = Duration.ofMinutes(3).toMillis();
   private static final long LONG_FLUSH_WARN_THRESHOLD_MS = Duration.ofMinutes(5).toMillis();
 
   private final DatastreamTask _datastreamTask;


### PR DESCRIPTION
We are noticing OOM with `SlidingTimeWindowReservoir` contributing to lot of memory usage. `SlidingTimeWindowReservoir` using `ConcurrentSkipListMap` internally to keep all the data, while `SlidingTimeWindowArrayReservoir` uses `ChunkedAssociativeLongArray` which uses 128 bytes for each entry. Based on [this PR](https://github.com/dropwizard/metrics/pull/1139), `SlidingTimeWindowArrayReservoir` has better performance because of reuse of chunks and less GC overhead.
We are hitting OOMs because of higher QPS and retention time is 5 minutes. So, to solve this problem, we should reduce the retention time and use a faster reservoir.

