### PR TITLE
Log and explicitly send 404 in get datastream rest call

### DIFF
--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -666,21 +666,22 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
   @Override
   public Datastream get(String name) {
+    Datastream stream = null;
     try {
-      LOG.info("Get datastream called for datastream {}", name);
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, GET_CALL, 1);
-      Instant startTime = Instant.now();
-      Datastream stream = _store.getDatastream(name);
-      LOG.info("Get datastream call took {} ms", Duration.between(startTime, Instant.now()).toMillis());
-      return stream;
+      stream = _store.getDatastream(name);
     } catch (Exception e) {
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, CALL_ERROR, 1);
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
           "Get datastream failed for datastream: " + name, e);
     }
 
-    // Returning null will automatically trigger a 404 Not Found response
-    return null;
+    if (stream == null) {
+      _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_404_NOT_FOUND,
+          "Datastream not found: " + name);
+    }
+
+    return stream;
   }
 
   @SuppressWarnings("deprecated")

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -668,6 +668,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
   public Datastream get(String name) {
     Datastream stream = null;
     try {
+      LOG.info("Get datastream called for datastream {}", name);
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, GET_CALL, 1);
       stream = _store.getDatastream(name);
     } catch (Exception e) {

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2194,7 +2194,15 @@ public class TestCoordinator {
     Assert.assertEquals(createResponse.getStatus(), HttpStatus.S_201_CREATED);
 
     // Poll up to 30s for stream1 to get deleted
-    PollUtils.poll(() -> setup._resource.get(streams[0].getName()) == null, 200, Duration.ofSeconds(30).toMillis());
+    PollUtils.poll(() -> {
+      try {
+        setup._resource.get(streams[0].getName());
+        return false;
+      } catch (RestLiServiceException e) {
+        Assert.assertEquals(e.getStatus(), HttpStatus.S_404_NOT_FOUND);
+        return true;
+      }
+    }, 200, Duration.ofSeconds(30).toMillis());
   }
 
   @Test

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -133,13 +133,12 @@ public class TestDatastreamResources {
   }
 
   @Test
-  public void testReadDatastream() {
+  public void testReadDatastream() throws Exception {
     DatastreamResources resource1 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
     DatastreamResources resource2 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
 
     // read before creating
-    Datastream ds = resource1.get("name_0");
-    Assert.assertNull(ds);
+    checkBadRequest(() -> resource1.get("name_0"), HttpStatus.S_404_NOT_FOUND);
 
     Datastream datastreamToCreate = generateDatastream(0);
     datastreamToCreate.setDestination(new DatastreamDestination());
@@ -150,9 +149,7 @@ public class TestDatastreamResources {
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
 
-    ds = resource2.get("name_0");
-    Assert.assertNotNull(ds);
-
+    Datastream ds = resource2.get("name_0");
     Assert.assertEquals(ds, datastreamToCreate);
   }
 


### PR DESCRIPTION
`DatastreamResources` get call does not log an error when stream is not
found. This is not consistent with other APIs. Make it consistent with
the rest of the APIs which allows for also logging in case stream is not
found and can be helpful with debugging. Change also removes the logging
of time it takes for the get for consistency. It is not a batch operation and
doesn't seem like it warrants a log for execution time.
