### PR TITLE
Add support for preserving source message timestamp

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -80,6 +80,13 @@ public class DatastreamMetadataConstants {
   public static final String DESTINATION_TOPIC_PREFIX = SYSTEM_DESTINATION_PREFIX + "destinationTopicPrefix";
 
   /**
+   * If set to true, datastream would make use of the message's source timestamp while producing record to the
+   * destination.
+   */
+  public static final String PRESERVE_EVENT_SOURCE_TIMESTAMP = SYSTEM_DESTINATION_PREFIX + "preserveEventSourceTimestamp";
+
+
+   /**
    * Timestamp of datastream creation in epoch-millis
    */
   public static final String CREATION_MS = "system.creation.ms";

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaTransportProvider.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaTransportProvider.java
@@ -209,7 +209,7 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
   }
 
   @Test
-  public void testEventWithtimestamp() throws Exception {
+  public void testEventWithTimestamp() throws Exception {
     testEventSendWithTimestamp(1, 2, -1, false, false, "test", true);
   }
 

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaTransportProvider.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaTransportProvider.java
@@ -20,6 +20,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.config.TopicConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -28,9 +29,11 @@ import org.testng.annotations.Test;
 
 import com.codahale.metrics.MetricRegistry;
 
+
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamDestination;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
@@ -206,6 +209,11 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
   }
 
   @Test
+  public void testEventWithtimestamp() throws Exception {
+    testEventSendWithTimestamp(1, 2, -1, false, false, "test", true);
+  }
+
+  @Test
   public void testSendMultipleEventsInSingleDatastreamProducerRecord() throws Exception {
     String metricsPrefix = "test";
     final int numberOfEvents = 10;
@@ -280,6 +288,92 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
     Assert.assertNotNull(DynamicMetricsManager.getInstance().getMetric(eventByteWriteRateMetricName));
     Assert.assertNotNull(DynamicMetricsManager.getInstance().getMetric(producerCountMetricName));
   }
