### PR TITLE
Added kafka headers in BrooklinEnvelope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ project(':datastream-common') {
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "com.intellij:annotations:$intellijAnnotationsVersion"
     compile "com.google.guava:guava:$guavaVersion"
+    compile "com.linkedin.kafka.clients:li-apache-kafka-clients:$LIKafkaVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang.Validate;
-import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 
 
 /**
@@ -30,7 +30,7 @@ public class BrooklinEnvelope {
 
   private Map<String, String> _metadata;
 
-  private Iterable<Header> _headers;
+  private Headers _headers;
 
   /**
    * Construct a BrooklinEnvelope using record key, value, and metadata
@@ -63,13 +63,13 @@ public class BrooklinEnvelope {
    * @param metadata Additional metadata to associate with the change event
    */
   public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
-      @Nullable Iterable<Header> headers, Map<String, String> metadata) {
+      @Nullable Headers headers, Map<String, String> metadata) {
     Validate.notNull(metadata, "metadata cannot be null");
     setKey(key);
     setValue(value);
     setPreviousValue(previousValue);
-    setMetadata(metadata);
     setHeaders(headers);
+    setMetadata(metadata);
   }
 
   /**
@@ -95,14 +95,14 @@ public class BrooklinEnvelope {
   /**
    * Get the Kafka headers
    */
-  public Iterable<Header> getHeaders() {
+  public Headers getHeaders() {
     return _headers;
   }
 
   /**
    * Set the Kafka headers
    */
-  public void setHeaders(Iterable<Header> headers) {
+  public void setHeaders(Headers headers) {
     _headers = headers;
   }
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang.Validate;
+import org.apache.kafka.common.header.Header;
 
 
 /**
@@ -29,6 +30,8 @@ public class BrooklinEnvelope {
 
   private Map<String, String> _metadata;
 
+  private Iterable<Header> _headers;
+
   /**
    * Construct a BrooklinEnvelope using record key, value, and metadata
    * @param key The record key (e.g. primary key)
@@ -36,7 +39,7 @@ public class BrooklinEnvelope {
    * @param metadata Additional metadata to associate with the change event
    */
   public BrooklinEnvelope(Object key, Object value, Map<String, String> metadata) {
-    this(key, value, null, metadata);
+    this(key, value, null, null, metadata);
   }
 
   /**
@@ -48,11 +51,25 @@ public class BrooklinEnvelope {
    */
   public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
       Map<String, String> metadata) {
+    this(key, value, previousValue, null, metadata);
+  }
+
+  /**
+   * Construct a {@link BrooklinEnvelope} using record key, value, headers and metadata
+   * @param key The record key (e.g. primary key)
+   * @param value The new record value
+   * @param previousValue The old record value
+   * @param headers Kafka headers to associate with the change event
+   * @param metadata Additional metadata to associate with the change event
+   */
+  public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
+      @Nullable Iterable<Header> headers, Map<String, String> metadata) {
     Validate.notNull(metadata, "metadata cannot be null");
     setKey(key);
     setValue(value);
     setPreviousValue(previousValue);
     setMetadata(metadata);
+    setHeaders(headers);
   }
 
   /**
@@ -73,6 +90,20 @@ public class BrooklinEnvelope {
    */
   public void setPreviousValue(Object previousValue) {
     _previousValue = previousValue instanceof Optional ? ((Optional<?>) previousValue).orElse(null) : previousValue;
+  }
+
+  /**
+   * Get the Kafka headers
+   */
+  public Iterable<Header> getHeaders() {
+    return _headers;
+  }
+
+  /**
+   * Set the Kafka headers
+   */
+  public void setHeaders(Iterable<Header> headers) {
+    _headers = headers;
   }
 
   @Nullable


### PR DESCRIPTION
Right now we're dropping headers that come with Kafka events when consuming from source topic and producing to destination. This poses a problem if downstream systems rely on those headers. Essentially headers are extra metadata that come with events. This pull requests adds a field in BrooklinEnvelope to store those headers with the purpose of setting them in ProducerRecord for transit.