### PR TITLE
Bump up the li-apache-kafka-clients version to 1.0.41 along with related dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,9 @@ allprojects {
 
   repositories {
     mavenCentral()
-    jcenter()
+    maven {
+      url  "https://linkedin.bintray.com/maven"
+    }
     mavenLocal()
   }
 }
@@ -184,7 +186,7 @@ project(':datastream-directory') {
 
 project(':datastream-kafka') {
   dependencies {
-    compile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion"
+    compile "com.linkedin.kafka:kafka_$scalaVersion:$kafkaVersion"
     compile "com.linkedin.kafka.clients:li-apache-kafka-clients:$LIKafkaVersion"
     compile "commons-httpclient:commons-httpclient:$commonsHttpClientVersion"
 
@@ -322,7 +324,7 @@ project(':datastream-server') {
     compile project(':datastream-client')
 
     testCompile project(':datastream-kafka')
-    testCompile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion"
+    testCompile "com.linkedin.kafka:kafka_$scalaVersion:$kafkaVersion"
     testCompile project(':datastream-client')
     testCompile project(':datastream-testcommon')
     testCompile "org.mockito:mockito-core:$mockitoVersion"
@@ -356,7 +358,7 @@ project(':datastream-server-restli') {
     compile project(':datastream-common')
 
     testCompile project(':datastream-kafka')
-    testCompile "org.apache.kafka:kafka_$scalaVersion:$kafkaVersion"
+    testCompile "com.linkedin.kafka:kafka_$scalaVersion:$kafkaVersion"
     testCompile project(':datastream-client')
     testCompile project(':datastream-file-connector')
     testCompile project(':datastream-testcommon')

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -1,5 +1,5 @@
 ext {
-    LIKafkaVersion = "1.0.4"
+    LIKafkaVersion = "1.0.41"
     apacheHttpClientVersion = "4.5.3"
     avroVersion = "1.7.7"
     commonsCliVersion = "1.2"
@@ -10,7 +10,7 @@ ext {
     guavaVersion = "25.0-jre"
     intellijAnnotationsVersion = "12.0"
     jacksonVersion = "1.8.5"
-    kafkaVersion = "2.0.0"
+    kafkaVersion = "2.0.0.25"
     log4jVersion = "1.2.17"
     metricsCoreVersion = "4.1.0"
     mockitoVersion = "1.10.19"


### PR DESCRIPTION
This required getting LinkedIn's open-source Kafka artifacts from Bintray instead of JCenter.