### PR TITLE
Support for Kafka broker message format bump for passthrough BMM

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -49,7 +49,6 @@ import com.linkedin.datastream.connectors.kafka.KafkaConnectionString;
 import com.linkedin.datastream.connectors.kafka.KafkaDatastreamStatesResponse;
 import com.linkedin.datastream.connectors.kafka.PausedSourcePartitionMetadata;
 import com.linkedin.datastream.connectors.kafka.TopicPartitionUtil;
-import com.linkedin.datastream.kafka.KafkaDatastreamMetadataConstants;
 import com.linkedin.datastream.kafka.KafkaPassthroughRecordMagicConverter;
 import com.linkedin.datastream.kafka.factory.KafkaConsumerFactory;
 import com.linkedin.datastream.metrics.BrooklinCounterInfo;
@@ -121,6 +120,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   // variables for flushless mode and flow control
   private final boolean _isFlushlessModeEnabled;
   private final boolean _isIdentityMirroringEnabled;
+  private final boolean _isPassthroughEnabled;
   private final boolean _enablePartitionAssignment;
   private final String _destinationTopicPrefix;
   private FlushlessEventProducerHandler<Long> _flushlessProducer = null;
@@ -147,6 +147,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     _isFlushlessModeEnabled = isFlushlessModeEnabled;
     _connectorName = connectorName;
     _isIdentityMirroringEnabled = KafkaMirrorMakerDatastreamMetadata.isIdentityPartitioningEnabled(_datastream);
+    _isPassthroughEnabled = KafkaMirrorMakerDatastreamMetadata.isPassthroughEnabled(_datastream);
     _enablePartitionAssignment = config.getEnablePartitionAssignment();
     _destinationTopicPrefix = task.getDatastreams().get(0).getMetadata()
         .getOrDefault(DatastreamMetadataConstants.DESTINATION_TOPIC_PREFIX, DEFAULT_DESTINATION_TOPIC_PREFIX);
@@ -244,8 +245,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     String offsetStr = String.valueOf(offset);
     metadata.put(KAFKA_ORIGIN_OFFSET, offsetStr);
     metadata.put(BrooklinEnvelopeMetadataConstants.EVENT_TIMESTAMP, String.valueOf(eventsSourceTimestamp));
