### PR TITLE
Fix producer.close() deadlock by moving actual producer.close() call to separate thread in KafkaProducerWrapper

### DIFF
--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -104,7 +105,7 @@ class KafkaProducerWrapper<K, V> {
   private final DynamicMetricsManager _dynamicMetricsManager;
   private final String _metricsNamesPrefix;
 
-  // A lock used to synchronized access to operations performed on the _kafkaProducer object
+  // A lock used to synchronize access to operations performed on the _kafkaProducer object
   private final Object _producerLock = new Object();
 
   // An executor to spawn threads to close the producer.
@@ -129,7 +130,7 @@ class KafkaProducerWrapper<K, V> {
     _dynamicMetricsManager.registerGauge(_metricsNamesPrefix, AGGREGATE, PRODUCER_COUNT, PRODUCER_GAUGE);
 
     _clientId = transportProviderProperties.getProperty(ProducerConfig.CLIENT_ID_CONFIG);
-    if (_clientId == null || _clientId.isEmpty()) {
+    if (StringUtils.isEmpty(_clientId)) {
       _log.warn("Client ID is either null or empty");
     }
 
@@ -276,10 +277,10 @@ class KafkaProducerWrapper<K, V> {
   private DatastreamRuntimeException generateSendFailure(Exception exception) {
     _dynamicMetricsManager.createOrUpdateMeter(_metricsNamesPrefix, AGGREGATE, PRODUCER_ERROR, 1);
     if (exception instanceof IllegalStateException) {
-      _log.warn("send failed transiently with exception: ", exception);
+      _log.warn("Send failed transiently with exception: ", exception);
       return new DatastreamTransientException(exception);
     } else {
-      _log.warn("send failed, restart producer, exception: ", exception);
+      _log.warn("Send failed with a non-transient exception. Shutting down producer, exception: ", exception);
       shutdownProducer();
       return new DatastreamRuntimeException(exception);
     }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
@@ -108,7 +108,7 @@ class KafkaProducerWrapper<K, V> {
   private final Object _producerLock = new Object();
 
   // An executor to spawn threads to close the producer.
-  private final ExecutorService _producerCloseExecutorService = Executors.newFixedThreadPool(1,
+  private final ExecutorService _producerCloseExecutorService = Executors.newSingleThreadExecutor(
       new ThreadFactoryBuilder().setNameFormat("KafkaProducerWrapperClose-%d").build());
 
   KafkaProducerWrapper(String logSuffix, Properties props) {

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
@@ -13,8 +13,11 @@ import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 
 import org.apache.kafka.clients.producer.Callback;
@@ -31,10 +34,12 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.util.concurrent.RateLimiter;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.DatastreamTransientException;
 import com.linkedin.datastream.common.ReflectionUtils;
+import com.linkedin.datastream.common.ThreadUtils;
 import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.kafka.factory.KafkaProducerFactory;
 import com.linkedin.datastream.kafka.factory.SimpleKafkaProducerFactory;
@@ -60,6 +65,8 @@ class KafkaProducerWrapper<K, V> {
 
   private static final int TIME_OUT = 2000;
   private static final int MAX_SEND_ATTEMPTS = 10;
+  private static final Duration PRODUCER_CLOSE_EXECUTOR_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
+
   private final Logger _log;
   private final long _sendFailureRetryWaitTimeMs;
 
@@ -98,6 +105,13 @@ class KafkaProducerWrapper<K, V> {
   private final DynamicMetricsManager _dynamicMetricsManager;
   private final String _metricsNamesPrefix;
 
+  // A lock used to synchronized access to operations performed on the _kafkaProducer object
+  private final ReentrantLock _producerLock = new ReentrantLock();
+
+  // An executor to spawn threads to close the producer.
+  private final ExecutorService _producerCloseExecutorService = Executors.newFixedThreadPool(10,
+      new ThreadFactoryBuilder().setNameFormat("KafkaProducerWrapperClose-%d").build());
+
   KafkaProducerWrapper(String logSuffix, Properties props) {
     this(logSuffix, props, null);
   }
@@ -117,7 +131,7 @@ class KafkaProducerWrapper<K, V> {
 
     _clientId = transportProviderProperties.getProperty(ProducerConfig.CLIENT_ID_CONFIG);
     if (_clientId == null || _clientId.isEmpty()) {
-      _log.warn("Client Id is either null or empty");
+      _log.warn("Client ID is either null or empty");
     }
 
     _sendFailureRetryWaitTimeMs =
@@ -163,22 +177,27 @@ class KafkaProducerWrapper<K, V> {
   }
 
   /**
-   * Must be synchronized to avoid creating duplicate producers when multiple concurrent
+   * Must be protected by a lock to avoid creating duplicate producers when multiple concurrent
    * sends are in-flight and _kafkaProducer has been set to null as a result of previous
    * producer exception.
    */
-  private synchronized Producer<K, V> initializeProducer(DatastreamTask task) {
-    if (!_tasks.contains(task)) {
-      _log.warn("Task {} has been unassigned for producer, abort the sending ", task);
-      return null;
-    } else {
-      if (_kafkaProducer == null) {
-        _rateLimiter.acquire();
-        _kafkaProducer = createKafkaProducer();
-        NUM_PRODUCERS.incrementAndGet();
+  private Producer<K, V> initializeProducer(DatastreamTask task) {
+    _producerLock.lock();
+    try {
+      if (!_tasks.contains(task)) {
+        _log.warn("Task {} has been unassigned for producer, abort the send", task);
+        return null;
+      } else {
+        if (_kafkaProducer == null) {
+          _rateLimiter.acquire();
+          _kafkaProducer = createKafkaProducer();
+          NUM_PRODUCERS.incrementAndGet();
+        }
       }
+      return _kafkaProducer;
+    } finally {
+      _producerLock.unlock();
     }
-    return _kafkaProducer;
   }
 
   @VisibleForTesting
@@ -208,11 +227,11 @@ class KafkaProducerWrapper<K, V> {
         retry = false;
       } catch (IllegalStateException e) {
         //The following exception should be quite rare as most exceptions will be throw async callback
-        _log.warn("Either send is called on a closed producer or broker count is less than minISR, retry in {} ms.",
-            _sendFailureRetryWaitTimeMs, e);
+        _log.warn(String.format("Either send is called on a closed producer or broker count is less than minISR, "
+                + "retry in %d ms.", _sendFailureRetryWaitTimeMs), e);
         Thread.sleep(_sendFailureRetryWaitTimeMs);
       } catch (TimeoutException e) {
-        _log.warn("Kafka producer buffer is full, retry in {} ms.", _sendFailureRetryWaitTimeMs, e);
+        _log.warn(String.format("Kafka producer buffer is full, retry in %d ms.", _sendFailureRetryWaitTimeMs), e);
         Thread.sleep(_sendFailureRetryWaitTimeMs);
       } catch (KafkaException e) {
         Throwable cause = e.getCause();
@@ -221,61 +240,87 @@ class KafkaProducerWrapper<K, V> {
         }
         // Set a max_send_attempts for KafkaException as it may be non-recoverable
         if (numberOfAttempt > MAX_SEND_ATTEMPTS || ((cause instanceof Error || cause instanceof RuntimeException))) {
-          _log.error("Send failed for partition {} with a non retriable exception", producerRecord.partition(), e);
+          _log.error(String.format("Send failed for partition %d with a non-retriable exception",
+              producerRecord.partition()), e);
           throw generateSendFailure(e);
         } else {
-          _log.warn("Send failed for partition {} with retriable exception, retry {} out of {} in {} ms.",
-              producerRecord.partition(), numberOfAttempt, MAX_SEND_ATTEMPTS, _sendFailureRetryWaitTimeMs, e);
+          _log.warn(String.format(
+              "Send failed for partition %d with a retriable exception, retry %d out of %d in %d ms.",
+              producerRecord.partition(), numberOfAttempt, MAX_SEND_ATTEMPTS, _sendFailureRetryWaitTimeMs), e);
           Thread.sleep(_sendFailureRetryWaitTimeMs);
         }
       } catch (Exception e) {
-        _log.error("Send failed for partition {} with an exception", producerRecord.partition(), e);
+        _log.error(String.format("Send failed for partition %d with an exception", producerRecord.partition()), e);
         throw generateSendFailure(e);
       }
     }
   }
 
-  private synchronized void shutdownProducer() {
-    Producer<K, V> producer = _kafkaProducer;
-    // Nullify first to prevent subsequent send() to use
-    // the current producer which is being shutdown.
-    _kafkaProducer = null;
+  @VisibleForTesting
+  void shutdownProducer() {
+    Producer<K, V> producer;
+    _producerLock.lock();
+    try {
+      producer = _kafkaProducer;
+      // Nullify first to prevent subsequent send() to use
+      // the current producer which is being shutdown.
+      _kafkaProducer = null;
+    } finally {
+      _producerLock.unlock();
+    }
+
+    // This may be called from the send callback. The callbacks are called from the sender thread, and must complete
+    // quickly to avoid delaying/blocking the sender thread. Thus schedule the actual producer.close() on a separate
+    // thread
     if (producer != null) {
-      producer.close(TIME_OUT, TimeUnit.MILLISECONDS);
-      NUM_PRODUCERS.decrementAndGet();
+      _producerCloseExecutorService.submit(() -> {
+        _log.debug("KafkaProducerWrapper: Closing the Kafka Producer");
+        producer.close(TIME_OUT, TimeUnit.MILLISECONDS);
+        NUM_PRODUCERS.decrementAndGet();
+        _log.debug("KafkaProducerWrapper: Kafka Producer is closed");
+      });
     }
   }
 
   private DatastreamRuntimeException generateSendFailure(Exception exception) {
     _dynamicMetricsManager.createOrUpdateMeter(_metricsNamesPrefix, AGGREGATE, PRODUCER_ERROR, 1);
     if (exception instanceof IllegalStateException) {
-      _log.warn("sent failure transiently, exception: ", exception);
+      _log.warn("send failed transiently with exception: ", exception);
       return new DatastreamTransientException(exception);
     } else {
-      _log.warn("sent failure, restart producer, exception: ", exception);
+      _log.warn("send failed, restart producer, exception: ", exception);
       shutdownProducer();
       return new DatastreamRuntimeException(exception);
     }
   }
 
-  synchronized void flush() {
-    if (_kafkaProducer != null) {
-      try {
+  void flush() {
+    _producerLock.lock();
+    try {
+      if (_kafkaProducer != null) {
         _kafkaProducer.flush();
-      } catch (InterruptException e) {
-        // The KafkaProducer object should not be reused on an interrupted flush
-        _log.warn("Kafka producer flush interrupted, closing producer {}.", _kafkaProducer);
-        shutdownProducer();
-        throw e;
       }
+    } catch (InterruptException e) {
+      // The KafkaProducer object should not be reused on an interrupted flush
+      _log.warn("Kafka producer flush interrupted, closing producer {}.", _kafkaProducer);
+      shutdownProducer();
+      throw e;
+    } finally {
+      _producerLock.unlock();
     }
   }
 
-  synchronized void close(DatastreamTask task) {
-    _tasks.remove(task);
-    if (_kafkaProducer != null && _tasks.isEmpty()) {
-      shutdownProducer();
+  void close(DatastreamTask task) {
+    _producerLock.lock();
+    try {
+      _tasks.remove(task);
+      if (_kafkaProducer != null && _tasks.isEmpty()) {
+        shutdownProducer();
+      }
+    } finally {
+      _producerLock.unlock();
     }
+    ThreadUtils.shutdownExecutor(_producerCloseExecutorService, PRODUCER_CLOSE_EXECUTOR_SHUTDOWN_TIMEOUT, _log);
   }
 
   static List<BrooklinMetricInfo> getMetricDetails(String metricsNamesPrefix) {

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
@@ -5,6 +5,8 @@
  */
 package com.linkedin.datastream.kafka;
 
+import java.lang.reflect.Method;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Properties;
 import java.util.concurrent.ExecutorService;
@@ -16,12 +18,14 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.InterruptException;
+import org.mockito.invocation.Invocation;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.codahale.metrics.MetricRegistry;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
@@ -31,6 +35,7 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockingDetails;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
@@ -112,6 +117,7 @@ public class TestKafkaProducerWrapper {
   private static class MockKafkaProducerWrapper<K, V> extends KafkaProducerWrapper<K, V> {
     private boolean _createKafkaProducerCalled;
     private int _numCreateKafkaProducerCalls;
+    private int _numShutdownProducerCalls;
     private Producer<K, V> _mockProducer;
 
     MockKafkaProducerWrapper(String logSuffix, Properties props, String metricsNamesPrefix) {
@@ -133,6 +139,12 @@ public class TestKafkaProducerWrapper {
       return _mockProducer;
     }
 
+    @Override
+    void shutdownProducer() {
+      super.shutdownProducer();
+      ++_numShutdownProducerCalls;
+    }
+
     void verifySend(int numExpected) {
       verify(_mockProducer, times(numExpected)).send(any(), any(Callback.class));
     }
@@ -141,8 +153,17 @@ public class TestKafkaProducerWrapper {
       verify(_mockProducer, times(numExpected)).flush();
     }
 
-    void verifyClose(int numExpected) {
+    void verifyClose(int numExpected) throws NoSuchMethodException {
+      // Producer close is invoked in a separate thread. Must wait for the thread to get scheduled and call close
+      Method method = Producer.class.getMethod("close", long.class, TimeUnit.class);
+      PollUtils.poll(() -> {
+        Collection<Invocation> invocations = mockingDetails(_mockProducer).getInvocations();
+        long count = invocations.stream().filter(invocation -> invocation.getMethod().equals(method)).count();
+        return count == numExpected;
+      }, 1000, 10000);
       verify(_mockProducer, times(numExpected)).close(anyLong(), any(TimeUnit.class));
+      Assert.assertEquals(_numShutdownProducerCalls, numExpected);
+      _numShutdownProducerCalls = 0;
     }
 
     public int getNumCreateKafkaProducerCalls() {


### PR DESCRIPTION
We have a deadlock scenario which looks like:

- The instance is shutdown, and all the KafkaProducerWrappers have their close() API called. This in turn results in calling the KafkaProducer's close() call. The close() API is synchronized
- We try to close the KafkaProducer (shutdownProducer()) on any send failures, and this callback is called from the KafkaProducer's Sender (I/O) thread.
- The KafkaProducerWrapper's shutdownProducer() is synchronized
- KafkaProducer's close() waits for a  Timeout duration for the close() to complete, otherwise it proceeds to force close. The force close path tries to do an `ioThread.join()` without a timeout.
- Due to the SendCallback firing with an Exception, and since SendCallbacks are processed as part of the ioThread, the callback is  stuck waiting for the lock on the shutdownProducer() method.
- The `ioThread.join()` is unable to complete because the ioThread is deadlocked waiting for the synchronized lock on shutdownProducer(), but the lock is held by the close() call.

This PR addresses the above by spawning the "producer.close()" part in a separate thread. It also removes the synchronized methods in favor of a synchronized lock object to avoid dealing with issues where the callers of the KafkaProducerWrapper APIs themselves try to lock the object. Synchronization with other methods may still be a problem, but some fixes have been added to force kill stuck tasks, etc which should reduce such deadlock scenarios.