### PR TITLE
Allow Connector to ValidateAndUpdateDatastreams instead of ValidateUpdateDatastreams

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -268,7 +268,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
   }
 
   @Override
-  public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+  public void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     // validate for paused partitions
     validatePausedPartitions(datastreams, allDatastreams);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
@@ -792,10 +792,10 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
         .put(DatastreamMetadataConstants.PAUSED_SOURCE_PARTITIONS_KEY, JsonUtils.toJson(pausedPartitions));
     boolean validationSuccess = PollUtils.poll(() -> {
       try {
-        connector.validateUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
+        connector.validateAndUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
         return expectedPartitions.equals(DatastreamUtils.getDatastreamSourcePartitions(datastream));
       } catch (Exception e) {
-        LOG.warn("validateUpdateDatastreams failed with error: " + e);
+        LOG.warn("validateAndUpdateDatastreams failed with error: " + e);
         return false;
       }
     }, POLL_PERIOD_MS, POLL_TIMEOUT_MS);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -371,7 +371,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         .put(DatastreamMetadataConstants.PAUSED_SOURCE_PARTITIONS_KEY, JsonUtils.toJson(pausedPartitions));
 
     // Update connector task with paused partitions
-    connector.validateUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
+    connector.validateAndUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
     connectorTask.checkForUpdateTask(datastreamTask);
 
     // Make sure there was an update, and that there paused partitions.
@@ -424,7 +424,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     pausedPartitions.put(spicyTopic, new HashSet<>(Collections.singletonList("0")));
     datastream.getMetadata()
         .put(DatastreamMetadataConstants.PAUSED_SOURCE_PARTITIONS_KEY, JsonUtils.toJson(pausedPartitions));
