### PR TITLE
Fix KeyedMeter metrics in the Coordinator

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -246,6 +246,7 @@ project(':datastream-testcommon') {
     compile "org.apache.zookeeper:zookeeper:$zookeeperVersion"
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "org.testng:testng:$testngVersion"
+    compile "com.google.guava:guava:$guavaVersion"
   }
 }
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/BrooklinMetricInfo.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/BrooklinMetricInfo.java
@@ -63,4 +63,10 @@ public abstract class BrooklinMetricInfo {
   public int hashCode() {
     return _hashCode;
   }
+
+  @Override
+  public String toString() {
+    return String.format("%s: nameOrRegex=%s, attributes=%s", getClass().getSimpleName(), _nameOrRegex,
+        _attributes.map(attrs -> String.join(",", attrs)).orElse("[]"));
+  }
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/MetricsAware.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/MetricsAware.java
@@ -48,6 +48,13 @@ public interface MetricsAware {
   }
 
   /**
+   * Get the metric name prepended with the caller's class name
+   */
+  default String buildMetricName(String classSimpleName, String key, String metricName) {
+    return MetricRegistry.name(classSimpleName, key, metricName);
+  }
+
+  /**
    * Get a regular expression for all dynamic metrics created within the class.
    *
    * For example, this regular expression should capture all topic-specific metrics emitted by KafkaTransportProvider

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/MetricsAware.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/MetricsAware.java
@@ -48,13 +48,6 @@ public interface MetricsAware {
   }
 
   /**
-   * Get the metric name prepended with the caller's class name
-   */
-  default String buildMetricName(String classSimpleName, String key, String metricName) {
-    return MetricRegistry.name(classSimpleName, key, metricName);
-  }
-
-  /**
    * Get a regular expression for all dynamic metrics created within the class.
    *
    * For example, this regular expression should capture all topic-specific metrics emitted by KafkaTransportProvider

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -26,7 +26,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Consumer;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.mockito.Mockito;
@@ -38,11 +37,8 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;
 
@@ -60,10 +56,6 @@ import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.kafka.KafkaDestination;
 import com.linkedin.datastream.kafka.KafkaTransportProviderAdmin;
-import com.linkedin.datastream.metrics.BrooklinCounterInfo;
-import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
-import com.linkedin.datastream.metrics.BrooklinHistogramInfo;
-import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.api.connector.Connector;
@@ -82,6 +74,7 @@ import com.linkedin.datastream.server.zk.KeyBuilder;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
 import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.testutil.MetricsTestUtils;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.BatchUpdateRequest;
 import com.linkedin.restli.server.CreateResponse;
@@ -191,42 +184,7 @@ public class TestCoordinator {
 
     // Make sure the set of metrics the Coordinator registers with the DynamicMetricsManager
     // matches the metricInfos the Coordinator returns from getMetricInfos().
-    List<BrooklinMetricInfo> metricInfos = coordinator.getMetricInfos();
-    DynamicMetricsManager metricsManager = DynamicMetricsManager.getInstance();
-
-    String coordinatorSimpleClassName = Coordinator.class.getSimpleName();
-    // Keep Coordinator metricInfos
-    Map<String, BrooklinMetricInfo> metricInfoByName = metricInfos.stream()
-        .filter(info -> info.getNameOrRegex().startsWith(coordinatorSimpleClassName))
-        .collect(Collectors.toMap(BrooklinMetricInfo::getNameOrRegex, Function.identity()));
-
-    // Keep Coordinator metrics
-    Map<String, Metric> metrics = metricsManager.getMetricRegistry().getMetrics().entrySet().stream()
-        .filter(entry -> entry.getKey().startsWith(coordinatorSimpleClassName))
-        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-
-    Assert.assertEquals(metricInfoByName.size(), metrics.size());
-
-    // Mapping of BrooklinMetricInfo sub-type -> com.codahale.metrics type
-    Map<Class<? extends BrooklinMetricInfo>, Class<? extends Metric>> metricInfoTypeToMetricType = new HashMap<>();
-    metricInfoTypeToMetricType.put(BrooklinCounterInfo.class, Counter.class);
-    metricInfoTypeToMetricType.put(BrooklinGaugeInfo.class, Gauge.class);
-    metricInfoTypeToMetricType.put(BrooklinHistogramInfo.class, Histogram.class);
-    metricInfoTypeToMetricType.put(BrooklinMeterInfo.class, Meter.class);
-
-    for (Map.Entry<String, BrooklinMetricInfo> entry : metricInfoByName.entrySet()) {
-      String metricInfoKey = entry.getKey();
-      BrooklinMetricInfo metricInfo = entry.getValue();
-
-      // For every BrooklinMetricInfo, there must be a registered codahale metric
-      Metric metric = metrics.get(metricInfoKey);
-      Assert.assertNotNull(metric);
-
-      // The registered codahale metric type must correspond to the BrooklinMetricInfo sub-type
-      Class<? extends Metric> actualMetricClazz = metric.getClass();
-      Class<? extends Metric> expectedMetricClazz = metricInfoTypeToMetricType.get(metricInfo.getClass());
-      Assert.assertTrue(expectedMetricClazz.isAssignableFrom(actualMetricClazz));
-    }
+    MetricsTestUtils.verifyMetrics(coordinator, DynamicMetricsManager.getInstance());
 
     coordinator.stop();
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1741,7 +1741,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
     private void registerMeterMetrics() {
       // These metrics are eagerly created (i.e. they are registered with _dynamicMetricsManager
-      // even before they are ever updated + we use BrooklinMeterInfo that specify metrics by full name)
+      // even before they are ever updated + we use BrooklinMeterInfos that specify metrics by full name)
       Arrays.stream(Meter.values()).forEach(this::registerMeter);
     }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1769,7 +1769,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     private void registerKeyedMeter(KeyedMeter metric) {
       String metricName = metric.getName();
       _dynamicMetricsManager.registerMetric(MODULE, metric.getKey(), metricName, com.codahale.metrics.Meter.class);
-      _metricInfos.add(new BrooklinMeterInfo(_coordinator.buildMetricName(MODULE, metricName)));
+      _metricInfos.add(new BrooklinMeterInfo(_coordinator.buildMetricName(MODULE, metric.getKey(), metricName)));
     }
 
     private void registerGauge(String metricName, Supplier<?> valueSupplier) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1236,7 +1236,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   void performCleanupOrphanConnectorTasks() {
     _log.info("performCleanupOrphanConnectorTasks called");
     int orphanCount = _adapter.cleanUpOrphanConnectorTasks(_config.getZkCleanUpOrphanConnectorTask());
-    _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.PERFORM_CLEANUP_ORPHAN_CONNECTOR_TASKS, orphanCount);
+    _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_ORPHAN_CONNECTOR_TASKS, orphanCount);
   }
 
   /**
@@ -1740,14 +1740,30 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
 
     private void registerMeterMetrics() {
+      // These metrics are eagerly created (i.e. they are registered with _dynamicMetricsManager
+      // even before they are ever updated + we use BrooklinMeterInfo that specify metrics by full name)
       Arrays.stream(Meter.values()).forEach(this::registerMeter);
     }
 
     private void registerKeyedMeterMetrics() {
-      Arrays.stream(KeyedMeter.values()).forEach(this::registerKeyedMeter);
+      // Our intent is to create KeyedMeter metrics lazily (i.e. only create the JMX metrics
+      // when the metrics are actually updated).
+      //
+      // To accomplish this, we:
+      //   - Refrain from registering metrics with _dynamicMetricsManager,
+      //     and rely on createOrUpdate*() methods so they are created upon
+      //     update instead.
+      //   - Return regex-based BrooklinMeterInfo as opposed to ones that
+      //     specify metrics by their full names
+
+      // All KeyedMeter metrics are covered by these two regex-based BrooklinMeterInfo objects
+      String prefix = _coordinator.getDynamicMetricPrefixRegex();
+      _metricInfos.add(new BrooklinMeterInfo(prefix + NUM_ERRORS));
+      _metricInfos.add(new BrooklinMeterInfo(prefix + NUM_RETRIES));
     }
 
     private void registerGaugeMetrics() {
+      // Gauges must be eagerly created
       ImmutableMap<String, Supplier<?>> gaugeMetrics = ImmutableMap.<String, Supplier<?>>builder()
           .put(MAX_PARTITION_COUNT_IN_TASK, MAX_PARTITION_COUNT::get)
           .put(NUM_PAUSED_DATASTREAMS_GROUPS, PAUSED_DATASTREAMS_GROUPS::get)
@@ -1757,6 +1773,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
 
     private void registerCounterMetrics() {
+      // These metrics are eagerly created
       Arrays.stream(Counter.values()).forEach(this::registerCounter);
     }
 
@@ -1764,12 +1781,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       String metricName = metric.getName();
       _dynamicMetricsManager.registerMetric(MODULE, metricName, com.codahale.metrics.Meter.class);
       _metricInfos.add(new BrooklinMeterInfo(_coordinator.buildMetricName(MODULE, metricName)));
-    }
-
-    private void registerKeyedMeter(KeyedMeter metric) {
-      String metricName = metric.getName();
-      _dynamicMetricsManager.registerMetric(MODULE, metric.getKey(), metricName, com.codahale.metrics.Meter.class);
-      _metricInfos.add(new BrooklinMeterInfo(_coordinator.buildMetricName(MODULE, metric.getKey(), metricName)));
     }
 
     private void registerGauge(String metricName, Supplier<?> valueSupplier) {
@@ -1790,7 +1801,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       NUM_REBALANCES("numRebalances"),
       NUM_ASSIGNMENT_CHANGES("numAssignmentChanges"),
       NUM_PARTITION_ASSIGNMENTS("numPartitionAssignments"),
-      NUM_PARTITION_MOVEMENTS("numPartitionMovements");
+      NUM_PARTITION_MOVEMENTS("numPartitionMovements"),
+      NUM_ORPHAN_CONNECTOR_TASKS("numOrphanConnectorTasks");
 
       private final String _name;
 
@@ -1816,7 +1828,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       IS_PARTITION_ASSIGNMENT_SUPPORTED_NUM_ERRORS("isPartitionAssignmentSupported", NUM_ERRORS),
       IS_DATASTREAM_UPDATE_TYPE_SUPPORTED_NUM_ERRORS("isDatastreamUpdateTypeSupported", NUM_ERRORS),
       INITIALIZE_DATASTREAM_NUM_ERRORS("initializeDatastream", NUM_ERRORS),
-      PERFORM_CLEANUP_ORPHAN_CONNECTOR_TASKS("performCleanupOrphanConnectorTasks", "numOrphanConnectorTasks"),
       /* Coordinator event metrics */
       LEADER_DO_ASSIGNMENT_NUM_ERRORS(HANDLE_EVENT_PREFIX + EventType.LEADER_DO_ASSIGNMENT, NUM_ERRORS),
       LEADER_PARTITION_ASSIGNMENT_NUM_ERRORS(HANDLE_EVENT_PREFIX + EventType.LEADER_PARTITION_ASSIGNMENT, NUM_ERRORS),

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
@@ -82,7 +82,7 @@ public class MetricsTestUtils {
 
     Map<String, BrooklinMetricInfo> metricInfoByName = new HashMap<>();
     List<BrooklinMetricInfo> regexMetricInfos = new ArrayList<>();
-    classifyMetricInfos(metricInfos, metricsAware, metricInfoByName, regexMetricInfos);
+    classifyMetricInfos(metricInfos, metricInfoByName, regexMetricInfos);
 
     Collection<Map.Entry<String, Metric>> metricEntries = metricsManager.getMetricRegistry().getMetrics().entrySet().stream()
         .filter(metricEntry -> metricFilter.test(metricEntry.getKey()))
@@ -97,11 +97,11 @@ public class MetricsTestUtils {
     }
   }
 
-  private static void classifyMetricInfos(Collection<BrooklinMetricInfo> metricInfos, MetricsAware metricsAware,
+  private static void classifyMetricInfos(Collection<BrooklinMetricInfo> metricInfos,
       Map<String, BrooklinMetricInfo> metricInfoByName, List<BrooklinMetricInfo> regexMetricInfos) {
     for (BrooklinMetricInfo metricInfo : metricInfos) {
       String nameOrRegex = metricInfo.getNameOrRegex();
-      if (nameOrRegex.contains(metricsAware.KEY_REGEX)) {
+      if (nameOrRegex.contains(MetricsAware.KEY_REGEX)) {
         regexMetricInfos.add(metricInfo);
       } else {
         metricInfoByName.put(nameOrRegex, metricInfo);

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
@@ -94,7 +94,7 @@ public class MetricsTestUtils {
         .collect(Collectors.toList());
 
     // Assert that every metric has exactly one metricInfo whose nameOrRegex matches the metric's name
-    for (Map.Entry<String, Metric> metricEntry: metricEntries) {
+    for (Map.Entry<String, Metric> metricEntry : metricEntries) {
       int count = getMatchingMetricInfoCount(metricEntry, metricInfoByName, regexMetricInfos);
       Assert.assertEquals(count, 1,
           String.format("Metric %s must match exactly one BrooklinMetricInfo but it matched %d",

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
@@ -1,3 +1,8 @@
+/**
+ *  Copyright 2020 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
 package com.linkedin.datastream.testutil;
 
 import java.util.ArrayList;

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
@@ -1,0 +1,146 @@
+package com.linkedin.datastream.testutil;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+import org.testng.Assert;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.google.common.collect.ImmutableMap;
+
+import com.linkedin.datastream.metrics.BrooklinCounterInfo;
+import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
+import com.linkedin.datastream.metrics.BrooklinHistogramInfo;
+import com.linkedin.datastream.metrics.BrooklinMeterInfo;
+import com.linkedin.datastream.metrics.BrooklinMetricInfo;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.metrics.MetricsAware;
+
+
+/**
+ * Test utilities for verifying metrics
+ * @see MetricsAware
+ */
+public class MetricsTestUtils {
+  // Mapping of BrooklinMetricInfo sub-types -> com.codahale.metrics types
+  private static final Map<Class<? extends BrooklinMetricInfo>, Class<? extends Metric>> METRICS_TYPE_MAPPING = ImmutableMap.of(
+      BrooklinCounterInfo.class, Counter.class,
+      BrooklinGaugeInfo.class, Gauge.class,
+      BrooklinHistogramInfo.class, Histogram.class,
+      BrooklinMeterInfo.class, Meter.class);
+
+  private MetricsTestUtils() {
+  }
+
+  /**
+   * @see #verifyMetrics(MetricsAware, DynamicMetricsManager, Predicate)
+   *
+   * This verification only covers {@link Metric} and {@link BrooklinMetricInfo} objects whose
+   * names start with the provided {@code metricsAware}'s simple class name.
+   */
+  public static void verifyMetrics(MetricsAware metricsAware, DynamicMetricsManager metricsManager) {
+    verifyMetrics(metricsAware, metricsManager, s -> s.startsWith(metricsAware.getClass().getSimpleName()));
+  }
+
+  /**
+   * Verifies consistency between:
+   * <ol>
+   *   <li>{@link BrooklinMetricInfo} objects returned by the specified {@code metricsAware}
+   *   (specifically {@link MetricsAware#getMetricInfos()}) after filtering them using {@code metricFilter}</li>
+   *   <li>{@link Metric} objects registered with the specified {@code metricsManager} after filtering them
+   *   using {@code metricFilter}</li>
+   * </ol>
+   *
+   * In particular, it verifies that:
+   * <ul>
+   *   <li>All {@link BrooklinMetricInfo} are distinct</li>
+   *   <li>Every {@link Metric} object has exactly one {@link BrooklinMetricInfo} object whose
+   *   {@link BrooklinMetricInfo#getNameOrRegex()} matches the metric's name</li>
+   *   <li>Every {@link Metric} is matched with a {@link BrooklinMetricInfo} object whose concrete
+   *   type matches the metric's type according to {@link MetricsTestUtils#METRICS_TYPE_MAPPING}</li>
+   * </ul>
+   */
+  public static void verifyMetrics(MetricsAware metricsAware, DynamicMetricsManager metricsManager,
+      Predicate<String> metricFilter) {
+
+    List<BrooklinMetricInfo> metricInfos = metricsAware.getMetricInfos().stream()
+        .filter(metricInfo -> metricFilter.test(metricInfo.getNameOrRegex()))
+        .collect(Collectors.toList());
+
+    // Assert that all metricInfos are distinct
+    Assert.assertEquals(metricInfos.size(), metricInfos.stream().distinct().count(),
+        "The supplied metricsAware returned duplicate BrooklinMetricInfo objects");
+
+    Map<String, BrooklinMetricInfo> metricInfoByName = new HashMap<>();
+    List<BrooklinMetricInfo> regexMetricInfos = new ArrayList<>();
+    classifyMetricInfos(metricInfos, metricsAware, metricInfoByName, regexMetricInfos);
+
+    Collection<Map.Entry<String, Metric>> metricEntries = metricsManager.getMetricRegistry().getMetrics().entrySet().stream()
+        .filter(metricEntry -> metricFilter.test(metricEntry.getKey()))
+        .collect(Collectors.toList());
+
+    // Assert that every metric has exactly one metricInfo whose nameOrRegex matches the metric's name
+    for (Map.Entry<String, Metric> metricEntry: metricEntries) {
+      int count = getMatchingMetricInfoCount(metricEntry, metricInfoByName, regexMetricInfos);
+      Assert.assertEquals(count, 1,
+          String.format("Metric %s must match exactly one BrooklinMetricInfo but it matched %d",
+              metricEntry.getKey(), count));
+    }
+  }
+
+  private static void classifyMetricInfos(Collection<BrooklinMetricInfo> metricInfos, MetricsAware metricsAware,
+      Map<String, BrooklinMetricInfo> metricInfoByName, List<BrooklinMetricInfo> regexMetricInfos) {
+    for (BrooklinMetricInfo metricInfo : metricInfos) {
+      String nameOrRegex = metricInfo.getNameOrRegex();
+      if (nameOrRegex.contains(metricsAware.KEY_REGEX)) {
+        regexMetricInfos.add(metricInfo);
+      } else {
+        metricInfoByName.put(nameOrRegex, metricInfo);
+      }
+    }
+  }
+
+  private static int getMatchingMetricInfoCount(Map.Entry<String, Metric> metricEntry,
+      Map<String, BrooklinMetricInfo> metricInfoByName, List<BrooklinMetricInfo> regexMetricInfos) {
+    int count = 0;
+
+    String metricName = metricEntry.getKey();
+    if (metricInfoByName.containsKey(metricName)) {
+      BrooklinMetricInfo metricInfo = metricInfoByName.get(metricName);
+      assertTypeCompatibility(metricInfo, metricEntry);
+      ++count;
+    }
+
+    for (BrooklinMetricInfo metricInfo : regexMetricInfos) {
+      if (metricName.matches(metricInfo.getNameOrRegex())) {
+        assertTypeCompatibility(metricInfo, metricEntry);
+        ++count;
+      }
+    }
+
+    return count;
+  }
+
+  private static void assertTypeCompatibility(BrooklinMetricInfo metricInfo, Map.Entry<String, Metric> metricEntry) {
+    String metricName = metricEntry.getKey();
+    Metric metric = metricEntry.getValue();
+
+    Class<? extends BrooklinMetricInfo> metricInfoClass = metricInfo.getClass();
+    Class<? extends Metric> expectedMetricClass = METRICS_TYPE_MAPPING.get(metricInfoClass);
+    Class<? extends Metric> actualMetricClass = metric.getClass();
+
+    // Assert that every metric is matched with a metricInfo whose concrete type matches the expected metric's type
+    Assert.assertTrue(expectedMetricClass.isAssignableFrom(actualMetricClass), String.format(
+        "Identified a mismatch between %s and metric %s. Expected metric type to be %s but found %s",
+        metricInfo, metricName, expectedMetricClass, actualMetricClass));
+  }
+}


### PR DESCRIPTION
This change is a follow-up on PR #701. 

As it turns out, the registration of all `KeyedMeter` metrics within the `Coordinator` is incorrect since it does not incorporate the metric key, which caused a mismatch between the names of the `KeyedMeter` metrics registered with the `DynamicsMetricsManager` and those returned by `Coordinator.getMetricInfos()`.

Special thanks to @vmaheshw for identifying the broken metrics _and_ the root cause.