### PR TITLE
Remove the DatastreamProducerRecord from the sendCallback in the EventProducer

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -222,9 +222,11 @@ public class EventProducer implements DatastreamEventProducer {
       String destination =
           record.getDestination().orElse(_datastreamTask.getDatastreamDestination().getConnectionString());
       record.setEventsSendTimestamp(System.currentTimeMillis());
+      long recordEventsSourceTimestamp = record.getEventsSourceTimestamp();
+      long recordEventsSendTimestamp = record.getEventsSendTimestamp().orElse(0L);
       _transportProvider.send(destination, record,
-          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record.getEventsSourceTimestamp(),
-              record.getEventsSendTimestamp().orElse(0L)));
+          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, recordEventsSourceTimestamp,
+              recordEventsSendTimestamp));
     } catch (Exception e) {
       String errorMessage = String.format("Failed send the event %s exception %s", record, e);
       _logger.warn(errorMessage, e);


### PR DESCRIPTION
The DatasteamProducerRecord is a large object and a reference to it is kept around in memory until the send callbacks fire.  There can be many outstanding sends resulting in a large number of DatastreamProducerRecord objects in memory. Even if the record is not directly used, just accessing it in the callback is enough to keep a reference around. Avoid keeping a reference to it.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
