### PR TITLE
Log information about topic partitions seeing events outside alternative SLA in the EventProducer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -147,6 +147,7 @@ project(':datastream-server-api') {
   dependencies {
     compile project(':datastream-common')
     compile project(':datastream-utils')
+    compile "com.linkedin.kafka.clients:li-apache-kafka-clients:$LIKafkaVersion"
   }
 }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -257,7 +257,7 @@ public class EventProducer implements DatastreamEventProducer {
       long sourceToDestinationLatencyMs) {
     if (_warnLogLatencyEnabled && (sourceToDestinationLatencyMs > _warnLogLatencyThresholdMs)) {
       _logger.warn("Source to destination latency {} ms is higher than {} ms, Source Timestamp: {}, Metadata: {}",
-          sourceToDestinationLatencyMs, _warnLogLatencyThresholdMs, eventsSourceTimestamp, metadata.toString());
+          sourceToDestinationLatencyMs, _warnLogLatencyThresholdMs, eventsSourceTimestamp, metadata);
     }
 
     if (_numEventsOutsideAltSlaLogEnabled) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -10,8 +10,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -66,6 +68,8 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS = "availabilityThresholdAlternateSlaMs";
   private static final String WARN_LOG_LATENCY_ENABLED = "warnLogLatencyEnabled";
   private static final String WARN_LOG_LATENCY_THRESHOLD_MS = "warnLogLatencyThresholdMs";
+  private static final String NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_ENABLED = "numEventsOutsideAltSlaLogEnabled";
+  private static final String NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_FREQUENCY_MS = "numEventsOutsideAltSlaFrequencyMs";
   private static final String EVENTS_PRODUCED_OUTSIDE_SLA = "eventsProducedOutsideSla";
   private static final String EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA = "eventsProducedOutsideAlternateSla";
   private static final String DROPPED_SENT_FROM_SERIALIZATION_ERROR = "droppedSentFromSerializationError";
@@ -74,6 +78,8 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS = "180000"; // 3 minutes
   private static final String DEFAULT_WARN_LOG_LATENCY_ENABLED = "false";
   private static final String DEFAULT_WARN_LOG_LATENCY_THRESHOLD_MS = "1500000000"; // 25000 minutes, ~17 days
+  private static final String DEFAULT_NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_ENABLED = "false";
+  private static final String DEFAULT_NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_FREQUENCY_MS = "300000"; // 5 minutes
   private static final long LATENCY_SLIDING_WINDOW_LENGTH_MS = Duration.ofMinutes(3).toMillis();
   private static final long LONG_FLUSH_WARN_THRESHOLD_MS = Duration.ofMinutes(5).toMillis();
 
