### PR TITLE
Deleting connector task nodes shouldn't do an ls

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -866,7 +866,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       _log.info(
           "No datastream left in the datastream group with taskPrefix {}. Deleting all tasks corresponding to the datastream.",
           taskPrefix);
-      _adapter.deleteTasksWithPrefix(_connectors.keySet(), taskPrefix);
+      _adapter.deleteTasksWithPrefix(ds.getConnectorName(), taskPrefix);
       deleteTopic(ds);
     } else {
       _log.info("Found duplicate datastream {} for the datastream to be deleted {}. Not deleting the tasks.",

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -165,13 +165,13 @@ public class ZkAdapter {
    * @param zkServers ZooKeeper server address to connect to
    * @param cluster Brooklin cluster this instance belongs to
    * @param defaultTransportProviderName Default transport provider to use for a newly created task
-   * @param sessionTimeout Session timeout to use for the connection with the ZooKeeper server
-   * @param connectionTimeout Connection timeout to use for the connection with the ZooKeeper server
+   * @param sessionTimeoutMs Session timeout to use for the connection with the ZooKeeper server
+   * @param connectionTimeoutMs Connection timeout to use for the connection with the ZooKeeper server
    * @param listener ZKAdapterListener implementation to receive callbacks based on various znode changes
    */
-  public ZkAdapter(String zkServers, String cluster, String defaultTransportProviderName, int sessionTimeout,
-      int connectionTimeout, ZkAdapterListener listener) {
-    this(zkServers, cluster, defaultTransportProviderName, sessionTimeout, connectionTimeout, -1,
+  public ZkAdapter(String zkServers, String cluster, String defaultTransportProviderName, int sessionTimeoutMs,
+      int connectionTimeoutMs, ZkAdapterListener listener) {
+    this(zkServers, cluster, defaultTransportProviderName, sessionTimeoutMs, connectionTimeoutMs, -1,
         listener);
   }
 
@@ -1324,11 +1324,6 @@ public class ZkAdapter {
     public void handleDataDeleted(String dataPath) throws Exception {
       // do nothing
     }
-  }
-
-  @VisibleForTesting
-  ZkClient getZkClient() {
-    return _zkclient;
   }
 
   /**

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -46,7 +46,7 @@ import static org.mockito.Mockito.spy;
  * Tests for {@link ZkAdapter}
  */
 public class TestZkAdapter {
-  private static final Logger LOG = LoggerFactory.getLogger(TestZkAdapter.class);
+  private static final Logger LOG = LoggerFactory.getLogger(com.linkedin.datastream.server.zk.TestZkAdapter.class);
   private static final int ZK_WAIT_IN_MS = 500;
 
   private final String defaultTransportProviderName = "test";
@@ -695,23 +695,23 @@ public class TestZkAdapter {
     Assert.assertTrue(PollUtils.poll(task2::isLocked, 100, 5000));
   }
 
-  private SpyingZkAdapter createSpyingZkAdapter(String testCluster) {
-    return new SpyingZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,  ZkClient.DEFAULT_SESSION_TIMEOUT,
-        ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
+  private ZkClientInterceptingAdapter createInterceptingZkAdapter(String testCluster) {
+    return new ZkClientInterceptingAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
+        ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
   }
 
-  private static class SpyingZkAdapter extends ZkAdapter {
+  private static class ZkClientInterceptingAdapter extends ZkAdapter {
     private ZkClient _zkClient;
 
-    public SpyingZkAdapter(String zkConnectionString, String testCluster, String defaultTransportProviderName,
-        int defaultSessionTimeout, int defaultConnectionTimeout, ZkAdapterListener listener) {
-      super(zkConnectionString, testCluster, defaultTransportProviderName, defaultSessionTimeout,
-          defaultConnectionTimeout, listener);
+    public ZkClientInterceptingAdapter(String zkConnectionString, String testCluster, String defaultTransportProviderName,
+        int defaultSessionTimeoutMs, int defaultConnectionTimeoutMs, ZkAdapterListener listener) {
+      super(zkConnectionString, testCluster, defaultTransportProviderName, defaultSessionTimeoutMs,
+          defaultConnectionTimeoutMs, listener);
     }
 
     @Override
     ZkClient createZkClient() {
-      _zkClient = spy(super.createZkClient());
+      _zkClient = super.createZkClient();
       return _zkClient;
     }
 
@@ -725,7 +725,7 @@ public class TestZkAdapter {
     String testCluster = "testDeleteTaskWithPrefix";
     String connectorType = "connectorType";
 
-    SpyingZkAdapter adapter = createSpyingZkAdapter(testCluster);
+    ZkClientInterceptingAdapter adapter = createInterceptingZkAdapter(testCluster);
     adapter.connect();
 
     List<DatastreamTask> tasks = new ArrayList<>();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -63,12 +63,12 @@ public class TestZkAdapter {
   }
 
   @AfterMethod
-  public void teardown() throws IOException {
+  public void teardown() {
     _embeddedZookeeper.shutdown();
   }
 
   @Test
-  public void testInstanceName() throws Exception {
+  public void testInstanceName() {
     String testCluster = "testInstanceName";
 
     //
@@ -97,12 +97,12 @@ public class TestZkAdapter {
   }
 
   private ZkAdapter createZkAdapter(String testCluster) {
-    return new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,  ZkClient.DEFAULT_SESSION_TIMEOUT,
-        ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
+    return new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
+        ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
   }
 
   @Test
-  public void testSmoke() throws Exception {
+  public void testSmoke() {
     String testCluster = "test_adapter_smoke";
 
     ZkAdapter adapter1 = createZkAdapter(testCluster);
@@ -125,7 +125,7 @@ public class TestZkAdapter {
   }
 
   @Test
-  public void testLeaderElection() throws Exception {
+  public void testLeaderElection() {
     String testCluster = "test_adapter_leader";
 
     //
@@ -454,7 +454,7 @@ public class TestZkAdapter {
 
   @Test
   // CHECKSTYLE:OFF
-  public void testInstanceAssignmentWithPartitions() throws Exception {
+  public void testInstanceAssignmentWithPartitions() {
     String testCluster = "testInstanceAssignmentWithPartitions";
     String connectorType = "connectorType";
     ZkClient zkClient = new ZkClient(_zkConnectionString);
@@ -526,7 +526,7 @@ public class TestZkAdapter {
   }
 
   @Test
-  public void testTaskAcquireRelease() throws Exception {
+  public void testTaskAcquireRelease() {
     String testCluster = "testTaskAcquireRelease";
     String connectorType = "connectorType";
     Duration timeout = Duration.ofMinutes(1);
@@ -570,7 +570,7 @@ public class TestZkAdapter {
    * such that the owner didn't get the chance to release the task.
    */
   @Test
-  public void testTaskAcquireReleaseOwnerUncleanShutdown() throws Exception {
+  public void testTaskAcquireReleaseOwnerUncleanShutdown() {
     String testCluster = "testTaskAcquireReleaseOwnerUncleanShutdown";
     String connectorType = "connectorType";
     Duration timeout = Duration.ofMinutes(1);
@@ -608,7 +608,7 @@ public class TestZkAdapter {
    * such that the owner didn't get the chance to release the task.
    */
   @Test
-  public void testTaskAcquireReleaseOwnerUncleanBounce() throws Exception {
+  public void testTaskAcquireReleaseOwnerUncleanBounce() {
     String testCluster = "testTaskAcquireReleaseOwnerUncleanBounce";
     String connectorType = "connectorType";
     Duration timeout = Duration.ofMinutes(1);
@@ -662,7 +662,7 @@ public class TestZkAdapter {
    * Test task acquire when there are dependencies
    */
   @Test
-  public void testTaskAcquireWithDependencies() throws Exception {
+  public void testTaskAcquireWithDependencies() {
     String testCluster = "testTaskAcquireReleaseOwnerUncleanBounce";
     String connectorType = "connectorType";
 
@@ -695,13 +695,37 @@ public class TestZkAdapter {
     Assert.assertTrue(PollUtils.poll(task2::isLocked, 100, 5000));
   }
 
+  private SpyingZkAdapter createSpyingZkAdapter(String testCluster) {
+    return new SpyingZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,  ZkClient.DEFAULT_SESSION_TIMEOUT,
+        ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
+  }
+
+  private static class SpyingZkAdapter extends ZkAdapter {
+    private ZkClient _zkClient;
+
+    public SpyingZkAdapter(String zkConnectionString, String testCluster, String defaultTransportProviderName,
+        int defaultSessionTimeout, int defaultConnectionTimeout, ZkAdapterListener listener) {
+      super(zkConnectionString, testCluster, defaultTransportProviderName, defaultSessionTimeout,
+          defaultConnectionTimeout, listener);
+    }
+
+    @Override
+    ZkClient createZkClient() {
+      _zkClient = spy(super.createZkClient());
+      return _zkClient;
+    }
+
+    public ZkClient getZkClient() {
+      return _zkClient;
+    }
+  }
+
   @Test
-  public void testDeleteTasksWithPrefix() throws IOException {
+  public void testDeleteTasksWithPrefix() {
     String testCluster = "testDeleteTaskWithPrefix";
     String connectorType = "connectorType";
 
-    // Set operation timeout of 5secs so ZK doesn't end up retrying for the longer default
-    ZkAdapter adapter =  createZkAdapter(testCluster);
+    SpyingZkAdapter adapter = createSpyingZkAdapter(testCluster);
     adapter.connect();
 
     List<DatastreamTask> tasks = new ArrayList<>();

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
@@ -36,53 +36,52 @@ public class ZkClient extends org.I0Itec.zkclient.ZkClient {
   public static final String ZK_PATH_SEPARATOR = "/";
   public static final int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
   public static final int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
+  public static final int DEFAULT_OPERATION_RETRY_TIMEOUT = -1;
 
   private static final Logger LOG = LoggerFactory.getLogger(ZkClient.class);
 
   private final ZkSerializer _zkSerializer = new ZKStringSerializer();
-  private int _zkSessionTimeoutMs = DEFAULT_SESSION_TIMEOUT;
-
-  /**
-   * Constructor for ZkClient
-   * @param zkServers the ZooKeeper connection String
-   * @param sessionTimeout the session timeout in milliseconds
-   * @param connectionTimeout the connection timeout in milliseconds
-   * @param operationRetryTimeoutMs The maximum amount of time, in milli seconds, each failed
-   *                                operation is retried. A value lesser than 0 is considered as
-   *                                retry forever until a connection has been reestablished.
-   */
-
-  public ZkClient(String zkServers, int sessionTimeout, int connectionTimeout, int operationRetryTimeoutMs) {
-    super(zkServers, sessionTimeout, connectionTimeout, new ZKStringSerializer(), operationRetryTimeoutMs);
-    _zkSessionTimeoutMs = sessionTimeout;
-  }
-
-  /**
-   * Constructor for ZkClient
-   * @param zkServers the ZooKeeper connection String
-   * @param sessionTimeout the session timeout in milliseconds
-   * @param connectionTimeout the connection timeout in milliseconds
-   */
-
-  public ZkClient(String zkServers, int sessionTimeout, int connectionTimeout) {
-    this(zkServers, sessionTimeout, connectionTimeout, -1);
-  }
-
-  /**
-   * Constructor for ZkClient
-   * @param zkServers the ZooKeeper connection String
-   * @param connectionTimeout the connection timeout in milliseconds
-   */
-  public ZkClient(String zkServers, int connectionTimeout) {
-    this(zkServers, DEFAULT_SESSION_TIMEOUT, connectionTimeout, -1);
-  }
+  private int _zkSessionTimeoutMs;
 
   /**
    * Constructor for ZkClient
    * @param zkServers the ZooKeeper connection String
    */
   public ZkClient(String zkServers) {
-    super(zkServers, DEFAULT_SESSION_TIMEOUT, DEFAULT_CONNECTION_TIMEOUT, new ZKStringSerializer());
+    this(zkServers, DEFAULT_SESSION_TIMEOUT);
+  }
+
+  /**
+   * Constructor for ZkClient
+   * @param zkServers the ZooKeeper connection String
+   * @param sessionTimeoutMs the session timeout in milliseconds
+   */
+  public ZkClient(String zkServers, int sessionTimeoutMs) {
+    this(zkServers, sessionTimeoutMs, DEFAULT_CONNECTION_TIMEOUT);
+  }
+
+  /**
+   * Constructor for ZkClient
+   * @param zkServers the ZooKeeper connection String
+   * @param sessionTimeoutMs the session timeout in milliseconds
+   * @param connectionTimeoutMs the connection timeout in milliseconds
+   */
+  public ZkClient(String zkServers, int sessionTimeoutMs, int connectionTimeoutMs) {
+    this(zkServers, sessionTimeoutMs, connectionTimeoutMs, DEFAULT_OPERATION_RETRY_TIMEOUT);
+  }
+
+  /**
+   * Constructor for ZkClient
+   * @param zkServers the ZooKeeper connection String
+   * @param sessionTimeoutMs the session timeout in milliseconds
+   * @param connectionTimeoutMs the connection timeout in milliseconds
+   * @param operationRetryTimeoutMs The maximum amount of time, in milli seconds, each failed
+   *                                operation is retried. A value lesser than 0 is considered as
+   *                                retry forever until a connection has been reestablished.
+   */
+  public ZkClient(String zkServers, int sessionTimeoutMs, int connectionTimeoutMs, int operationRetryTimeoutMs) {
+    super(zkServers, sessionTimeoutMs, connectionTimeoutMs, new ZKStringSerializer(), operationRetryTimeoutMs);
+    _zkSessionTimeoutMs = sessionTimeoutMs;
   }
 
   @Override

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
@@ -47,11 +47,25 @@ public class ZkClient extends org.I0Itec.zkclient.ZkClient {
    * @param zkServers the ZooKeeper connection String
    * @param sessionTimeout the session timeout in milliseconds
    * @param connectionTimeout the connection timeout in milliseconds
+   * @param operationRetryTimeoutMs The maximum amount of time, in milli seconds, each failed
+   *                                operation is retried. A value lesser than 0 is considered as
+   *                                retry forever until a connection has been reestablished.
    */
-  public ZkClient(String zkServers, int sessionTimeout, int connectionTimeout) {
-    super(zkServers, sessionTimeout, connectionTimeout, new ZKStringSerializer());
 
+  public ZkClient(String zkServers, int sessionTimeout, int connectionTimeout, int operationRetryTimeoutMs) {
+    super(zkServers, sessionTimeout, connectionTimeout, new ZKStringSerializer(), operationRetryTimeoutMs);
     _zkSessionTimeoutMs = sessionTimeout;
+  }
+
+  /**
+   * Constructor for ZkClient
+   * @param zkServers the ZooKeeper connection String
+   * @param sessionTimeout the session timeout in milliseconds
+   * @param connectionTimeout the connection timeout in milliseconds
+   */
+
+  public ZkClient(String zkServers, int sessionTimeout, int connectionTimeout) {
+    this(zkServers, sessionTimeout, connectionTimeout, -1);
   }
 
   /**
@@ -60,7 +74,7 @@ public class ZkClient extends org.I0Itec.zkclient.ZkClient {
    * @param connectionTimeout the connection timeout in milliseconds
    */
   public ZkClient(String zkServers, int connectionTimeout) {
-    super(zkServers, DEFAULT_SESSION_TIMEOUT, connectionTimeout, new ZKStringSerializer());
+    this(zkServers, DEFAULT_SESSION_TIMEOUT, connectionTimeout, -1);
   }
 
   /**


### PR DESCRIPTION
Task node deletion does not require reading all connector task nodes. If
top level directories get too heavy an ls on the node will start failing
due to jute.maxbuffer limits on zookeeper and we will not successfully
delete nodes because of that causing a huge set of stale tasks to get
built up further adding to the issue of growing tasks nodes under one top
level node. Change also adds a couple of constructors in zkclient and
zkadaper to override operation retry ms which I was planning to use in
unit-test, however the UT did not pan out and I thought it might come of
use later, so leaving those constructors in place.