-    connector.validateUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
+    connector.validateAndUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
     connectorTask.checkForUpdateTask(datastreamTask);
     if (!PollUtils.poll(() -> connectorTask.getPausedPartitionsConfigUpdateCount() == 2, POLL_PERIOD_MS,
         POLL_TIMEOUT_MS)) {
@@ -456,7 +456,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
 
     // Now resume both the partitions.
     datastream.getMetadata().put(DatastreamMetadataConstants.PAUSED_SOURCE_PARTITIONS_KEY, "");
-    connector.validateUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
+    connector.validateAndUpdateDatastreams(Collections.singletonList(datastream), Collections.singletonList(datastream));
     connectorTask.checkForUpdateTask(datastreamTask);
     if (!PollUtils.poll(() -> connectorTask.getPausedPartitionsConfigUpdateCount() == 4, POLL_PERIOD_MS,
         POLL_TIMEOUT_MS)) {

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/NoOpConnectorFactory.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/NoOpConnectorFactory.java
@@ -72,7 +72,7 @@ public class NoOpConnectorFactory implements ConnectorFactory<NoOpConnectorFacto
      * @throws DatastreamValidationException
      */
     @Override
-    public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+    public void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
       for (Datastream newDatastream : datastreams) {
         List<Datastream> existingDatastreams = allDatastreams.stream().filter(ds -> ds.getName()

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -66,14 +66,14 @@ public interface Connector extends MetricsAware, DatastreamChangeListener {
   void initializeDatastream(Datastream stream, List<Datastream> allDatastreams) throws DatastreamValidationException;
 
   /**
-   * Validate the update datastreams operation. By default this is not supported. Any connectors that want to support
-   * datastream updates should override this method to perform the validation needed.
+   * Validate and update the datastreams during update operation. By default this is not supported. Any connectors that
+   * want to support datastream updates should override this method to perform the validation needed.
    * @param datastreams list of datastreams to be updated
    * @param allDatastreams all existing datastreams in the system of connector type of the datastream that is being
    *                       validated.
    * @throws DatastreamValidationException when the datastreams update is not valid
    */
-  default void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+  default void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
     throw new DatastreamValidationException("Datastream update is not supported");
   }

--- a/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestNoOpConnectorFactory.java
+++ b/datastream-server-api/src/test/java/com/linkedin/datastream/server/TestNoOpConnectorFactory.java
@@ -39,7 +39,7 @@ public class TestNoOpConnectorFactory {
   }
 
   @Test
-  public void testValidateUpdateDatastreams() throws Exception {
+  public void testvalidateAndUpdateDatastreams() throws Exception {
     Properties properties = new Properties();
 
     NoOpConnectorFactory noOpConnectorFactory = new NoOpConnectorFactory();
@@ -50,13 +50,13 @@ public class TestNoOpConnectorFactory {
     Datastream datastream2 = createDatastream("noOp-2", "likafkakac");
 
     // Happy path - no change in either datastream
-    connector.validateUpdateDatastreams(Arrays.asList(datastream1, datastream2), Arrays.asList(datastream1, datastream2));
+    connector.validateAndUpdateDatastreams(Arrays.asList(datastream1, datastream2), Arrays.asList(datastream1, datastream2));
 
     // Try to modify source on one of the datastreams
     Datastream datastream3 = createDatastream("noOp-2", "likafkakac");
     datastream3.getSource().setConnectionString("source-blah");
     try {
-      connector.validateUpdateDatastreams(Arrays.asList(datastream1, datastream3), Arrays.asList(datastream1, datastream2));
+      connector.validateAndUpdateDatastreams(Arrays.asList(datastream1, datastream3), Arrays.asList(datastream1, datastream2));
       Assert.fail();
     } catch (DatastreamValidationException e) {
     }
@@ -65,7 +65,7 @@ public class TestNoOpConnectorFactory {
     datastream3 = createDatastream("noOp-1", "likafkakac");
     datastream3.getDestination().setConnectionString("dest-blah");
     try {
-      connector.validateUpdateDatastreams(Arrays.asList(datastream3, datastream2), Arrays.asList(datastream1, datastream2));
+      connector.validateAndUpdateDatastreams(Arrays.asList(datastream3, datastream2), Arrays.asList(datastream1, datastream2));
       Assert.fail();
     } catch (DatastreamValidationException e) {
     }
@@ -73,7 +73,7 @@ public class TestNoOpConnectorFactory {
     // Try to modify the transport provider name on one of the datastreams
     datastream3 = createDatastream("noOp-2", "likafkakactest");
     try {
-      connector.validateUpdateDatastreams(Arrays.asList(datastream1, datastream3), Arrays.asList(datastream1, datastream2));
+      connector.validateAndUpdateDatastreams(Arrays.asList(datastream1, datastream3), Arrays.asList(datastream1, datastream2));
       Assert.fail();
     } catch (DatastreamValidationException e) {
     }
@@ -81,12 +81,12 @@ public class TestNoOpConnectorFactory {
     // Happy path - try to modify the metadata on one of the datastreams
     datastream3 = createDatastream("noOp-1", "likafkakac");
     datastream3.getMetadata().put("random-metadata-key", "random-metadata-value");
-    connector.validateUpdateDatastreams(Arrays.asList(datastream3, datastream2), Arrays.asList(datastream1, datastream2));
+    connector.validateAndUpdateDatastreams(Arrays.asList(datastream3, datastream2), Arrays.asList(datastream1, datastream2));
 
     // Happy path - modify already existing metadata on one of the datastreams
     datastream2.getMetadata().put("metadata-key", "metadata-value");
     datastream3 = createDatastream("noOp-2", "likafkakac");
     datastream3.getMetadata().put("metadata-key", "new-metadata-value");
-    connector.validateUpdateDatastreams(Arrays.asList(datastream1, datastream3), Arrays.asList(datastream1, datastream2));
+    connector.validateAndUpdateDatastreams(Arrays.asList(datastream1, datastream3), Arrays.asList(datastream1, datastream2));
   }
 }

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2560,7 +2560,7 @@ public class TestCoordinator {
     }
 
     @Override
-    public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+    public void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
         throws DatastreamValidationException {
       if (!_allowDatastreamUpdate) {
         throw new DatastreamValidationException("not allowed");
@@ -2595,7 +2595,7 @@ public class TestCoordinator {
     }
 
     @Override
-    public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+    public void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
         throws DatastreamValidationException {
       if (!_allowDatastreamUpdate) {
         throw new DatastreamValidationException("not allowed");

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -180,17 +180,17 @@ public class ConnectorWrapper {
   }
 
   /**
-   * Wrapper API to validate updates to given datastreams. This API calls connector's {@link Connector#validateUpdateDatastreams}.
+   * Wrapper API to validate updates to given datastreams. This API calls connector's {@link Connector#validateAndUpdateDatastreams}.
    * @param datastreams List of datastreams whose update needs to be validated.
    * @param allDatastreams all existing datastreams in the system that have the same connector type as the datastream
    *    *                  being updated.
    * @throws DatastreamValidationException
    */
-  public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+  public void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
-    logApiStart("validateUpdateDatastreams");
-    _connector.validateUpdateDatastreams(datastreams, allDatastreams);
-    logApiEnd("validateUpdateDatastreams");
+    logApiStart("validateAndUpdateDatastreams");
+    _connector.validateAndUpdateDatastreams(datastreams, allDatastreams);
+    logApiEnd("validateAndUpdateDatastreams");
   }
 
   /**

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1333,7 +1333,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       }
 
       connectorInfo.getConnector()
-          .validateUpdateDatastreams(datastreams, _datastreamCache.getAllDatastreams()
+          .validateAndUpdateDatastreams(datastreams, _datastreamCache.getAllDatastreams()
               .stream()
               .filter(d -> d.getConnectorName().equals(connectorName))
               .collect(Collectors.toList()));

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/BrokenConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/BrokenConnector.java
@@ -68,7 +68,7 @@ public class BrokenConnector implements Connector, DiagnosticsAware {
   }
 
   @Override
-  public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+  public void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
   }
 

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
@@ -68,7 +68,7 @@ public class DummyConnector implements Connector, DiagnosticsAware {
   }
 
   @Override
-  public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
+  public void validateAndUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
   }
 


### PR DESCRIPTION
Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