+
+  private void testEventSendWithTimestamp(int numberOfEvents, int numberOfPartitions, int partition, boolean includeKey,
+                             boolean includeValue, String metricsPrefix, boolean preserveSourceEventTimestamp) throws Exception {
+    String topicName = getUniqueTopicName();
+
+    if (metricsPrefix != null) {
+      _transportProviderProperties.put(KafkaTransportProviderAdmin.CONFIG_METRICS_NAMES_PREFIX, metricsPrefix);
+    }
+    KafkaTransportProviderAdmin provider = new KafkaTransportProviderAdmin("test", _transportProviderProperties);
+
+    String destinationUri = provider.getDestination(null, topicName);
+
+    Datastream ds = DatastreamTestUtils.createDatastream("test", "ds1", "source", destinationUri, numberOfPartitions);
+
+    ds.getMetadata().put(DatastreamMetadataConstants.PRESERVE_EVENT_SOURCE_TIMESTAMP, Boolean.TRUE.toString());
+
+    DatastreamTask task = new DatastreamTaskImpl(Collections.singletonList(ds));
+    TransportProvider transportProvider = provider.assignTransportProvider(task);
+    Properties topicProperties = new Properties();
+    topicProperties.put(TopicConfig.MESSAGE_TIMESTAMP_TYPE_CONFIG, "CreateTime");
+    provider.createTopic(destinationUri, numberOfPartitions, topicProperties);
+
+    KafkaTestUtils.waitForTopicCreation(_zkUtils, topicName, _kafkaCluster.getBrokers());
+
+    LOG.info(String.format("Topic %s created with %d partitions and topic properties %s", topicName, numberOfPartitions,
+            new Properties()));
+    // Specify source event timestamp for asserting
+    Long sourceTimestampBase = 1582766709000L;
+    List<Long> eventSourceTimestamps = new ArrayList<>();
+    for (int index = 0; index < numberOfEvents; ++index) {
+      eventSourceTimestamps.add(sourceTimestampBase + index);
+    }
+
+    List<DatastreamProducerRecord> datastreamEvents =
+          createEvents(topicName, partition, numberOfEvents, includeKey, includeValue, eventSourceTimestamps);
+
+    LOG.info(String.format("Trying to send %d events to topic %s", datastreamEvents.size(), topicName));
+
+    final Integer[] callbackCalled = {0};
+    for (DatastreamProducerRecord event : datastreamEvents) {
+      transportProvider.send(destinationUri, event, ((metadata, exception) -> callbackCalled[0]++));
+    }
+
+    // wait until all messages were acked, to ensure all events were successfully sent to the topic
+    Assert.assertTrue(PollUtils.poll(() -> callbackCalled[0] == datastreamEvents.size(), 1000, 10000),
+            "Send callback was not called; likely topic was not created in time");
+
+    LOG.info(String.format("Trying to read events from the topicName %s partition %d", topicName, partition));
+
+    List<Long> readTimestamps = new ArrayList<>();
+    KafkaTestUtils.readTopic(topicName, partition, _kafkaCluster.getBrokers(), (record) -> {
+      readTimestamps.add(record.timestamp());
+      return readTimestamps.size() < numberOfEvents;
+    });
+
+    Assert.assertEquals(readTimestamps, eventSourceTimestamps);
+
+    if (metricsPrefix != null) {
+      // verify that configured metrics prefix was used
+      for (BrooklinMetricInfo metric : provider.getMetricInfos()) {
+        Assert.assertTrue(metric.getNameOrRegex().startsWith(metricsPrefix));
+      }
+
+      String eventWriteRateMetricName = new StringJoiner(".").add(metricsPrefix)
+              .add(KafkaTransportProvider.class.getSimpleName())
+              .add(KafkaTransportProvider.AGGREGATE)
+              .add(KafkaTransportProvider.EVENT_WRITE_RATE)
+              .toString();
+
+      String eventByteWriteRateMetricName = new StringJoiner(".").add(metricsPrefix)
+              .add(KafkaTransportProvider.class.getSimpleName())
+              .add(KafkaTransportProvider.AGGREGATE)
+              .add(KafkaTransportProvider.EVENT_BYTE_WRITE_RATE)
+              .toString();
+
+      String producerCountMetricName = new StringJoiner(".").add(metricsPrefix)
+              .add(KafkaProducerWrapper.class.getSimpleName())
+              .add(KafkaTransportProvider.AGGREGATE)
+              .add(KafkaProducerWrapper.PRODUCER_COUNT)
+              .toString();
+      Assert.assertNotNull(DynamicMetricsManager.getInstance().getMetric(eventWriteRateMetricName));
+      Assert.assertNotNull(DynamicMetricsManager.getInstance().getMetric(eventByteWriteRateMetricName));
+      Assert.assertNotNull(DynamicMetricsManager.getInstance().getMetric(producerCountMetricName));
+    }
+  }
+
 
   private void testEventSend(int numberOfEvents, int numberOfPartitions, int partition, boolean includeKey,
       boolean includeValue, String metricsPrefix) throws Exception {
@@ -358,8 +452,13 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
     return text.getBytes();
   }
 
+  private  List<DatastreamProducerRecord> createEvents(String topicName, int partition, int numberOfEvents,
+                                                       boolean includeKey, boolean includeValue) {
+    return createEvents(topicName, partition, numberOfEvents, includeKey, includeValue, null);
+  }
+
   private List<DatastreamProducerRecord> createEvents(String topicName, int partition, int numberOfEvents,
-      boolean includeKey, boolean includeValue) {
+      boolean includeKey, boolean includeValue, List<Long> eventSourceTimeStamps) {
     Datastream stream = new Datastream();
     stream.setName("datastream_" + topicName);
     stream.setConnectorName("dummyConnector");
@@ -369,6 +468,10 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
     destination.setConnectionString(topicName);
     destination.setPartitions(NUM_PARTITIONS);
     stream.setDestination(destination);
+
+    if (eventSourceTimeStamps != null) {
+      Assert.assertEquals(numberOfEvents, eventSourceTimeStamps.size());
+    }
 
     List<DatastreamProducerRecord> events = new ArrayList<>();
     for (int index = 0; index < numberOfEvents; index++) {
@@ -390,7 +493,8 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
       }
 
       DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
-      builder.setEventsSourceTimestamp(System.currentTimeMillis());
+      builder.setEventsSourceTimestamp(eventSourceTimeStamps != null ?
+              eventSourceTimeStamps.get(index) : System.currentTimeMillis());
       builder.addEvent(new BrooklinEnvelope(keyValue, payloadValue, previousPayloadValue, new HashMap<>()));
       if (partition >= 0) {
         builder.setPartition(partition);


### PR DESCRIPTION
This feature allows Brooklin to make use of Kafka message's source timestamp when sending the
event to destination cluster. If the mirrored topic is configured with message.timestamp.type
set to CreateTime, the intent is to have the timestamp supplied by the application. This feature
will help achieving this intention.