-    if (Boolean.TRUE.toString()
-        .equals(_datastream.getMetadata().get(KafkaDatastreamMetadataConstants.USE_PASSTHROUGH_COMPRESSION))) {
+    if (_isPassthroughEnabled) {
       // If passthrough mode is enabled, we need to create a Kafka header on the transport side for supporting
       // Kafka broker message format bump. The magic byte contains details about the message format for the passthrough
       // record and it needs to be preserved and set via the Kafka headers to ensure that the correct message format

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerDatastreamMetadata.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerDatastreamMetadata.java
@@ -8,6 +8,7 @@ package com.linkedin.datastream.connectors.kafka.mirrormaker;
 import java.util.Optional;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.kafka.KafkaDatastreamMetadataConstants;
 
 
 /**
@@ -23,6 +24,15 @@ public final class KafkaMirrorMakerDatastreamMetadata {
   public static boolean isIdentityPartitioningEnabled(Datastream datastream) {
     return Boolean.parseBoolean(Optional.ofNullable(datastream)
         .map(d -> d.getMetadata().get(IDENTITY_PARTITIONING_ENABLED))
+        .orElse(Boolean.FALSE.toString()));
+  }
+
+  /**
+   * Getter for whether passthrough is enabled for this datastream. The default is false.
+   */
+  public static boolean isPassthroughEnabled(Datastream datastream) {
+    return Boolean.parseBoolean(Optional.ofNullable(datastream)
+        .map(d -> d.getMetadata().get(KafkaDatastreamMetadataConstants.USE_PASSTHROUGH_COMPRESSION))
         .orElse(Boolean.FALSE.toString()));
   }
 }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaPassthroughRecordMagicConverter.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaPassthroughRecordMagicConverter.java
@@ -1,15 +1,31 @@
+/**
+ *  Copyright 2020 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
 package com.linkedin.datastream.kafka;
 
 import java.io.UnsupportedEncodingException;
 
+import org.apache.kafka.common.header.internals.RecordHeader;
+import org.apache.kafka.common.header.internals.RecordHeaders;
+
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 
 
+/**
+ * This class is a utility class to convert the PassthroughConsumerRecord's magic() to a String, and back into byte.
+ * It also adds a utility to create the RecordHeaders which can be used to pass headers with the magic set to the
+ * ProducerRecord for passthrough message format bump support.
+ */
 public class KafkaPassthroughRecordMagicConverter {
   private static final String CHARSET = "ISO-8859-1";
 
   public static final String PASS_THROUGH_MAGIC_VALUE = "__passThroughMagicValue";
 
+  /**
+   * Convert the magic byte of the PassthroughConsumerRecord to a String
+   */
   public static String convertMagicToString(byte magic) {
     try {
       return new String(new byte[] { magic }, CHARSET);
@@ -18,6 +34,9 @@ public class KafkaPassthroughRecordMagicConverter {
     }
   }
 
+  /**
+   * Convert the converted magic String back into a byte array
+   */
   public static byte[] convertMagicStringToByteArray(String magic) {
     try {
       return magic.getBytes(CHARSET);
@@ -25,5 +44,21 @@ public class KafkaPassthroughRecordMagicConverter {
       throw new DatastreamRuntimeException(String.format("Cannot convert magic String %s to byte array", magic),
           e);
     }
+  }
+
+  /**
+   * Return a RecordHeaders containing the correct Passthrough magic header which can be used to create the
+   * ProducerRecord to send the passthrough record
+   */
+  public static RecordHeaders convertMagicStringToRecordHeaders(String magicString) {
+    RecordHeaders recordHeaders = null;
+    if (magicString != null) {
+      byte[] magic = convertMagicStringToByteArray(magicString);
+      RecordHeader recordHeader = new RecordHeader(KafkaPassthroughRecordMagicConverter.PASS_THROUGH_MAGIC_VALUE,
+          magic);
+      recordHeaders = new RecordHeaders();
+      recordHeaders.add(recordHeader);
+    }
+    return recordHeaders;
   }
 }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaPassthroughRecordMagicConverter.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaPassthroughRecordMagicConverter.java
@@ -1,0 +1,29 @@
+package com.linkedin.datastream.kafka;
+
+import java.io.UnsupportedEncodingException;
+
+import com.linkedin.datastream.common.DatastreamRuntimeException;
+
+
+public class KafkaPassthroughRecordMagicConverter {
+  private static final String CHARSET = "ISO-8859-1";
+
+  public static final String PASS_THROUGH_MAGIC_VALUE = "__passThroughMagicValue";
+
+  public static String convertMagicToString(byte magic) {
+    try {
+      return new String(new byte[] { magic }, CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      throw new DatastreamRuntimeException(String.format("Cannot convert magic byte %02X to String", magic), e);
+    }
+  }
+
+  public static byte[] convertMagicStringToByteArray(String magic) {
+    try {
+      return magic.getBytes(CHARSET);
+    } catch (UnsupportedEncodingException e) {
+      throw new DatastreamRuntimeException(String.format("Cannot convert magic String %s to byte array", magic),
+          e);
+    }
+  }
+}

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -17,6 +17,7 @@ import org.apache.commons.lang3.Validate;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.common.header.internals.RecordHeaders;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -99,6 +100,7 @@ public class KafkaTransportProvider implements TransportProvider {
 
     byte[] keyValue = null;
     byte[] payloadValue = new byte[0];
+    RecordHeaders recordHeaders = null;
     if (event instanceof BrooklinEnvelope) {
       BrooklinEnvelope envelope = (BrooklinEnvelope) event;
       if (envelope.key().isPresent() && envelope.key().get() instanceof byte[]) {
@@ -108,19 +110,23 @@ public class KafkaTransportProvider implements TransportProvider {
       if (envelope.value().isPresent() && envelope.value().get() instanceof byte[]) {
         payloadValue = (byte[]) envelope.value().get();
       }
+
+      String magic = envelope.getMetadata().getOrDefault(KafkaPassthroughRecordMagicConverter.PASS_THROUGH_MAGIC_VALUE,
+          null);
+      recordHeaders = KafkaPassthroughRecordMagicConverter.convertMagicStringToRecordHeaders(magic);
     } else if (event instanceof byte[]) {
       payloadValue = (byte[]) event;
     }
 
     if (partition.isPresent() && partition.get() >= 0) {
       // If the partition is specified. We send the record to the specific partition
-      return new ProducerRecord<>(topicName, partition.get(), keyValue, payloadValue);
+      return new ProducerRecord<>(topicName, partition.get(), keyValue, payloadValue, recordHeaders);
     } else {
       // If the partition is not specified. We use the partitionKey as the key. Kafka will use the hash of that
       // to determine the partition. If partitionKey does not exist, use the key value.
       keyValue = record.getPartitionKey().isPresent()
               ? record.getPartitionKey().get().getBytes(StandardCharsets.UTF_8) : keyValue;
-      return new ProducerRecord<>(topicName, keyValue, payloadValue);
+      return new ProducerRecord<>(topicName, null, null, keyValue, payloadValue, recordHeaders);
     }
   }
 

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaPassthroughRecordMagicConverter.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaPassthroughRecordMagicConverter.java
@@ -1,0 +1,30 @@
+package com.linkedin.datastream.kafka;
+
+import org.apache.kafka.common.record.RecordBatch;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test
+public class TestKafkaPassthroughRecordMagicConverter {
+
+  @Test
+  public void testMagicConversion() {
+    String magicValue0 = KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.MAGIC_VALUE_V0);
+    Assert.assertEquals(new byte[] { RecordBatch.MAGIC_VALUE_V0 },
+        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValue0));
+
+    String magicValue1 = KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.MAGIC_VALUE_V1);
+    Assert.assertEquals(new byte[] { RecordBatch.MAGIC_VALUE_V1 },
+        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValue1));
+
+    String magicValue2 = KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.MAGIC_VALUE_V2);
+    Assert.assertEquals(new byte[] { RecordBatch.MAGIC_VALUE_V2 },
+        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValue2));
+
+    String magicValueCurrent =
+        KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.CURRENT_MAGIC_VALUE);
+    Assert.assertEquals(new byte[] { RecordBatch.CURRENT_MAGIC_VALUE },
+        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValueCurrent));
+  }
+}

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaPassthroughRecordMagicConverter.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaPassthroughRecordMagicConverter.java
@@ -18,21 +18,17 @@ public class TestKafkaPassthroughRecordMagicConverter {
 
   @Test
   public void testMagicConversion() {
-    String magicValue0 = KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.MAGIC_VALUE_V0);
-    Assert.assertEquals(new byte[] { RecordBatch.MAGIC_VALUE_V0 },
-        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValue0));
+    byte[] magics = {
+        RecordBatch.MAGIC_VALUE_V0,
+        RecordBatch.MAGIC_VALUE_V1,
+        RecordBatch.MAGIC_VALUE_V2,
+        RecordBatch.CURRENT_MAGIC_VALUE
+    };
 
