### PR TITLE
Invoke topic manger when the partitions are assigned

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -200,6 +200,10 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       // Consumer can be assigned with an empty set, but it cannot run poll against it
       // While it's allowed to assign an empty set here, the check on poll need to be performed
       _consumer.assign(_consumerAssignment);
+
+      // Invoke topic manager
+      Collection<TopicPartition> topicPartitionsToPause = _topicManager.onPartitionsAssigned(topicPartition);
+      pauseTopicManagerPartitions(topicPartitionsToPause);
     } else {
       LOG.info("About to subscribe to source: {}", _mirrorMakerSource.getTopicName());
       _consumer.subscribe(Pattern.compile(_mirrorMakerSource.getTopicName()), this);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -202,8 +202,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       _consumer.assign(_consumerAssignment);
 
       // Invoke topic manager
-      Collection<TopicPartition> topicPartitionsToPause = _topicManager.onPartitionsAssigned(topicPartition);
-      pauseTopicManagerPartitions(topicPartitionsToPause);
+      handleTopicMangerPartitionAssignment(topicPartition);
     } else {
       LOG.info("About to subscribe to source: {}", _mirrorMakerSource.getTopicName());
       _consumer.subscribe(Pattern.compile(_mirrorMakerSource.getTopicName()), this);
@@ -288,9 +287,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
 
 
 
-  @Override
-  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
-    super.onPartitionsAssigned(partitions);
+  private void handleTopicMangerPartitionAssignment(Collection<TopicPartition> partitions) {
     Collection<TopicPartition> topicPartitionsToPause = _topicManager.onPartitionsAssigned(partitions);
     // we need to explicitly pause these partitions here and not wait for PreConsumerPollHook.
     // The reason being onPartitionsAssigned() gets called as part of Kafka poll, so we need to pause partitions
@@ -299,6 +296,12 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     // Chances are that the current poll call will return data already for that topic/partition and we will end up
     // auto creating that topic.
     pauseTopicManagerPartitions(topicPartitionsToPause);
+  }
+
+  @Override
+  public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    super.onPartitionsAssigned(partitions);
+    handleTopicMangerPartitionAssignment(partitions);
   }
 
   @Override


### PR DESCRIPTION
As there will be no partition assignment callback triggered with low level, we will have to call topicManager explicitly when we created the task assignment. As we don't revoke the partitions but terminate the entire tasks, we dont need to call topicManger on revoke.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.



Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
