### PR TITLE
Release the datastream task lock after shutdown is complete and not during stop()

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -207,6 +207,11 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       throws Exception;
 
   /**
+   * Post shutdown hook to be called for any operations that need to be performed before exiting the task.
+   */
+  protected void postShutdownHook() { }
+
+  /**
    * Get the taskName
    */
   protected String getTaskName() {
@@ -349,6 +354,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       if (null != _consumer) {
         _consumer.close();
       }
+      postShutdownHook();
       _logger.info("{} stopped", _taskName);
     }
   }


### PR DESCRIPTION
Partition-managed BMM:
Currently the datastream task lock is released on the call to stop(). This is incorrect because stop() only sets a flag indicating a shutdown has been triggered. The actual task thread will complete its current loop, commit offsets, and then complete (or throw exception). The finally() block of the run-loop is where the consumer is closed, and is a safe point in time to release the lock, since consumption is no longer possible. This change adds a postShutdownHook(), and implements this for the KafkaMirrorMakerConnectorTask.