### PR TITLE
Add support for Producer flush() with a configurable timeout

### DIFF
--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
@@ -57,8 +57,6 @@ import static com.linkedin.datastream.kafka.factory.KafkaProducerFactory.DOMAIN_
 class KafkaProducerWrapper<K, V> {
   private static final String CLASS_NAME = KafkaProducerWrapper.class.getSimpleName();
   private static final String PRODUCER_ERROR = "producerError";
-  @VisibleForTesting
-  static final String PRODUCER_COUNT = "producerCount";
 
   // Default producer configuration for no data loss pipeline.
   private static final String DEFAULT_PRODUCER_ACKS_CONFIG_VALUE = "all";
@@ -72,14 +70,19 @@ class KafkaProducerWrapper<K, V> {
   private static final String CFG_SEND_FAILURE_RETRY_WAIT_MS = "send.failure.retry.wait.time.ms";
   private static final String CFG_KAFKA_PRODUCER_FACTORY = "kafkaProducerFactory";
   private static final String CFG_RATE_LIMITER_CFG = "producerRateLimiter";
-  private static final String CFG_PRODUCER_FLUSH_TIMEOUT_MS = "producerFlushTimeoutMs";
 
   private static final AtomicInteger NUM_PRODUCERS = new AtomicInteger();
   private static final Supplier<Integer> PRODUCER_GAUGE = NUM_PRODUCERS::get;
 
-  private static final int CLOSE_TIME_OUT_MS = 2000;
+  private static final int CLOSE_TIMEOUT_MS = 2000;
   private static final int MAX_SEND_ATTEMPTS = 10;
   private static final Duration PRODUCER_CLOSE_EXECUTOR_SHUTDOWN_TIMEOUT = Duration.ofSeconds(30);
+
+  @VisibleForTesting
+  static final String PRODUCER_COUNT = "producerCount";
+
+  @VisibleForTesting
+  static final String CFG_PRODUCER_FLUSH_TIMEOUT_MS = "producerFlushTimeoutMs";
 
   private final Logger _log;
   private final long _sendFailureRetryWaitTimeMs;
@@ -273,7 +276,7 @@ class KafkaProducerWrapper<K, V> {
     if (producer != null) {
       _producerCloseExecutorService.submit(() -> {
         _log.info("KafkaProducerWrapper: Closing the Kafka Producer");
-        producer.close(CLOSE_TIME_OUT_MS, TimeUnit.MILLISECONDS);
+        producer.close(CLOSE_TIMEOUT_MS, TimeUnit.MILLISECONDS);
         NUM_PRODUCERS.decrementAndGet();
         _log.info("KafkaProducerWrapper: Kafka Producer is closed");
       });

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
@@ -32,6 +32,7 @@ import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -130,7 +131,7 @@ public class TestKafkaProducerWrapper {
       Producer<K, V> producer = (Producer<K, V>) mock(Producer.class);
       // Calling flush() on the first producer created will throw an InterruptException.
       if (!_createKafkaProducerCalled) {
-        doThrow(InterruptException.class).when(producer).flush();
+        doThrow(InterruptException.class).when(producer).flush(anyInt(), any(TimeUnit.class));
       }
 
       _mockProducer = producer;
@@ -150,7 +151,7 @@ public class TestKafkaProducerWrapper {
     }
 
     void verifyFlush(int numExpected) {
-      verify(_mockProducer, times(numExpected)).flush();
+      verify(_mockProducer, times(numExpected)).flush(anyInt(), any(TimeUnit.class));
     }
 
     void verifyClose(int numExpected) throws NoSuchMethodException {

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
@@ -18,6 +18,7 @@ import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.errors.InterruptException;
+import org.apache.kafka.common.errors.TimeoutException;
 import org.mockito.invocation.Invocation;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -115,23 +116,81 @@ public class TestKafkaProducerWrapper {
     Assert.assertEquals(producerWrapper.getNumCreateKafkaProducerCalls(), 2);
   }
 
+  @Test
+  public void testFlushTimeout() throws Exception {
+    DynamicMetricsManager.createInstance(new MetricRegistry(), getClass().getSimpleName());
+    Properties transportProviderProperties = new Properties();
+    transportProviderProperties.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:1234");
+    transportProviderProperties.put(ProducerConfig.CLIENT_ID_CONFIG, "testClient");
+    transportProviderProperties.put(KafkaTransportProviderAdmin.ZK_CONNECT_STRING_CONFIG, "zk-connect-string");
+    transportProviderProperties.put(KafkaProducerWrapper.CFG_PRODUCER_FLUSH_TIMEOUT_MS, "1");
+
+    String topicName = "topic-42";
+
+    MockKafkaProducerWrapper<byte[], byte[]> producerWrapper =
+        new MockKafkaProducerWrapper<>("log-suffix", transportProviderProperties, "metrics",
+            TimeoutException.class);
+
+    String destinationUri = "localhost:1234/" + topicName;
+    Datastream ds = DatastreamTestUtils.createDatastream("test", "ds1", "source", destinationUri, 1);
+
+    DatastreamTask task = new DatastreamTaskImpl(Collections.singletonList(ds));
+    ProducerRecord<byte[], byte[]> producerRecord = new ProducerRecord<>(topicName, null, null);
+    producerWrapper.assignTask(task);
+
+    // Sending first event, send should pass, none of the other methods on the producer should have been called
+    producerWrapper.send(task, producerRecord, null);
+    producerWrapper.verifySend(1);
+    producerWrapper.verifyFlush(0);
+    producerWrapper.verifyClose(0);
+    Assert.assertEquals(producerWrapper.getNumCreateKafkaProducerCalls(), 1);
+
+    // Producer was mocked to throw a TimeoutException
+    Assert.assertThrows(TimeoutException.class, producerWrapper::flush);
+
+    producerWrapper.verifySend(1);
+    producerWrapper.verifyFlush(1);
+    producerWrapper.verifyClose(0);
+
+    // Second send should reuse the same producer since the producer is not closed on TimeoutException
+    producerWrapper.send(task, producerRecord, null);
+    producerWrapper.verifySend(2);
+    producerWrapper.verifyFlush(1);
+    producerWrapper.verifyClose(0);
+    Assert.assertEquals(producerWrapper.getNumCreateKafkaProducerCalls(), 1);
+
+    // Closing the producer's task. Since this is the only task, the producer should be closed
+    producerWrapper.close(task);
+    producerWrapper.verifySend(2);
+    producerWrapper.verifyFlush(1);
+    producerWrapper.verifyClose(1);
+    Assert.assertEquals(producerWrapper.getNumCreateKafkaProducerCalls(), 1);
+  }
+
   private static class MockKafkaProducerWrapper<K, V> extends KafkaProducerWrapper<K, V> {
+    private Class<? extends Throwable> _exceptionClass;
     private boolean _createKafkaProducerCalled;
     private int _numCreateKafkaProducerCalls;
     private int _numShutdownProducerCalls;
     private Producer<K, V> _mockProducer;
 
     MockKafkaProducerWrapper(String logSuffix, Properties props, String metricsNamesPrefix) {
+      this(logSuffix, props, metricsNamesPrefix, InterruptException.class);
+    }
+
+    MockKafkaProducerWrapper(String logSuffix, Properties props, String metricsNamesPrefix,
+        Class<? extends Throwable> exceptionClass) {
       super(logSuffix, props, metricsNamesPrefix);
+      _exceptionClass = exceptionClass;
     }
 
     @Override
     Producer<K, V> createKafkaProducer() {
       @SuppressWarnings("unchecked")
       Producer<K, V> producer = (Producer<K, V>) mock(Producer.class);
-      // Calling flush() on the first producer created will throw an InterruptException.
+      // Calling flush() on the first producer created will throw an exception of type _exceptionClass.
       if (!_createKafkaProducerCalled) {
-        doThrow(InterruptException.class).when(producer).flush(anyInt(), any(TimeUnit.class));
+        doThrow(_exceptionClass).when(producer).flush(anyInt(), any(TimeUnit.class));
       }
 
       _mockProducer = producer;


### PR DESCRIPTION
This PR adds support for Kafka Producer flush with a timeout which can be configured via config. It also involves some refactoring.
