### PR TITLE
Passing Kafka headers to downstream systems in KafkaConnectorTask

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -142,7 +142,8 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
       eventsSourceTimestamp = fromKafka.timestamp();
     }
 
-    BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null, metadata);
+    BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null,
+        fromKafka.headers(), metadata);
     DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
     builder.addEvent(envelope);
     builder.setEventsSourceTimestamp(eventsSourceTimestamp);


### PR DESCRIPTION
The same has been done for mirror maker in #739. `KafkaTransportProvider` already handles the `headers` field properly.