@@ -90,11 +96,17 @@ public class EventProducer implements DatastreamEventProducer {
   private final boolean _warnLogLatencyEnabled;
   // Latency threshold at which to log a warning message
   private final long _warnLogLatencyThresholdMs;
+  // Whether to enable logging the list of TopicPartitions with events outside alternative SLA
+  private final boolean _numEventsOutsideAltSlaLogEnabled;
+  // Frequency at which to log the list of TopicPartitions with events outside alternative SLA
+  private final long _numEventsOutsideAltSlaFrequencyMs;
   private final boolean _skipMessageOnSerializationErrors;
   private final boolean _enablePerTopicMetrics;
   private final Duration _flushInterval;
 
   private Instant _lastFlushTime = Instant.now();
+  private long _lastEventsOutsideAltSlaLogTimeMs = System.currentTimeMillis();
+  private Map<TopicPartitionInfo, Integer> _trackEventsOutsideAltSlaMap = new HashMap<>();
 
   /**
    * Construct an EventProducer instance.
@@ -134,6 +146,12 @@ public class EventProducer implements DatastreamEventProducer {
 
     _warnLogLatencyThresholdMs =
         Long.parseLong(config.getProperty(WARN_LOG_LATENCY_THRESHOLD_MS, DEFAULT_WARN_LOG_LATENCY_THRESHOLD_MS));
+
+    _numEventsOutsideAltSlaLogEnabled = Boolean.parseBoolean(config.getProperty(NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_ENABLED,
+        DEFAULT_NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_ENABLED));
+
+    _numEventsOutsideAltSlaFrequencyMs = Long.parseLong(config.getProperty(NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_FREQUENCY_MS,
+        DEFAULT_NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_FREQUENCY_MS));
 
     _flushInterval =
         Duration.ofMillis(Long.parseLong(config.getProperty(CONFIG_FLUSH_INTERVAL_MS, DEFAULT_FLUSH_INTERVAL_MS)));
@@ -235,6 +253,32 @@ public class EventProducer implements DatastreamEventProducer {
         outsideSLAValue);
   }
 
+  private void performSlaRelatedLogging(DatastreamRecordMetadata metadata, long eventsSourceTimestamp,
+      long sourceToDestinationLatencyMs) {
+    if (_warnLogLatencyEnabled && (sourceToDestinationLatencyMs > _warnLogLatencyThresholdMs)) {
+      _logger.warn("Source to destination latency {} ms is higher than {} ms, Source Timestamp: {}, Metadata: {}",
+          sourceToDestinationLatencyMs, _warnLogLatencyThresholdMs, eventsSourceTimestamp, metadata.toString());
+    }
+
+    if (_numEventsOutsideAltSlaLogEnabled) {
+      if (sourceToDestinationLatencyMs > _availabilityThresholdAlternateSlaMs) {
+        TopicPartitionInfo topicPartitionInfo = new TopicPartitionInfo(metadata.getTopic(), metadata.getPartition());
+        _trackEventsOutsideAltSlaMap.putIfAbsent(topicPartitionInfo, 0);
+        int numEvents = _trackEventsOutsideAltSlaMap.get(topicPartitionInfo);
+        _trackEventsOutsideAltSlaMap.put(topicPartitionInfo, numEvents + 1);
+      }
+
+      long timeSinceLastLog = System.currentTimeMillis() - _lastEventsOutsideAltSlaLogTimeMs;
+      if (timeSinceLastLog >= _numEventsOutsideAltSlaFrequencyMs) {
+        _trackEventsOutsideAltSlaMap.forEach((topicPartitionInfo, numEvents) ->
+            _logger.warn("{} had {} event(s) with latency greater than alternative SLA of {} ms in the last {} ms",
+                topicPartitionInfo, numEvents, _availabilityThresholdAlternateSlaMs, timeSinceLastLog));
+        _trackEventsOutsideAltSlaMap.clear();
+        _lastEventsOutsideAltSlaLogTimeMs = System.currentTimeMillis();
+      }
+    }
+  }
+
   /**
    * Report metrics on every send callback from the transport provider. Because this can be invoked multiple times
    * per DatastreamProducerRecord (i.e. by the number of events within the record), only increment all metrics by 1
@@ -263,11 +307,6 @@ public class EventProducer implements DatastreamEventProducer {
       reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
           EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
 
-      if (_warnLogLatencyEnabled && (sourceToDestinationLatencyMs > _warnLogLatencyThresholdMs)) {
-        _logger.warn("Source to destination latency {} ms is higher than {} ms, Source Timestamp: {}, Metadata: {}",
-            sourceToDestinationLatencyMs, _warnLogLatencyThresholdMs, eventsSourceTimestamp, metadata.toString());
-      }
-
       if (_logger.isDebugEnabled()) {
         if (sourceToDestinationLatencyMs > _availabilityThresholdSlaMs) {
           _logger.debug(
@@ -286,6 +325,10 @@ public class EventProducer implements DatastreamEventProducer {
       _dynamicMetricsManager.createOrUpdateCounter(MODULE, AGGREGATE, TOTAL_EVENTS_PRODUCED, 1);
       _dynamicMetricsManager.createOrUpdateCounter(MODULE, _datastreamTask.getConnectorType(), TOTAL_EVENTS_PRODUCED,
           1);
+
+      // Log information about events if either warn logging is enabled or logging for topic partitions outside
+      // alternative SLA is enabled
+      performSlaRelatedLogging(metadata, eventsSourceTimestamp, sourceToDestinationLatencyMs);
     }
 
     // Report the time it took to just send the events to destination
@@ -412,5 +455,40 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + FLUSH_LATENCY_MS_STRING));
 
     return Collections.unmodifiableList(metrics);
+  }
+
+  /**
+   * This class encapsulates the topic and partition information for a given event
+   */
+  static class TopicPartitionInfo {
+    private final String _topic;
+    private final int _partition;
+
+    TopicPartitionInfo(String topic, int partition) {
+      _topic = topic;
+      _partition = partition;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      TopicPartitionInfo that = (TopicPartitionInfo) o;
+      return _partition == that._partition && Objects.equals(_topic, that._topic);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_topic, _partition);
+    }
+
+    @Override
+    public String toString() {
+      return _topic + "-" + _partition;
+    }
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -169,4 +169,17 @@ public class TestEventProducer {
     }
     return builder.build();
   }
+
+  @Test
+  public void testTopicPartitionInfo() {
+    EventProducer.TopicPartitionInfo topicPartitionInfo1 = new EventProducer.TopicPartitionInfo("topic", 5);
+    EventProducer.TopicPartitionInfo topicPartitionInfo2 = new EventProducer.TopicPartitionInfo("topic", 42);
+    EventProducer.TopicPartitionInfo topicPartitionInfo3 = new EventProducer.TopicPartitionInfo("topic1", 42);
+    EventProducer.TopicPartitionInfo topicPartitionInfo4 = new EventProducer.TopicPartitionInfo("topic", 5);
+
+    Assert.assertNotEquals(topicPartitionInfo1, topicPartitionInfo2);
+    Assert.assertNotEquals(topicPartitionInfo2, topicPartitionInfo3);
+    Assert.assertNotEquals(topicPartitionInfo1, topicPartitionInfo3);
+    Assert.assertEquals(topicPartitionInfo1, topicPartitionInfo4);
+  }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -169,17 +169,4 @@ public class TestEventProducer {
     }
     return builder.build();
   }
-
-  @Test
-  public void testTopicPartitionInfo() {
-    EventProducer.TopicPartitionInfo topicPartitionInfo1 = new EventProducer.TopicPartitionInfo("topic", 5);
-    EventProducer.TopicPartitionInfo topicPartitionInfo2 = new EventProducer.TopicPartitionInfo("topic", 42);
-    EventProducer.TopicPartitionInfo topicPartitionInfo3 = new EventProducer.TopicPartitionInfo("topic1", 42);
-    EventProducer.TopicPartitionInfo topicPartitionInfo4 = new EventProducer.TopicPartitionInfo("topic", 5);
-
-    Assert.assertNotEquals(topicPartitionInfo1, topicPartitionInfo2);
-    Assert.assertNotEquals(topicPartitionInfo2, topicPartitionInfo3);
-    Assert.assertNotEquals(topicPartitionInfo1, topicPartitionInfo3);
-    Assert.assertEquals(topicPartitionInfo1, topicPartitionInfo4);
-  }
 }


### PR DESCRIPTION
Log information about topic partitions seeing events outside alternative SLA in the EventProducer
This feature to enable logging such events will be enabled by a config.