### PR TITLE
Add key schema to the datastream metadata

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -69,9 +69,14 @@ public class DatastreamMetadataConstants {
   public static final String DESTINATION_ENCRYPTION_REQUIRED = "system.destination.encryptionRequired";
 
   /**
-   * The name of the schema used to serialize the messages in the destination
+   * The name of the schema used to serialize the payload in the message on the destination
    */
   public static final String DESTINATION_PAYLOAD_SCHEMA_NAME = SYSTEM_DESTINATION_PREFIX + "payloadSchemaName";
+
+  /**
+   * The name of the schema used to serialize the key in the message on the destination
+   */
+  public static final String DESTINATION_KEY_SCHEMA_NAME = SYSTEM_DESTINATION_PREFIX + "keySchemaName";
 
   /**
    * This metadata, if set to a non-blank value, prepends a prefix to the destination topic name for all topics


### PR DESCRIPTION
This patch just adds the constant. The actual change will be done
in the brooklin-server.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
