### PR TITLE
Initiate the Kafka position tracker when the task is created

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -682,13 +682,15 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   @Override
   public void onPartitionsAssigned(Collection<TopicPartition> partitions) {
+    this.onPartitionsAssignedInternal(partitions);
     _logger.info("{} Partition ownership assigned for {}.", _datastreamTask.getDatastreamTaskName(), partitions);
-    _kafkaPositionTracker.ifPresent(tracker -> tracker.onPartitionsAssigned(partitions));
     _consumerMetrics.updateRebalanceRate(1);
-
     updateConsumerAssignment(partitions);
+  }
 
-    // update paused partitions, in case.
+  protected void onPartitionsAssignedInternal(Collection<TopicPartition> partitions) {
+    _kafkaPositionTracker.ifPresent(tracker -> tracker.onPartitionsAssigned(partitions));
+    // update paused partitions, in case
     _taskUpdates.add(DatastreamConstants.UpdateType.PAUSE_RESUME_PARTITIONS);
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -199,7 +199,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       // Consumer can be assigned with an empty set, but it cannot run poll against it
       // While it's allowed to assign an empty set here, the check on poll need to be performed
       _consumer.assign(_consumerAssignment);
-
+      this.onPartitionsAssignedInternal(topicPartition);
       // Invoke topic manager
       handleTopicMangerPartitionAssignment(topicPartition);
     } else {


### PR DESCRIPTION
Fix an issue where Kafka position tracker is not triggered in a Brooklin-managed partition assignment
