### PR TITLE
Add synchronization around runningTasks map in AbstractKafkaConnector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -238,6 +238,9 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
         _logger.warn("Connector task for datastream task {} took longer than {} ms to stop. Interrupting the thread.",
             datastreamTask, CANCEL_TASK_TIMEOUT.toMillis());
         connectorTaskEntry.getThread().interrupt();
+        // Check that the thread really got interrupted and log a message if it seems like the thread is still running.
+        // Threads which don't check for the interrupt status may land up running forever, and we would like to
+        // at least know of such cases for debugging purposes.
         if (!connectorTask.awaitStop(POST_CANCEL_TASK_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
           _logger.warn("Connector task for datastream task {} did not stop even after {} ms.", datastreamTask,
               POST_CANCEL_TASK_TIMEOUT.toMillis());

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -247,7 +247,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
   }
 
   /**
-   * Check if the {@link AbstractKafkaBasedConnectorTask} corresponding to the {@link DatastreamTask} is dead.
+   * Check if the {@link AbstractKafkaBasedConnectorTask} is dead.
    * @param connectorTaskEntry connector task and thread that needs to be checked whether it is dead.
    * @return true if it is dead, false if it is still running.
    */

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -118,7 +118,7 @@ public class TestAbstractKafkaConnector {
 
     /**
      * Constructor for TestKafkaConnector
-     * @param restartThrows Indicates whether calling {@link #restartTasksIfNotRunning()}
+     * @param restartThrows Indicates whether calling {@link #restartDeadTasks()}
      *                      for the first time should throw a {@link RuntimeException}
      * @param props Configuration properties to use
      */
@@ -147,17 +147,17 @@ public class TestAbstractKafkaConnector {
     }
 
     @Override
-    protected boolean isTaskRunning(DatastreamTask datastreamTask) {
-      return false;
+    protected boolean isTaskDead(ConnectorTaskEntry connectorTaskEntry) {
+      return true;
     }
 
     @Override
-    protected void restartTasksIfNotRunning() {
+    protected void restartDeadTasks() {
       if (_restartThrows) {
         _restartThrows = false;
         throw new RuntimeException();
       }
-      super.restartTasksIfNotRunning();
+      super.restartDeadTasks();
     }
 
     public int getCreateTaskCalled() {

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -118,7 +118,7 @@ public class TestAbstractKafkaConnector {
 
     /**
      * Constructor for TestKafkaConnector
-     * @param restartThrows Indicates whether calling {@link #restartIfNotRunning(DatastreamTask)}
+     * @param restartThrows Indicates whether calling {@link #restartTasksIfNotRunning()}
      *                      for the first time should throw a {@link RuntimeException}
      * @param props Configuration properties to use
      */
@@ -152,12 +152,12 @@ public class TestAbstractKafkaConnector {
     }
 
     @Override
-    protected void restartIfNotRunning(DatastreamTask task) {
+    protected void restartTasksIfNotRunning() {
       if (_restartThrows) {
         _restartThrows = false;
         throw new RuntimeException();
       }
-      super.restartIfNotRunning(task);
+      super.restartTasksIfNotRunning();
     }
 
     public int getCreateTaskCalled() {


### PR DESCRIPTION
The AbstractKafkaConnector maintains a list of _runningTasks and threads. These use a concurrent hashmap, but aren't otherwise locked/synchronized. This can lead to race conditions because concurrent hashmaps only prevent races for individual operations being performed on the hashmap itself (e.g. put, get, delete). It does not provide guarantees when multiple operations being performed on the hashmap need to be atomic as a unit.

One potential race condition: Datastream update (onAssignmentChange) races with the daemon thread which tries to restart tasks which aren't running, and the update gets lost.
