### PR TITLE
Separated test for auto pause and fixed a potential race condition

### DIFF
--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -1142,7 +1142,44 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
         "did not shut down on time");
   }
 
-  @Test (enabled = false) // Test disabled since it has been flaky
+  @Test
+  public void testAutoPauseOnSendError() throws Exception {
+    String[] cookieTopics = new String[] {
+        "MacadamiaWhiteChocolateCookie",
+        "AlmondCookie",
+        "ChocolateChipCookie",
+        "SaltyCaramelCookie"
+    };
+
+    for (String topic: cookieTopics) {
+      createTopic(_zkUtils, topic);
+    }
+
+    // create a datastream to consume from topics ending in "Pizza"
+    Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("cookieStream", _broker, "\\w+Cookie");
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+    MockDatastreamEventProducer datastreamProducer = new MockDatastreamEventProducer((r) -> true);
+    task.setEventProducer(datastreamProducer);
+
+    KafkaMirrorMakerConnectorTask connectorTask =
+        KafkaMirrorMakerConnectorTestUtils.createFlushlessKafkaMirrorMakerConnectorTask(task, true, 50, 100,
+            Duration.ofDays(1));
+    KafkaMirrorMakerConnectorTestUtils.runKafkaMirrorMakerConnectorTask(connectorTask);
+
+    for (String topic: cookieTopics) {
+      KafkaMirrorMakerConnectorTestUtils.produceEvents(topic, 1, _kafkaCluster);
+    }
+
+    Assert.assertTrue(PollUtils.poll(() -> connectorTask.getAutoPausedSourcePartitions().size() == cookieTopics.length, POLL_PERIOD_MS, POLL_TIMEOUT_MS),
+        "All topics should have had auto-paused partitions");
+
+    connectorTask.stop();
+    Assert.assertTrue(connectorTask.awaitStop(CONNECTOR_AWAIT_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+        "did not shut down on time");
+  }
+
+  @Test
   public void testInFlightMessageCount() throws Exception {
     String yummyTopic = "YummyPizza";
     String saltyTopic = "SaltyPizza";
@@ -1184,8 +1221,6 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
 
     // verify the states response returned by diagnostics endpoint contains correct counts
     KafkaDatastreamStatesResponse statesResponse = connectorTask.getKafkaDatastreamStatesResponse();
-    Assert.assertEquals(statesResponse.getAutoPausedPartitions().size(), 3,
-        "All topics should have had auto-paused partitions");
     Assert.assertEquals(
         statesResponse.getInFlightMessageCounts().get(new FlushlessEventProducerHandler.SourcePartition(yummyTopic, 0)),
         Long.valueOf(1), "In flight message count for yummyTopic was incorrect");


### PR DESCRIPTION
This pull request addresses the flakiness of `testInFlightMessageCount()`. That test is simulating errors while producing messages to a few topics and asserts that the messages are reported as being in-flight (i.e. send executed but not the send callback). The flakiness was due to the assertion that checked if the topics that failed to send a message had their partitions paused.

That assertion has been separated into a test method of its own to have more granular tests and localize flaky tests/test failures around a feature. Also, the assertion didn't poll for the condition, and I think there could be a race condition between test method and connector pausing partitions.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
