### PR TITLE
Ensure existing ZK session closed before opening a new one

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -201,6 +201,7 @@ public class ZkAdapter {
    * the actions that need to be taken with them, which are implemented in the Coordinator class
    */
   public void connect() {
+    disconnect(); // Guard against leaking an existing zookeeper session
     _zkclient = new ZkClient(_zkServers, _sessionTimeout, _connectionTimeout);
 
     // create a globally unique instance name and create a live instance node in ZooKeeper


### PR DESCRIPTION
It looks like `ZkAdapter.joinLeaderElection()` calls `connect()` without an accompanying call to `disconnect()` when it can't find its node name in the ZK liveinstances path. The assumption is that the existing ZK session is dead and unrecoverable.

In practice, this does not seem to always be the case, and the consequence of calling `connect()` before `disconnect()` means that we leak a ZK session which hold onto ephemeral nodes and poison the ZK state.

A permanent fix to this issue is to guard `connect()` with `disconnect()`, which is the change this PR makes.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
