### PR TITLE
Add logs to ZookeeperCheckpointProvider.flush()

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/providers/ZookeeperCheckpointProvider.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/providers/ZookeeperCheckpointProvider.java
@@ -112,7 +112,9 @@ public class ZookeeperCheckpointProvider implements CheckpointProvider {
 
   @Override
   public void flush() {
+    LOG.info("Flushing checkpoints for {} datatstream tasks to ZooKeeper", _checkpointsToCommit.size());
     _checkpointsToCommit.keySet().forEach(this::writeCheckpointsToStore);
+    LOG.info("Flushing checkpoints to ZooKeeper completed successfully");
   }
 
   private Map<Integer, String> mergeAndGetSafeCheckpoints(DatastreamTask task, Map<Integer, String> safeCheckpoints) {


### PR DESCRIPTION
Recently, we started seeing extended shutdown times for Brooklin
(up to 30 minutes) during deployments with 100% host concurrency.
Vaibhav's analysis presents plausible evidence that this is caused by
the numerous simultaneous checkpoint flushes made to ZooKeeper 
as part of EventProducer shutdown.

This change adds log statements on entry and exit of 
`ZookeeperCheckpointProvider.flush()` so we have a direct way to 
observe the exact amount of time it takes to flush checkpoints.