### PR TITLE
Fix hash and equals for DatstreamTaskImpl

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -89,8 +89,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
   private DatastreamEventProducer _eventProducer;
   private String _transportProviderName;
   private SerDeSet _destinationSerDes = new SerDeSet(null, null, null);
-  //precalculated hash
-  private int _hashValue;
 
   /**
    * Constructor for DatastreamTaskImpl.
@@ -102,7 +100,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
     _partitions = new ArrayList<>();
     _partitionsV2 = new ArrayList<>();
     _dependencies = new ArrayList<>();
-    computeHash();
   }
 
   /**
@@ -151,7 +148,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
     }
     LOG.info("Created new DatastreamTask " + this);
     _dependencies = new ArrayList<>();
-    computeHash();
   }
 
 
@@ -183,7 +179,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
     _dependencies = new ArrayList<>();
     _dependencies.add(predecessor.getDatastreamTaskName());
-    computeHash();
   }
 
     /**
@@ -250,7 +245,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
   public void setPartitions(List<Integer> partitions) {
     Validate.notNull(partitions);
     _partitions = partitions;
-    computeHash();
   }
 
   /**
@@ -260,7 +254,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
   public void setPartitionsV2(List<String> partitionsV2) {
     Validate.notNull(partitionsV2);
     _partitionsV2 = partitionsV2;
-    computeHash();
   }
 
   @JsonIgnore
@@ -297,7 +290,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
     // destination and connector type should be immutable
     _transportProviderName = _datastreams.get(0).getTransportProviderName();
     _connectorType = _datastreams.get(0).getConnectorName();
-    computeHash();
   }
 
   @Override
@@ -366,7 +358,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public void setConnectorType(String connectorType) {
     _connectorType = connectorType;
-    computeHash();
   }
 
   @Override
@@ -388,7 +379,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public void setId(String id) {
     _id = id;
-    computeHash();
   }
 
   public String getTaskPrefix() {
@@ -401,7 +391,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public void setTaskPrefix(String taskPrefix) {
     _taskPrefix = taskPrefix;
-    computeHash();
   }
 
   @JsonIgnore
@@ -456,11 +445,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   @Override
   public int hashCode() {
-    return _hashValue;
-  }
-
-  private void computeHash() {
-    _hashValue = Objects.hash(_connectorType, _id, _taskPrefix, new HashSet<>(_partitions), new HashSet<>(_partitionsV2));
+    return Objects.hash(_connectorType, _id, _taskPrefix, new HashSet<>(_partitions), new HashSet<>(_partitionsV2));
   }
 
   @Override

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -222,9 +222,11 @@ public class EventProducer implements DatastreamEventProducer {
       String destination =
           record.getDestination().orElse(_datastreamTask.getDatastreamDestination().getConnectionString());
       record.setEventsSendTimestamp(System.currentTimeMillis());
+      long recordEventsSourceTimestamp = record.getEventsSourceTimestamp();
+      long recordEventsSendTimestamp = record.getEventsSendTimestamp().orElse(0L);
       _transportProvider.send(destination, record,
-          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, record.getEventsSourceTimestamp(),
-              record.getEventsSendTimestamp().orElse(0L)));
+          (metadata, exception) -> onSendCallback(metadata, exception, sendCallback, recordEventsSourceTimestamp,
+              recordEventsSendTimestamp));
     } catch (Exception e) {
       String errorMessage = String.format("Failed send the event %s exception %s", record, e);
       _logger.warn(errorMessage, e);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -119,17 +119,22 @@ public class TestDatastreamTask {
     DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(stream), "dummyId", new ArrayList<>());
     DatastreamTaskImpl task2 = new DatastreamTaskImpl(Collections.singletonList(stream), "dummyId", new ArrayList<>());
     Assert.assertEquals(task, task2);
+    Assert.assertEquals(task.hashCode(), task2.hashCode());
 
     task.setPartitions(Arrays.asList(1, 2));
     task2.setPartitions(Arrays.asList(2, 1, 3));
     Assert.assertNotEquals(task, task2);
+    Assert.assertNotEquals(task.hashCode(), task2.hashCode());
     task2.setPartitions(Arrays.asList(2, 1));
     Assert.assertEquals(task, task2);
+    Assert.assertEquals(task.hashCode(), task2.hashCode());
 
     task.setPartitionsV2(Arrays.asList("1", "2"));
     task2.setPartitionsV2(Arrays.asList("2", "1", "3"));
     Assert.assertNotEquals(task, task2);
+    Assert.assertNotEquals(task.hashCode(), task2.hashCode());
     task2.setPartitionsV2(Arrays.asList("2", "1"));
     Assert.assertEquals(task, task2);
+    Assert.assertEquals(task.hashCode(), task2.hashCode());
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -7,6 +7,7 @@ package com.linkedin.datastream.server;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 
@@ -108,5 +109,27 @@ public class TestDatastreamTask {
     String json = task.toJson();
     DatastreamTaskImpl task2 = DatastreamTaskImpl.fromJson(json);
     task2.getDatastreams();
+  }
+
+  @Test
+  public void testDatastreamTaskComparison() {
+    Datastream stream = DatastreamTestUtils.createDatastream("dummy", "dummy", "dummy");
+    stream.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(stream));
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(stream), "dummyId", new ArrayList<>());
+    DatastreamTaskImpl task2 = new DatastreamTaskImpl(Collections.singletonList(stream), "dummyId", new ArrayList<>());
+    Assert.assertEquals(task, task2);
+
+    task.setPartitions(Arrays.asList(1, 2));
+    task2.setPartitions(Arrays.asList(2, 1, 3));
+    Assert.assertNotEquals(task, task2);
+    task2.setPartitions(Arrays.asList(2, 1));
+    Assert.assertEquals(task, task2);
+
+    task.setPartitionsV2(Arrays.asList("1", "2"));
+    task2.setPartitionsV2(Arrays.asList("2", "1", "3"));
+    Assert.assertNotEquals(task, task2);
+    task2.setPartitionsV2(Arrays.asList("2", "1"));
+    Assert.assertEquals(task, task2);
   }
 }


### PR DESCRIPTION
DatastreamTaskImpl has ArrayList for partitions and partitionsV2. The ordering can be a issue in comparison if the list is not sorted, event though the list is same, just differently ordered. 
