### PR TITLE
 Ignore lock node during orphan connector node cleanup

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -222,9 +222,11 @@ public class EventProducer implements DatastreamEventProducer {
       String destination =
           record.getDestination().orElse(_datastreamTask.getDatastreamDestination().getConnectionString());
       record.setEventsSendTimestamp(System.currentTimeMillis());
+      long recordEventsSourceTimestamp = record.getEventsSourceTimestamp();
+      long recordEventsSendTimestamp = record.getEventsSendTimestamp().orElse(0L);
       _transportProvider.send(destination, record,
-          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record.getEventsSourceTimestamp(),
-              record.getEventsSendTimestamp().orElse(0L)));
+          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, recordEventsSourceTimestamp,
+              recordEventsSendTimestamp));
     } catch (Exception e) {
       String errorMessage = String.format("Failed send the event %s exception %s", record, e);
       _logger.warn(errorMessage, e);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -60,11 +60,15 @@ public final class KeyBuilder {
    */
   private static final String DATASTREAM_TASK_CONFIG = CONNECTOR + "/%s/config";
 
+  /**
+   * lock node
+   */
+  protected static final String DATASTREAM_TASK_LOCK_ROOT_NAME = "lock";
 
   /**
    * Task lock root path under connectorType
    */
-  private static final String DATASTREAM_TASK_LOCK_ROOT = CONNECTOR + "/lock";
+  private static final String DATASTREAM_TASK_LOCK_ROOT = CONNECTOR + "/" + DATASTREAM_TASK_LOCK_ROOT_NAME;
 
   /**
    * Task lock node under connectorType/lock/{taskName}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -61,9 +61,9 @@ public final class KeyBuilder {
   private static final String DATASTREAM_TASK_CONFIG = CONNECTOR + "/%s/config";
 
   /**
-   * lock node
+   * Lock node
    */
-  protected static final String DATASTREAM_TASK_LOCK_ROOT_NAME = "lock";
+  static final String DATASTREAM_TASK_LOCK_ROOT_NAME = "lock";
 
   /**
    * Task lock root path under connectorType

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -992,6 +992,9 @@ public class ZkAdapter {
           .map(DatastreamTask::getDatastreamTaskName)
           .collect(Collectors.toSet()));
 
+      // ignore the lock root node.
+      connectorTaskList.remove(KeyBuilder.DATASTREAM_TASK_LOCK_ROOT_NAME);
+
       if (connectorTaskList.size() > 0) {
         LOG.warn("Found orphan tasks: {} in connector: {}", connectorTaskList, connector);
         if (cleanUpOrphanTasksInConnector) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -791,6 +791,7 @@ public class TestZkAdapter {
 
     leftOverTasks = zkClient.getChildren(KeyBuilder.connector(testCluster, connectorType));
     Assert.assertEquals(leftOverTasks.size(), 1);
+    Assert.assertEquals(leftOverTasks.get(0), KeyBuilder.DATASTREAM_TASK_LOCK_ROOT_NAME);
 
     // lock root node does not get deleted, once created.
     adapter.releaseTask(lockTask);


### PR DESCRIPTION
Lock node will not be assigned to any instance and the orphan node cleanup code should ignore deleting this node by considering it as orphan node.