-    String magicValue1 = KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.MAGIC_VALUE_V1);
-    Assert.assertEquals(new byte[] { RecordBatch.MAGIC_VALUE_V1 },
-        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValue1));
-
-    String magicValue2 = KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.MAGIC_VALUE_V2);
-    Assert.assertEquals(new byte[] { RecordBatch.MAGIC_VALUE_V2 },
-        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValue2));
-
-    String magicValueCurrent =
-        KafkaPassthroughRecordMagicConverter.convertMagicToString(RecordBatch.CURRENT_MAGIC_VALUE);
-    Assert.assertEquals(new byte[] { RecordBatch.CURRENT_MAGIC_VALUE },
-        KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicValueCurrent));
+    for (byte magic : magics) {
+      String magicString = KafkaPassthroughRecordMagicConverter.convertMagicToString(magic);
+      Assert.assertEquals(new byte[] { magic },
+          KafkaPassthroughRecordMagicConverter.convertMagicStringToByteArray(magicString));
+    }
   }
 }

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaPassthroughRecordMagicConverter.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaPassthroughRecordMagicConverter.java
@@ -1,3 +1,8 @@
+/**
+ *  Copyright 2020 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
 package com.linkedin.datastream.kafka;
 
 import org.apache.kafka.common.record.RecordBatch;
@@ -5,6 +10,9 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 
+/**
+ * Tests for {@link KafkaPassthroughRecordMagicConverter}.
+ */
 @Test
 public class TestKafkaPassthroughRecordMagicConverter {
 


### PR DESCRIPTION
This PR adds support for the Kafka broker message format bump for passthrough by extracting the magic from the PassthroughConsumerRecord. This magic is stored in the metadata of the BrooklinEnvelope after consumption. A utility class is added for abstracting out conversion of byte to String and back to byte. The transport layer is responsible for extracting this metadata field and constructing the right ProducerRecord with headers if the metadata is present. This is done in the KafkaTransportProvider class.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
