### PR TITLE
Move consumer.close() to a try-catch block in AbstractKafkaBasedConnectorTask

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -352,7 +352,11 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     } finally {
       _stoppedLatch.countDown();
       if (null != _consumer) {
-        _consumer.close();
+        try {
+          _consumer.close();
+        } catch (Exception e) {
+          _logger.warn(String.format("Got exception on consumer close for task %s.", _taskName), e);
+        }
       }
       postShutdownHook();
       _logger.info("{} stopped", _taskName);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfigBuilder.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfigBuilder.java
@@ -18,6 +18,7 @@ import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_POLL_TIMEOUT_MILLIS;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_RETRY_COUNT;
 import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.CONFIG_RETRY_SLEEP_DURATION_MILLIS;
+import static com.linkedin.datastream.connectors.kafka.KafkaBasedConnectorConfig.ENABLE_PARTITION_ASSIGNMENT;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
@@ -144,6 +145,14 @@ public class KafkaBasedConnectorConfigBuilder {
    */
   public KafkaBasedConnectorConfigBuilder setPollTimeoutMillis(long pollTimeoutMillis) {
     _properties.put(CONFIG_POLL_TIMEOUT_MILLIS, Long.toString(pollTimeoutMillis));
+    return this;
+  }
+
+  /**
+   * Set enable partition managed
+   */
+  public KafkaBasedConnectorConfigBuilder setEnablePartitionManaged(boolean enablePartitionManaged) {
+    _properties.put(ENABLE_PARTITION_ASSIGNMENT, Boolean.toString(enablePartitionManaged));
     return this;
   }
 }


### PR DESCRIPTION
The AbstractKafkaBasedConnectorTask calls consumer.close() in the finally block
without checking for exceptions. If consumer.close() throws an exception, it can result
in the remaining cleanup to be ignored. This can have major repercussions for scenarios
in partition-managed, where the lock is not released. So we should encapsulate the
consumer.close() in a try-catch block to prevent this.