### PR TITLE
Throw if rewind to last checkpoint fails in AbstractKafkaBasedConnectorTask

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -290,8 +290,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     //    not added to the auto-pause list.
     // 2) The rewind is successful and the Exception returned by the SendCallback is non-transient. This TopicPartition
     //    is added to the auto-pause list with SEND_ERROR as the reason.
-    // 3) The rewind itself failed. An exception is thrown, and the connector task is brought down to avoid wrongfully
-    //    committing checkpoints.
+    // 3) The rewind itself failed. An exception is thrown and the connector task is brought down to avoid committing
+    //    incorrect checkpoints.
     //
     // If the same TopicPartition sees send failures across multiple calls of this function, the attempt to rewind
     // it to the last committed offset may be performed multiple times. The auto-pause list can potentially be

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -263,17 +263,19 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected void rewindAndPausePartitionOnException(TopicPartition srcTopicPartition, Exception ex) {
     _consumerMetrics.updateErrorRate(1);
     Instant start = Instant.now();
-    // seek to previous checkpoints for this topic partition
-    boolean partitionRewound = false;
+    // Seek to previous checkpoints for this topic partition
     try {
       seekToLastCheckpoint(Collections.singleton(srcTopicPartition));
-      partitionRewound = true;
     } catch (Exception e) {
-      _logger.error(String.format("Partition rewind for %s failed due to ", srcTopicPartition), e);
+      // Seek to last checkpoint failed. Throw an exception to avoid any data loss scenarios where the consumed
+      // offset can be committed even though the send for that offset has failed.
+      String errorMessage = String.format("Partition rewind for %s failed due to ", srcTopicPartition);
+      _logger.error(errorMessage, e);
+      throw new DatastreamRuntimeException(errorMessage, e);
     }
-    if (_pausePartitionOnError && (!partitionRewound || !containsTransientException(ex))) {
-      // If partition rewind failed or the exception is not of type DatastreamTransientException and
-      // it is configured to pause partition on error conditions, add it to the auto-paused set
+    if (_pausePartitionOnError && !containsTransientException(ex)) {
+      // If the exception is not of type DatastreamTransientException and it is configured
+      // to pause partition on error conditions, add it to the auto-paused set
       _logger.warn("Adding source topic partition {} to auto-pause set", srcTopicPartition);
       _autoPausedSourcePartitions.put(srcTopicPartition,
           PausedSourcePartitionMetadata.sendError(start, _pauseErrorPartitionDuration, ex));
@@ -282,15 +284,21 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   }
 
   protected void rewindAndPausePartitionsOnSendException() {
-    // For all topic partitions which have seen send exceptions, attempt to rewind them to the last checkpoint
+    // For all topic partitions which have seen send exceptions, attempt to rewind them to the last checkpoint.
+    // The outcome of the rewind can fall into three categories:
+    // 1) The rewind is successful and the Exception returned by the SendCallback is transient. This TopicPartition is
+    //    not added to the auto-pause list.
+    // 2) The rewind is successful and the Exception returned by the SendCallback is non-transient. This TopicPartition
+    //    is added to the auto-pause list with SEND_ERROR as the reason.
+    // 3) The rewind itself failed. An exception is thrown, and the connector task is brought down to avoid wrongfully
+    //    committing checkpoints.
+    //
     // If the same TopicPartition sees send failures across multiple calls of this function, the attempt to rewind
-    // it to the last committed offset may be performed multiple times. TopicPartitions may be added to the auto-pause
-    // list for two reasons, a) the send exception is not transient, b) partition rewind failed. The auto-pause list
-    // can potentially be checked, and such superfluous rewinds can be avoided, but this will take away the chance
-    // to attempt an offset rewind for TopicPartitions that failed to rewind. When TopicPartitions are resumed, no
-    // rewind is performed.
-    // TODO: Check if a TopicPartition already exists on the auto-pause list and avoid re-rewinding it if it was added
-    // due to a non-transient exception.
+    // it to the last committed offset may be performed multiple times. The auto-pause list can potentially be
+    // checked, and a subset of such superfluous rewinds can be avoided (i.e. TopicPartitions which fall under
+    // case (2)).
+    // TODO: Check if a TopicPartition already exists on the auto-pause list and avoid re-rewinding it if its
+    // auto-pause reason is SEND_ERROR.
     synchronized (_sendFailureTopicPartitionExceptionMap) {
       _sendFailureTopicPartitionExceptionMap.forEach(this::rewindAndPausePartitionOnException);
       _sendFailureTopicPartitionExceptionMap.clear();
@@ -608,7 +616,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   /**
    * Seek to the last checkpoint for the given topicPartitions.
    */
-  void seekToLastCheckpoint(Set<TopicPartition> topicPartitions) {
+  @VisibleForTesting
+  protected void seekToLastCheckpoint(Set<TopicPartition> topicPartitions) {
     _logger.info("Trying to seek to previous checkpoint for partitions: {}", topicPartitions);
     Map<TopicPartition, OffsetAndMetadata> lastCheckpoint = new HashMap<>();
     Set<TopicPartition> tpWithNoCommits = new HashSet<>();

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
@@ -136,8 +136,7 @@ final class KafkaMirrorMakerConnectorTestUtils {
   }
 
   static Thread runKafkaMirrorMakerConnectorTask(KafkaMirrorMakerConnectorTask connectorTask,
-      Thread.UncaughtExceptionHandler exceptionHandler)
-      throws InterruptedException {
+      Thread.UncaughtExceptionHandler exceptionHandler) throws InterruptedException {
     Thread t = new Thread(connectorTask, "connector thread");
     t.setDaemon(true);
     t.setUncaughtExceptionHandler(exceptionHandler);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
@@ -132,9 +132,15 @@ final class KafkaMirrorMakerConnectorTestUtils {
 
   static Thread runKafkaMirrorMakerConnectorTask(KafkaMirrorMakerConnectorTask connectorTask)
       throws InterruptedException {
+    return runKafkaMirrorMakerConnectorTask(connectorTask, (t, e) -> Assert.fail("connector thread died", e));
+  }
+
+  static Thread runKafkaMirrorMakerConnectorTask(KafkaMirrorMakerConnectorTask connectorTask,
+      Thread.UncaughtExceptionHandler exceptionHandler)
+      throws InterruptedException {
     Thread t = new Thread(connectorTask, "connector thread");
     t.setDaemon(true);
-    t.setUncaughtExceptionHandler((t1, e) -> Assert.fail("connector thread died", e));
+    t.setUncaughtExceptionHandler(exceptionHandler);
     t.start();
     if (!connectorTask.awaitStart(60, TimeUnit.SECONDS)) {
       Assert.fail("connector did not start within timeout");

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -407,10 +407,10 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         .setEnablePartitionManaged(true)
         .build();
 
-    ZkAdapter zkAdatper = new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null,
+    ZkAdapter zkAdapter = new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null,
         ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
-    task.setZkAdapter(zkAdatper);
-    zkAdatper.connect();
+    task.setZkAdapter(zkAdapter);
+    zkAdapter.connect();
 
     KafkaMirrorMakerConnectorTaskTest connectorTask = new KafkaMirrorMakerConnectorTaskTest(connectorConfig, task, "",
         false, new KafkaMirrorMakerGroupIdConstructor(false, "testCluster"));
@@ -848,10 +848,10 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         new MockDatastreamEventProducer((r) -> new String((byte[]) r.getEvents().get(0).key().get()).equals("key-2"));
     task.setEventProducer(datastreamProducer);
 
-    ZkAdapter zkAdatper = new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null,
+    ZkAdapter zkAdapter = new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null,
         ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
-    task.setZkAdapter(zkAdatper);
-    zkAdatper.connect();
+    task.setZkAdapter(zkAdapter);
+    zkAdapter.connect();
 
     Properties consumerProps = KafkaMirrorMakerConnectorTestUtils.getKafkaConsumerProperties();
     consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -380,10 +380,10 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         .setEnablePartitionManaged(true)
         .build();
 
-    ZkAdapter zkAdatper = new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null,
+    ZkAdapter zkAdapter = new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null,
         ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
-    task.setZkAdapter(zkAdatper);
-    zkAdatper.connect();
+    task.setZkAdapter(zkAdapter);
+    zkAdapter.connect();
 
     KafkaMirrorMakerConnectorTaskTest connectorTask = new KafkaMirrorMakerConnectorTaskTest(connectorConfig, task, "",
         false, new KafkaMirrorMakerGroupIdConstructor(false, "testCluster"));

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -357,8 +357,8 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
       super.seekToLastCheckpoint(topicPartitions);
     }
 
-    void setFailOnSeekToLastCheckpoint() {
-      _failOnSeekToLastCheckpoint = true;
+    void setFailOnSeekToLastCheckpoint(boolean failOnSeekToLastCheckpoint) {
+      _failOnSeekToLastCheckpoint = failOnSeekToLastCheckpoint;
     }
 
     boolean isPostShutdownHookExceptionCaught() {
@@ -862,7 +862,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
 
     KafkaMirrorMakerConnectorTaskTest connectorTask = new KafkaMirrorMakerConnectorTaskTest(connectorConfig, task, "",
         false, new KafkaMirrorMakerGroupIdConstructor(false, "testCluster"));
-    connectorTask.setFailOnSeekToLastCheckpoint();
+    connectorTask.setFailOnSeekToLastCheckpoint(true);
 
     CountDownLatch exceptionCaught = new CountDownLatch(1);
     Thread connectorThread =

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -332,7 +332,8 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   }
 
   private static class KafkaMirrorMakerConnectorTaskTest extends KafkaMirrorMakerConnectorTask {
-    private boolean postShutdownHookExceptionCaught;
+    private boolean _postShutdownHookExceptionCaught;
+    private boolean _failOnSeekToLastCheckpoint;
 
     public KafkaMirrorMakerConnectorTaskTest(KafkaBasedConnectorConfig config, DatastreamTask task,
         String connectorName, boolean isFlushlessModeEnabled, GroupIdConstructor groupIdConstructor) {
@@ -344,12 +345,24 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
       try {
         super.postShutdownHook();
       } catch (Exception e) {
-        postShutdownHookExceptionCaught = true;
+        _postShutdownHookExceptionCaught = true;
       }
     }
 
+    @Override
+    protected void seekToLastCheckpoint(Set<TopicPartition> topicPartitions) {
+      if (_failOnSeekToLastCheckpoint) {
+        throw new KafkaException("KafkaException: failed to seek");
+      }
+      super.seekToLastCheckpoint(topicPartitions);
+    }
+
+    void setFailOnSeekToLastCheckpoint() {
+      _failOnSeekToLastCheckpoint = true;
+    }
+
     boolean isPostShutdownHookExceptionCaught() {
-      return postShutdownHookExceptionCaught;
+      return _postShutdownHookExceptionCaught;
     }
   }
 
@@ -819,6 +832,56 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     connectorTask.stop();
     Assert.assertTrue(connectorTask.awaitStop(CONNECTOR_AWAIT_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS),
         "did not shut down on time");
+  }
+
+  @Test
+  public void testValidateTaskDiesOnRewindFailure() throws InterruptedException {
+    String yummyTopic = "YummyPizza";
+    createTopic(_zkUtils, yummyTopic);
+
+    // create a datastream to consume from topics ending in "Pizza"
+    Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+    // create event producer that fails on 3rd event (of 5)
+    MockDatastreamEventProducer datastreamProducer =
+        new MockDatastreamEventProducer((r) -> new String((byte[]) r.getEvents().get(0).key().get()).equals("key-2"));
+    task.setEventProducer(datastreamProducer);
+
+    ZkAdapter zkAdatper = new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null,
+        ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
+    task.setZkAdapter(zkAdatper);
+    zkAdatper.connect();
+
+    Properties consumerProps = KafkaMirrorMakerConnectorTestUtils.getKafkaConsumerProperties();
+    consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+    KafkaBasedConnectorConfig connectorConfig = KafkaMirrorMakerConnectorTestUtils
+        .getKafkaBasedConnectorConfigBuilder()
+        .setConsumerProps(consumerProps)
+        .build();
+
+    KafkaMirrorMakerConnectorTaskTest connectorTask = new KafkaMirrorMakerConnectorTaskTest(connectorConfig, task, "",
+        false, new KafkaMirrorMakerGroupIdConstructor(false, "testCluster"));
+    connectorTask.setFailOnSeekToLastCheckpoint();
+
+    CountDownLatch exceptionCaught = new CountDownLatch(1);
+    Thread connectorThread =
+        KafkaMirrorMakerConnectorTestUtils.runKafkaMirrorMakerConnectorTask(connectorTask, (t, e) -> {
+          Assert.assertEquals(DatastreamRuntimeException.class, e.getClass());
+          exceptionCaught.countDown();
+        });
+
+    // produce 5 events
+    KafkaMirrorMakerConnectorTestUtils.produceEvents(yummyTopic, 5, _kafkaCluster);
+
+    Assert.assertTrue(exceptionCaught.await(30, TimeUnit.SECONDS),
+        "Exception was not thrown by the KafkaMirrorMakerConnectorTask");
+
+    // Assert that the first two events made it
+    Assert.assertEquals(datastreamProducer.getEvents().size(), 2,
+        "The events before the failure should have been sent");
+
+    connectorThread.join();
   }
 
   @Test


### PR DESCRIPTION
The AbstractKafkaBasedConnectorTask attempts to rewind TopicPartitions to the last checkpoint if any send failures are seen. To avoid data loss, we should thrown an exception if rewind fails, since we may accidentally commit newer offsets for data we were not able to send successfully (e.g. calling KafkaConsumer pause() and then calling commitSync() will commit offsets for paused TopicPartitions).

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
