### PR TITLE
Add record index to DatastreamRecordMetadata

### DIFF
--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -147,14 +147,14 @@ public class KafkaTransportProvider implements TransportProvider {
         KafkaProducerWrapper<byte[], byte[]> producer =
             _producers.get(Math.abs(Objects.hash(outgoing.topic(), outgoing.partition())) % _producers.size());
 
-        final int recordIndex = index;
+        final int eventIndex = index;
         producer.send(_datastreamTask, outgoing, (metadata, exception) -> {
           int partition = metadata != null ? metadata.partition() : -1;
           if (exception != null) {
             LOG.error("Sending a message with source checkpoint {} to topic {} partition {} for datastream task {} "
                     + "threw an exception.", record.getCheckpoint(), topicName, partition, _datastreamTask, exception);
           }
-          doOnSendCallback(record, onSendComplete, metadata, exception, recordIndex);
+          doOnSendCallback(record, onSendComplete, metadata, exception, eventIndex);
         });
 
         _dynamicMetricsManager.createOrUpdateMeter(_metricsNamesPrefix, topicName, EVENT_WRITE_RATE, 1);
@@ -188,11 +188,11 @@ public class KafkaTransportProvider implements TransportProvider {
   }
 
   private void doOnSendCallback(DatastreamProducerRecord record, SendCallback onComplete, RecordMetadata metadata,
-      Exception exception, int recordIndex) {
+      Exception exception, int eventIndex) {
     if (onComplete != null) {
       onComplete.onCompletion(
           metadata != null ? new DatastreamRecordMetadata(record.getCheckpoint(), metadata.topic(),
-              metadata.partition(), recordIndex) : null, exception);
+              metadata.partition(), eventIndex) : null, exception);
     }
   }
 

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
@@ -13,10 +13,10 @@ public class DatastreamRecordMetadata {
   private final String _topic;
   private final int _partition;
   private final String _checkpoint;
-  private final int _brooklinEventIndex;
+  private final int _eventIndex;
 
   /**
-   * Construct an instance of DatastreamRecordMetadata. Defaults the record index to 0.
+   * Construct an instance of DatastreamRecordMetadata. Defaults the event index to 0.
    * @param  checkpoint checkpoint string
    * @param topic Kafka topic name
    * @param partition Kafka topic partition
@@ -25,7 +25,7 @@ public class DatastreamRecordMetadata {
     _checkpoint = checkpoint;
     _topic = topic;
     _partition = partition;
-    _brooklinEventIndex = 0;
+    _eventIndex = 0;
   }
 
   /**
@@ -33,13 +33,13 @@ public class DatastreamRecordMetadata {
    * @param checkpoint checkpoint string
    * @param topic Kafka topic name
    * @param partition Kafka topic partition
-   * @param brooklinEventIndex Index of event within {@link com.linkedin.datastream.server.DatastreamProducerRecord}
+   * @param eventIndex Index of event within {@link com.linkedin.datastream.server.DatastreamProducerRecord}
    */
-  public DatastreamRecordMetadata(String checkpoint, String topic, int partition, int brooklinEventIndex) {
+  public DatastreamRecordMetadata(String checkpoint, String topic, int partition, int eventIndex) {
     _checkpoint = checkpoint;
     _topic = topic;
     _partition = partition;
-    _brooklinEventIndex = brooklinEventIndex;
+    _eventIndex = eventIndex;
   }
 
   /**
@@ -64,15 +64,16 @@ public class DatastreamRecordMetadata {
   }
 
   /**
-   * Event index within the {@link com.linkedin.datastream.server.DatastreamProducerRecord}'s event list
+   * An index identifying the exact {@link com.linkedin.datastream.common.BrooklinEnvelope} event produced,
+   * from those obtainable through {@link com.linkedin.datastream.server.DatastreamProducerRecord#getEvents()}
    */
-  public int getBrooklinEventIndex() {
-    return _brooklinEventIndex;
+  public int getEventIndex() {
+    return _eventIndex;
   }
 
   @Override
   public String toString() {
     return String.format("Checkpoint: %s, Topic: %s, Partition: %d, Event Index: %d", _checkpoint, _topic, _partition,
-        _brooklinEventIndex);
+        _eventIndex);
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
@@ -13,9 +13,10 @@ public class DatastreamRecordMetadata {
   private final String _topic;
   private final int _partition;
   private final String _checkpoint;
+  private final int _recordIndex;
 
   /**
-   * Construct an instance of DatastreamRecordMetadata
+   * Construct an instance of DatastreamRecordMetadata. Defaults the record index to 0.
    * @param  checkpoint checkpoint string
    * @param topic Kafka topic name
    * @param partition Kafka topic partition
@@ -24,6 +25,21 @@ public class DatastreamRecordMetadata {
     _checkpoint = checkpoint;
     _topic = topic;
     _partition = partition;
+    _recordIndex = 0;
+  }
+
+  /**
+   * Construct an instance of DatastreamRecordMetadata.
+   * @param checkpoint checkpoint string
+   * @param topic Kafka topic name
+   * @param partition Kafka topic partition
+   * @param recordIndex Index of event within {@link com.linkedin.datastream.server.DatastreamProducerRecord}
+   */
+  public DatastreamRecordMetadata(String checkpoint, String topic, int partition, int recordIndex) {
+    _checkpoint = checkpoint;
+    _topic = topic;
+    _partition = partition;
+    _recordIndex = recordIndex;
   }
 
   /**
@@ -47,8 +63,16 @@ public class DatastreamRecordMetadata {
     return _topic;
   }
 
+  /**
+   * Event index within the {@link com.linkedin.datastream.server.DatastreamProducerRecord}'s event list
+   */
+  public int getRecordIndex() {
+    return _recordIndex;
+  }
+
   @Override
   public String toString() {
-    return String.format("Checkpoint: %s, Topic: %s, Partition: %d", _checkpoint, _topic, _partition);
+    return String.format("Checkpoint: %s, Topic: %s, Partition: %d, Record Index: %d", _checkpoint, _topic, _partition,
+        _recordIndex);
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
@@ -13,7 +13,7 @@ public class DatastreamRecordMetadata {
   private final String _topic;
   private final int _partition;
   private final String _checkpoint;
-  private final int _recordIndex;
+  private final int _brooklinEventIndex;
 
   /**
    * Construct an instance of DatastreamRecordMetadata. Defaults the record index to 0.
@@ -25,7 +25,7 @@ public class DatastreamRecordMetadata {
     _checkpoint = checkpoint;
     _topic = topic;
     _partition = partition;
-    _recordIndex = 0;
+    _brooklinEventIndex = 0;
   }
 
   /**
@@ -33,13 +33,13 @@ public class DatastreamRecordMetadata {
    * @param checkpoint checkpoint string
    * @param topic Kafka topic name
    * @param partition Kafka topic partition
-   * @param recordIndex Index of event within {@link com.linkedin.datastream.server.DatastreamProducerRecord}
+   * @param brooklinEventIndex Index of event within {@link com.linkedin.datastream.server.DatastreamProducerRecord}
    */
-  public DatastreamRecordMetadata(String checkpoint, String topic, int partition, int recordIndex) {
+  public DatastreamRecordMetadata(String checkpoint, String topic, int partition, int brooklinEventIndex) {
     _checkpoint = checkpoint;
     _topic = topic;
     _partition = partition;
-    _recordIndex = recordIndex;
+    _brooklinEventIndex = brooklinEventIndex;
   }
 
   /**
@@ -66,13 +66,13 @@ public class DatastreamRecordMetadata {
   /**
    * Event index within the {@link com.linkedin.datastream.server.DatastreamProducerRecord}'s event list
    */
-  public int getRecordIndex() {
-    return _recordIndex;
+  public int getBrooklinEventIndex() {
+    return _brooklinEventIndex;
   }
 
   @Override
   public String toString() {
-    return String.format("Checkpoint: %s, Topic: %s, Partition: %d, Record Index: %d", _checkpoint, _topic, _partition,
-        _recordIndex);
+    return String.format("Checkpoint: %s, Topic: %s, Partition: %d, Event Index: %d", _checkpoint, _topic, _partition,
+        _brooklinEventIndex);
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProvider.java
@@ -25,7 +25,7 @@ public interface TransportProvider {
    * @param destination the destination topic to which the record should be sent.
    * @param record DatastreamEvent that needs to be sent to the stream.
    * @param onComplete call back that needs to called when the send completes. Any exception during sending will
-   *                   be reported through callback
+   *                   be reported through callback. A callback must be called for each event in the record.
    */
   void send(String destination, DatastreamProducerRecord record, SendCallback onComplete);
 


### PR DESCRIPTION
This change adds a record index to the DatastreamRecordMetadata.
An index is useful to have in cases where multiple events are bundled up
in a single DatastreamProducerRecord. The send callback is called for each
event, and it can be useful to know which event in the DatastreamProducerRecord
this callback is being received for.
As part of this change, KafkaTransportProvider has been updated to pass this
information as part of the DatastreamRecordMetadata created and returned in
the callback.
Add some tests around sending multiple events in a single DatastreamProducerRecord.
