### PR TITLE
Enforce JMX metrics name generation logic used in io.dropwizard.metrics prior to v4.1.0-rc2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -350,6 +350,7 @@ project(':datastream-server-restli') {
     compile "org.apache.commons:commons-lang3:$commonslang3Version"
 
     compile project(':datastream-server')
+    compile project(':datastream-common')
 
     testCompile project(':datastream-kafka')
     testCompile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion"

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/JmxReporterFactory.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/JmxReporterFactory.java
@@ -1,0 +1,67 @@
+/**
+ *  Copyright 2019 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.metrics;
+
+import javax.management.MalformedObjectNameException;
+import javax.management.ObjectName;
+
+import org.apache.commons.lang.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.jmx.JmxReporter;
+import com.codahale.metrics.jmx.ObjectNameFactory;
+
+
+/**
+ * A factory for {@link JmxReporter} objects that generates metrics whose
+ * names are decided according to {@link BrooklinObjectNameFactory}.
+ */
+public class JmxReporterFactory {
+  private static final ObjectNameFactory OBJECT_NAME_FACTORY = new BrooklinObjectNameFactory();
+
+  /**
+   * Creates a {@link JmxReporter} that generates metrics whose names
+   * are decided according to the {@link BrooklinObjectNameFactory}.
+   */
+  public static JmxReporter createJmxReporter(MetricRegistry metricRegistry) {
+    Validate.notNull(metricRegistry);
+
+    return JmxReporter.forRegistry(metricRegistry)
+        .createsObjectNamesWith(OBJECT_NAME_FACTORY)
+        .build();
+  }
+
+  /**
+   * An implementation of {@link ObjectNameFactory} that uses the same method
+   * for generating metric names as that employed by {@code io.dropwizard.metrics}'s
+   * {@link com.codahale.metrics.jmx.DefaultObjectNameFactory} prior to {@code v4.1.0-rc2}.
+   * In particular, this implementation does not encode metric types in the names
+   * of the generated JMX MBeans/metrics.
+   */
+  private static class BrooklinObjectNameFactory implements ObjectNameFactory {
+    private static final Logger LOGGER = LoggerFactory.getLogger(JmxReporter.class);
+
+    @Override
+    public ObjectName createName(String type, String domain, String name) {
+      try {
+        ObjectName objectName = new ObjectName(domain, "name", name);
+        if (objectName.isPattern()) {
+          objectName = new ObjectName(domain, "name", ObjectName.quote(name));
+        }
+        return objectName;
+      } catch (MalformedObjectNameException e) {
+        try {
+          return new ObjectName(domain, "name", ObjectName.quote(name));
+        } catch (MalformedObjectNameException e1) {
+          LOGGER.warn("Unable to register {} {}", type, name, e1);
+          throw new RuntimeException(e1);
+        }
+      }
+    }
+  }
+}

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -39,6 +39,7 @@ import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.metrics.JmxReporterFactory;
 import com.linkedin.datastream.server.api.connector.Connector;
 import com.linkedin.datastream.server.api.connector.ConnectorFactory;
 import com.linkedin.datastream.server.api.connector.DatastreamDeduper;
@@ -76,7 +77,6 @@ import static com.linkedin.datastream.server.DatastreamServerConfigurationConsta
 import static com.linkedin.datastream.server.DatastreamServerConfigurationConstants.DOMAIN_DEDUPER;
 import static com.linkedin.datastream.server.DatastreamServerConfigurationConstants.DOMAIN_DIAG;
 import static com.linkedin.datastream.server.DatastreamServerConfigurationConstants.STRATEGY_DOMAIN;
-
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
 import static java.util.concurrent.TimeUnit.MINUTES;
 import static java.util.concurrent.TimeUnit.SECONDS;
@@ -349,7 +349,7 @@ public class DatastreamServer {
     METRIC_INFOS.addAll(_coordinator.getMetricInfos());
     METRIC_INFOS.addAll(DatastreamResources.getMetricInfos());
 
-    _jmxReporter = JmxReporter.forRegistry(METRIC_REGISTRY).build();
+    _jmxReporter = JmxReporterFactory.createJmxReporter(METRIC_REGISTRY);
 
     if (StringUtils.isNotEmpty(_csvMetricsDir)) {
       LOG.info("Starting CsvReporter in " + _csvMetricsDir);


### PR DESCRIPTION
This change restores the JMX metrics name generation logic used in
io.dropwizard.metrics prior to v.4.1.0-rc2 in order to avoid breaking
our existing metrics graphs and dashboards.
