### PR TITLE
Avoid accessing consumer in send callback to avoid ConcurrentModificationException in the Kafka connector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -110,6 +110,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected final Set<TopicPartition> _consumerAssignment = new HashSet<>();
 
   // TopicPartitions which have seen exceptions on send. Access to this map must be synchronized.
+  // A ConcurrentHashMap is not used here due to the need for having more than one operation performed together as an
+  // atomic block
   private final Map<TopicPartition, Exception> _sendFailureTopicPartitionExceptionMap = new HashMap<>();
 
   // Datastream task updates that need to be processed

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -238,7 +238,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
                 || _sendFailureTopicPartitionExceptionMap.containsKey(topicPartition);
           }
           if (skipRecord) {
-            _logger.warn("Abort sending as {} is auto-paused or saw a send failure, rewind offset", topicPartition);
+            _logger.warn("Abort sending as {} {}, rewind offset", topicPartition,
+                _autoPausedSourcePartitions.containsKey(topicPartition) ? "is auto-paused" : "saw a send failure");
             seekToLastCheckpoint(Collections.singleton(topicPartition));
             break;
           } else {

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -264,9 +264,12 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
           ((metadata, exception) -> {
             if (exception != null) {
               _logger.warn(
-                  String.format("Detected exception being throw from callback for src partition: %s while sending producer "
-                      + "record: %s, exception: ", srcTopicPartition, datastreamProducerRecord), exception);
-              rewindAndPausePartitionOnException(srcTopicPartition, exception);
+                  String.format("Detected exception being throw from flushless send callback for source "
+                      + "topic-partition: %s with metadata: %s, exception: ", srcTopicPartition, metadata),
+                  exception);
+              synchronized (_sendFailureTopicPartitionExceptionMap) {
+                _sendFailureTopicPartitionExceptionMap.put(srcTopicPartition, exception);
+              }
             } else {
               _consumerMetrics.updateBytesProcessedRate(numBytes);
             }
@@ -357,6 +360,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       if (hardCommit) { // hard commit (flush and commit checkpoints)
         LOG.info("Calling flush on the producer.");
         _datastreamTask.getEventProducer().flush();
+        rewindAndPausePartitionsOnSendException();
         commitSafeOffsets(consumer);
 
         // clear the flushless producer state after flushing all messages and checkpointing


### PR DESCRIPTION
This change just avoids allowing access to the consumer from different threads to avoid the ConcurrentModificationException we sometimes see. It basically tracks all the TopicPartitions which have seen send failures, and attempts to rewind their offsets to the last checkpoint after flush() or before the next poll.

The flush() enabled mode can still land up committing offsets for TopicPartitions that have seen send failures in case rewind to last checkpoint fails. Addressing this will be done as part of a separate PR.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
