### PR TITLE
Passing Kafka headers to downstream systems via ProducerRecord

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,6 +141,7 @@ project(':datastream-common') {
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "com.intellij:annotations:$intellijAnnotationsVersion"
     compile "com.google.guava:guava:$guavaVersion"
+    compile "com.linkedin.kafka.clients:li-apache-kafka-clients:$LIKafkaVersion"
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -11,7 +11,7 @@ import java.util.Optional;
 
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang.Validate;
-import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
 
 
 /**
@@ -30,7 +30,7 @@ public class BrooklinEnvelope {
 
   private Map<String, String> _metadata;
 
-  private Iterable<Header> _headers;
+  private Headers _headers;
 
   /**
    * Construct a BrooklinEnvelope using record key, value, and metadata
@@ -63,13 +63,13 @@ public class BrooklinEnvelope {
    * @param metadata Additional metadata to associate with the change event
    */
   public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
-      @Nullable Iterable<Header> headers, Map<String, String> metadata) {
+      @Nullable Headers headers, Map<String, String> metadata) {
     Validate.notNull(metadata, "metadata cannot be null");
     setKey(key);
     setValue(value);
     setPreviousValue(previousValue);
-    setMetadata(metadata);
     setHeaders(headers);
+    setMetadata(metadata);
   }
 
   /**
@@ -95,14 +95,14 @@ public class BrooklinEnvelope {
   /**
    * Get the Kafka headers
    */
-  public Iterable<Header> getHeaders() {
+  public Headers getHeaders() {
     return _headers;
   }
 
   /**
    * Set the Kafka headers
    */
-  public void setHeaders(Iterable<Header> headers) {
+  public void setHeaders(Headers headers) {
     _headers = headers;
   }
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang.Validate;
+import org.apache.kafka.common.header.Header;
 
 
 /**
@@ -29,6 +30,8 @@ public class BrooklinEnvelope {
 
   private Map<String, String> _metadata;
 
+  private Iterable<Header> _headers;
+
   /**
    * Construct a BrooklinEnvelope using record key, value, and metadata
    * @param key The record key (e.g. primary key)
@@ -36,7 +39,7 @@ public class BrooklinEnvelope {
    * @param metadata Additional metadata to associate with the change event
    */
   public BrooklinEnvelope(Object key, Object value, Map<String, String> metadata) {
-    this(key, value, null, metadata);
+    this(key, value, null, null, metadata);
   }
 
   /**
@@ -48,11 +51,25 @@ public class BrooklinEnvelope {
    */
   public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
       Map<String, String> metadata) {
+    this(key, value, previousValue, null, metadata);
+  }
+
+  /**
+   * Construct a {@link BrooklinEnvelope} using record key, value, headers and metadata
+   * @param key The record key (e.g. primary key)
+   * @param value The new record value
+   * @param previousValue The old record value
+   * @param headers Kafka headers to associate with the change event
+   * @param metadata Additional metadata to associate with the change event
+   */
+  public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
+      @Nullable Iterable<Header> headers, Map<String, String> metadata) {
     Validate.notNull(metadata, "metadata cannot be null");
     setKey(key);
     setValue(value);
     setPreviousValue(previousValue);
     setMetadata(metadata);
+    setHeaders(headers);
   }
 
   /**
@@ -73,6 +90,20 @@ public class BrooklinEnvelope {
    */
   public void setPreviousValue(Object previousValue) {
     _previousValue = previousValue instanceof Optional ? ((Optional<?>) previousValue).orElse(null) : previousValue;
+  }
+
+  /**
+   * Get the Kafka headers
+   */
+  public Iterable<Header> getHeaders() {
+    return _headers;
+  }
+
+  /**
+   * Set the Kafka headers
+   */
+  public void setHeaders(Iterable<Header> headers) {
+    _headers = headers;
   }
 
   @Nullable

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -241,7 +241,8 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     String offsetStr = String.valueOf(offset);
     metadata.put(KAFKA_ORIGIN_OFFSET, offsetStr);
     metadata.put(BrooklinEnvelopeMetadataConstants.EVENT_TIMESTAMP, String.valueOf(eventsSourceTimestamp));
-    BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null, metadata);
+    BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null,
+        fromKafka.headers(), metadata);
     DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
     builder.addEvent(envelope);
     builder.setEventsSourceTimestamp(eventsSourceTimestamp);


### PR DESCRIPTION
This is a follow up pull request for #737. We're passing headers to downstream systems by setting them in `BrooklinEnvelope` first, then passing to the `ProducerRecord` constructor in `translate()` method.