### PR TITLE
Retry task release in postShutdownHook in KafkaMirrorMakerConnectorTask on interrupt

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.clients.consumer.OffsetOutOfRangeException;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.WakeupException;
 import org.codehaus.jackson.type.TypeReference;
 import org.slf4j.Logger;
@@ -302,6 +303,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _logger.info("Starting the Kafka-based connector task for {}", _datastreamTask);
     _connectorTaskThread = Thread.currentThread();
     boolean startingUp = true;
+    boolean isInterrupted = false;
     long pollInterval = 0; // so 1st call to poll is fast for purposes of startup
 
     _eventsProcessedCountLoggedTime = Instant.now();
@@ -346,6 +348,12 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         throw e;
       }
     } catch (Exception e) {
+      if (e instanceof InterruptException || e instanceof InterruptedException) {
+        // If the current thread is interrupted, any actions performed in the finally block may fail. To give
+        // cleanup actions a chance to complete, we temporarily reset the interrupted status of the thread.
+        isInterrupted = Thread.interrupted();
+      }
+
       _logger.error(String.format("%s failed with exception.", _taskName), e);
       _datastreamTask.setStatus(DatastreamTaskStatus.error(e.toString() + ExceptionUtils.getFullStackTrace(e)));
       throw new DatastreamRuntimeException(e);
@@ -355,10 +363,20 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         try {
           _consumer.close();
         } catch (Exception e) {
+          if (e instanceof InterruptException) {
+            // If the consumer.close() call is interrupted, any actions performed later may fail. To give further
+            // cleanup actions a chance to complete, we temporarily reset the interrupted status of the thread.
+            isInterrupted = Thread.interrupted();
+          }
           _logger.warn(String.format("Got exception on consumer close for task %s.", _taskName), e);
         }
       }
       postShutdownHook();
+
+      if (isInterrupted) {
+        // If the thread was originally interrupted, we should reset its status.
+        Thread.currentThread().interrupt();
+      }
       _logger.info("{} stopped", _taskName);
     }
   }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -302,7 +302,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _logger.info("Starting the Kafka-based connector task for {}", _datastreamTask);
     _connectorTaskThread = Thread.currentThread();
     boolean startingUp = true;
-    boolean isInterrupted = false;
     long pollInterval = 0; // so 1st call to poll is fast for purposes of startup
 
     _eventsProcessedCountLoggedTime = Instant.now();

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
@@ -130,7 +130,7 @@ final class KafkaMirrorMakerConnectorTestUtils {
         new KafkaMirrorMakerGroupIdConstructor(false, "testCluster"));
   }
 
-  static void runKafkaMirrorMakerConnectorTask(KafkaMirrorMakerConnectorTask connectorTask)
+  static Thread runKafkaMirrorMakerConnectorTask(KafkaMirrorMakerConnectorTask connectorTask)
       throws InterruptedException {
     Thread t = new Thread(connectorTask, "connector thread");
     t.setDaemon(true);
@@ -139,6 +139,7 @@ final class KafkaMirrorMakerConnectorTestUtils {
     if (!connectorTask.awaitStart(60, TimeUnit.SECONDS)) {
       Assert.fail("connector did not start within timeout");
     }
+    return t;
   }
 
   static KafkaBasedConnectorConfigBuilder getKafkaBasedConnectorConfigBuilder() {

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -331,6 +331,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     Assert.assertTrue(releaseCall.await(10, TimeUnit.SECONDS), "DatastreamTask never released");
   }
 
+  @Test
   public void testPartitionManagedLockReleaseOnInterruptException() throws InterruptedException {
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
     DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));


### PR DESCRIPTION
Releasing the lock for partition-managed BMM gets an interrupted exception if the producer flush() is interrupted. Due to this the lock is not released, and the next task is never able to get the lock and doesn't run, causing stopped partitions. Since partition-managed does its own partition assignment, if some tasks are unable to run, those partitions are never consumed from. The only way to recover from this is to restart the affected host(s) or the full cluster to clear out the ephemeral nodes.

This PR gracefully handles interrupt exceptions, allowing the finally block to complete without worrying about having been interrupted.