### PR TITLE
 Change task locks from Ephemeral to Persistent 

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2488,7 +2488,7 @@ public class TestCoordinator {
     ZkAdapter createZkAdapter() {
       return spy(new ZkAdapter(getConfig().getZkAddress(), getConfig().getCluster(),
           getConfig().getDefaultTransportProviderName(), getConfig().getZkSessionTimeout(),
-          getConfig().getZkConnectionTimeout(), this));
+          getConfig().getZkConnectionTimeout(), 1000, this));
     }
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -946,10 +946,10 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   }
 
   /*
-   * If cleanUpOrphanConnectorTasks is set to true, it cleans up the orphan connector tasks not assigned to
+   * If cleanUpOrphanNodes is set to true, it cleans up the orphan connector tasks not assigned to
    * any instance after old unused tasks are cleaned up.
    */
-  private void handleLeaderDoAssignment(boolean cleanUpOrphanConnectorTasks) {
+  private void handleLeaderDoAssignment(boolean cleanUpOrphanNodes) {
     boolean succeeded = true;
     List<String> liveInstances = Collections.emptyList();
     Map<String, Set<DatastreamTask>> previousAssignmentByInstance = Collections.emptyMap();
@@ -990,8 +990,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       instances.add(PAUSED_INSTANCE);
       _adapter.cleanUpDeadInstanceDataAndOtherUnusedTasks(previousAssignmentByInstance,
           newAssignmentsByInstance, instances);
-      if (cleanUpOrphanConnectorTasks) {
-        performCleanupOrphanConnectorTasks();
+      if (cleanUpOrphanNodes) {
+        performCleanupOrphanNodes();
       }
       _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_REBALANCES, 1);
     }
@@ -1002,7 +1002,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.HANDLE_LEADER_DO_ASSIGNMENT_NUM_RETRIES, 1);
       leaderDoAssignmentScheduled.set(true);
       _executor.schedule(() -> {
-        _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(cleanUpOrphanConnectorTasks));
+        _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(cleanUpOrphanNodes));
         leaderDoAssignmentScheduled.set(false);
       }, _config.getRetryIntervalMs(), TimeUnit.MILLISECONDS);
     }
@@ -1248,11 +1248,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     return newAssignmentsByInstance;
   }
 
-  void performCleanupOrphanConnectorTasks() {
-    _log.info("performCleanupOrphanConnectorTasks called");
+  void performCleanupOrphanNodes() {
+    _log.info("performCleanupOrphanNodes called");
     int orphanCount = _adapter.cleanUpOrphanConnectorTasks(_config.getZkCleanUpOrphanConnectorTask());
     _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_ORPHAN_CONNECTOR_TASKS, orphanCount);
-    int orphanLockCount = _adapter.cleanUpOrphanConnectorTaskLocks(_config.getZkCleanUpOrphanConnectorTask());
+    int orphanLockCount = _adapter.cleanUpOrphanConnectorTaskLocks(_config.getZkCleanUpOrphanConnectorTaskLock());
     _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_ORPHAN_CONNECTOR_TASK_LOCKS, orphanLockCount);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -234,7 +234,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   @VisibleForTesting
   ZkAdapter createZkAdapter() {
     return new ZkAdapter(_config.getZkAddress(), _clusterName, _config.getDefaultTransportProviderName(),
-        _config.getZkSessionTimeout(), _config.getZkConnectionTimeout(), this);
+        _config.getZkSessionTimeout(), _config.getZkConnectionTimeout(), _config.getDebounceTimerMs(), this);
   }
 
   /**
@@ -1252,6 +1252,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _log.info("performCleanupOrphanConnectorTasks called");
     int orphanCount = _adapter.cleanUpOrphanConnectorTasks(_config.getZkCleanUpOrphanConnectorTask());
     _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_ORPHAN_CONNECTOR_TASKS, orphanCount);
+    int orphanLockCount = _adapter.cleanUpOrphanConnectorTaskLocks(_config.getZkCleanUpOrphanConnectorTask());
+    _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_ORPHAN_CONNECTOR_TASK_LOCKS, orphanLockCount);
   }
 
   /**
@@ -1825,7 +1827,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       NUM_ASSIGNMENT_CHANGES("numAssignmentChanges"),
       NUM_PARTITION_ASSIGNMENTS("numPartitionAssignments"),
       NUM_PARTITION_MOVEMENTS("numPartitionMovements"),
-      NUM_ORPHAN_CONNECTOR_TASKS("numOrphanConnectorTasks");
+      NUM_ORPHAN_CONNECTOR_TASKS("numOrphanConnectorTasks"),
+      NUM_ORPHAN_CONNECTOR_TASK_LOCKS("numOrphanConnectorTaskLocks");
 
       private final String _name;
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -21,10 +21,12 @@ public final class CoordinatorConfig {
   public static final String CONFIG_ZK_ADDRESS = PREFIX + "zkAddress";
   public static final String CONFIG_ZK_SESSION_TIMEOUT = PREFIX + "zkSessionTimeout";
   public static final String CONFIG_ZK_CONNECTION_TIMEOUT = PREFIX + "zkConnectionTimeout";
+  // debounce timer is used to postpone the operations by a certain time to handle zookeeper session expiry.
   public static final String CONFIG_DEBOUNCE_TIMER_MS = PREFIX + "debounceTimerMs";
   public static final String CONFIG_RETRY_INTERVAL = PREFIX + "retryIntervalMs";
   public static final String CONFIG_HEARTBEAT_PERIOD_MS = PREFIX + "heartbeatPeriodMs";
   public static final String CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK = PREFIX + "zkCleanUpOrphanConnectorTask";
+  public static final String CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK_LOCK = PREFIX + "zkCleanUpOrphanConnectorTaskLock";
 
   private final String _cluster;
   private final String _zkAddress;
@@ -37,6 +39,7 @@ public final class CoordinatorConfig {
   private final long _heartbeatPeriodMs;
   private final String _defaultTransportProviderName;
   private final boolean _zkCleanUpOrphanConnectorTask;
+  private final boolean _zkCleanUpOrphanConnectorTaskLock;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -55,7 +58,7 @@ public final class CoordinatorConfig {
     _debounceTimerMs = _properties.getLong(CONFIG_DEBOUNCE_TIMER_MS, Duration.ofSeconds(30).toMillis());
     _defaultTransportProviderName = _properties.getString(CONFIG_DEFAULT_TRANSPORT_PROVIDER, "");
     _zkCleanUpOrphanConnectorTask = _properties.getBoolean(CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK, false);
-
+    _zkCleanUpOrphanConnectorTaskLock = _properties.getBoolean(CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK_LOCK, false);
   }
 
   public Properties getConfigProperties() {
@@ -94,8 +97,11 @@ public final class CoordinatorConfig {
     return _zkCleanUpOrphanConnectorTask;
   }
 
+  public boolean getZkCleanUpOrphanConnectorTaskLock() {
+    return _zkCleanUpOrphanConnectorTaskLock;
+  }
+
   public long getDebounceTimerMs() {
     return _debounceTimerMs;
   }
-
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -21,6 +21,7 @@ public final class CoordinatorConfig {
   public static final String CONFIG_ZK_ADDRESS = PREFIX + "zkAddress";
   public static final String CONFIG_ZK_SESSION_TIMEOUT = PREFIX + "zkSessionTimeout";
   public static final String CONFIG_ZK_CONNECTION_TIMEOUT = PREFIX + "zkConnectionTimeout";
+  public static final String CONFIG_DEBOUNCE_TIMER_MS = PREFIX + "debounceTimerMs";
   public static final String CONFIG_RETRY_INTERVAL = PREFIX + "retryIntervalMs";
   public static final String CONFIG_HEARTBEAT_PERIOD_MS = PREFIX + "heartbeatPeriodMs";
   public static final String CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK = PREFIX + "zkCleanUpOrphanConnectorTask";
@@ -32,6 +33,7 @@ public final class CoordinatorConfig {
   private final Properties _config;
   private final VerifiableProperties _properties;
   private final int _retryIntervalMs;
+  private final long _debounceTimerMs;
   private final long _heartbeatPeriodMs;
   private final String _defaultTransportProviderName;
   private final boolean _zkCleanUpOrphanConnectorTask;
@@ -50,8 +52,10 @@ public final class CoordinatorConfig {
     _zkConnectionTimeout = _properties.getInt(CONFIG_ZK_CONNECTION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
     _retryIntervalMs = _properties.getInt(CONFIG_RETRY_INTERVAL, 1000 /* 1 second */);
     _heartbeatPeriodMs = _properties.getLong(CONFIG_HEARTBEAT_PERIOD_MS, Duration.ofMinutes(1).toMillis());
+    _debounceTimerMs = _properties.getLong(CONFIG_DEBOUNCE_TIMER_MS, Duration.ofSeconds(30).toMillis());
     _defaultTransportProviderName = _properties.getString(CONFIG_DEFAULT_TRANSPORT_PROVIDER, "");
     _zkCleanUpOrphanConnectorTask = _properties.getBoolean(CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK, false);
+
   }
 
   public Properties getConfigProperties() {
@@ -89,4 +93,9 @@ public final class CoordinatorConfig {
   public boolean getZkCleanUpOrphanConnectorTask() {
     return _zkCleanUpOrphanConnectorTask;
   }
+
+  public long getDebounceTimerMs() {
+    return _debounceTimerMs;
+  }
+
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -301,7 +301,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
     try {
       // Need to confirm the dependencies for task are not locked
       _dependencies.forEach(predecessor -> {
-           if (_zkAdapter.checkIsTaskLocked(this.getConnectorType(), predecessor)) {
+           if (_zkAdapter.checkIsTaskLocked(this.getConnectorType(), this.getTaskPrefix(), predecessor)) {
              String msg = String.format("previous task %s failed to release lock in %dms", predecessor,
                  timeout.toMillis());
              throw new DatastreamRuntimeException(msg);
@@ -323,7 +323,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
   @JsonIgnore
   public boolean isLocked() {
     Validate.notNull(_zkAdapter, "Task is not properly initialized for processing.");
-    return _zkAdapter.checkIsTaskLocked(_connectorType, getDatastreamTaskName());
+    return _zkAdapter.checkIsTaskLocked(_connectorType, this.getTaskPrefix(), this.getDatastreamTaskName());
   }
 
   @Override
@@ -354,7 +354,7 @@ public class DatastreamTaskImpl implements DatastreamTask {
 
   /**
    * set connector type
-   * @param connectorType
+   * @param connectorType connector type
    */
   public void setConnectorType(String connectorType) {
     _connectorType = connectorType;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -301,13 +301,11 @@ public class DatastreamTaskImpl implements DatastreamTask {
     try {
       // Need to confirm the dependencies for task are not locked
       _dependencies.forEach(predecessor -> {
-           if (_zkAdapter.checkIsTaskLocked(this.getConnectorType(), this.getTaskPrefix(), predecessor)) {
-             String msg = String.format("previous task %s failed to release lock in %dms", predecessor,
-                 timeout.toMillis());
-             throw new DatastreamRuntimeException(msg);
-           }
+        if (_zkAdapter.checkIsTaskLocked(this.getConnectorType(), this.getTaskPrefix(), predecessor)) {
+          String msg = String.format("previous task %s failed to release lock in %dms", predecessor, timeout.toMillis());
+          throw new DatastreamRuntimeException(msg);
         }
-      );
+      });
 
       _zkAdapter.acquireTask(this, timeout);
     } catch (Exception e) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -38,7 +38,9 @@ public final class KeyBuilder {
    *
    * Below keys represent the various locations under connectors for parts of
    * a DatastreamTask can be persisted.
+   */
 
+  /**
    * Task node under connectorType
    */
   private static final String CONNECTOR_DATASTREAM_TASK = CONNECTOR + "/%s";
@@ -74,7 +76,7 @@ public final class KeyBuilder {
   private static final String DATASTREAM_TASK_LOCK_PREFIX = DATASTREAM_TASK_LOCK_ROOT + "/%s";
 
   /**
-   * Task lock node under connectorType/lock/{taskPrefix}/{task}
+   * Task lock node under connectorType/lock/{taskPrefix}/{taskName }
    */
   private static final String DATASTREAM_TASK_LOCK = DATASTREAM_TASK_LOCK_PREFIX + "/%s";
 
@@ -296,7 +298,8 @@ public final class KeyBuilder {
 
   /**
    * Get the ZooKeeper znode for a specific datastream task's lock
-   * The lock is ephemeral node and it should not be stored under task node
+   * The lock is persistent node and it should not be stored under task node to handle the race condition where the connector
+   * tries   to acquire the lock while the coordinator deletes the task node.
    *
    * <pre>Example: /{cluster}/connectors/{connectorType}/lock/{task-prefix}/{taskName}</pre>
    * @param cluster Brooklin cluster name

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -76,7 +76,7 @@ public final class KeyBuilder {
   private static final String DATASTREAM_TASK_LOCK_PREFIX = DATASTREAM_TASK_LOCK_ROOT + "/%s";
 
   /**
-   * Task lock node under connectorType/lock/{taskPrefix}/{taskName }
+   * Task lock node under connectorType/lock/{taskPrefix}/{taskName}
    */
   private static final String DATASTREAM_TASK_LOCK = DATASTREAM_TASK_LOCK_PREFIX + "/%s";
 
@@ -283,8 +283,7 @@ public final class KeyBuilder {
   }
 
   /**
-   * Get the ZooKeeper znode for a specific datastream task's lock prefix
-   * The lock is ephemeral node and it should not be stored under task node
+   * Get the ZooKeeper znode for a specific datastream task's lock prefix.
    *
    * <pre>Example: /{cluster}/connectors/{connectorType}/lock/{task-prefix}</pre>
    * @param cluster Brooklin cluster name
@@ -299,7 +298,7 @@ public final class KeyBuilder {
   /**
    * Get the ZooKeeper znode for a specific datastream task's lock
    * The lock is persistent node and it should not be stored under task node to handle the race condition where the connector
-   * tries   to acquire the lock while the coordinator deletes the task node.
+   * tries to acquire the lock while the coordinator deletes the task node.
    *
    * <pre>Example: /{cluster}/connectors/{connectorType}/lock/{task-prefix}/{taskName}</pre>
    * @param cluster Brooklin cluster name

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -38,9 +38,7 @@ public final class KeyBuilder {
    *
    * Below keys represent the various locations under connectors for parts of
    * a DatastreamTask can be persisted.
-   */
 
-  /**
    * Task node under connectorType
    */
   private static final String CONNECTOR_DATASTREAM_TASK = CONNECTOR + "/%s";
@@ -71,9 +69,14 @@ public final class KeyBuilder {
   private static final String DATASTREAM_TASK_LOCK_ROOT = CONNECTOR + "/" + DATASTREAM_TASK_LOCK_ROOT_NAME;
 
   /**
-   * Task lock node under connectorType/lock/{taskName}
+   * Task lock node under connectorType/lock/{taskPrefix}
    */
-  private static final String DATASTREAM_TASK_LOCK = DATASTREAM_TASK_LOCK_ROOT + "/%s";
+  private static final String DATASTREAM_TASK_LOCK_PREFIX = DATASTREAM_TASK_LOCK_ROOT + "/%s";
+
+  /**
+   * Task lock node under connectorType/lock/{taskPrefix}/{task}
+   */
+  private static final String DATASTREAM_TASK_LOCK = DATASTREAM_TASK_LOCK_PREFIX + "/%s";
 
   /**
    * Base path to store partition movement info
@@ -271,22 +274,39 @@ public final class KeyBuilder {
    * <pre>Example: /{cluster}/connectors/{connectorType}/lock</pre>
    * @param cluster Brooklin cluster name
    * @param connectorType Connector
-  \   */
+   * @return datastream task lock root
+   */
   public static String datastreamTaskLockRoot(String cluster, String connectorType) {
     return String.format(DATASTREAM_TASK_LOCK_ROOT, cluster, connectorType).replaceAll("//", "/");
+  }
+
+  /**
+   * Get the ZooKeeper znode for a specific datastream task's lock prefix
+   * The lock is ephemeral node and it should not be stored under task node
+   *
+   * <pre>Example: /{cluster}/connectors/{connectorType}/lock/{task-prefix}</pre>
+   * @param cluster Brooklin cluster name
+   * @param connectorType Connector
+   * @param datastreamTaskPrefix Datastream task prefix name
+   * @return datastream task lock prefix
+   */
+  public static String datastreamTaskLockPrefix(String cluster, String connectorType, String datastreamTaskPrefix) {
+    return String.format(DATASTREAM_TASK_LOCK_PREFIX, cluster, connectorType, datastreamTaskPrefix).replaceAll("//", "/");
   }
 
   /**
    * Get the ZooKeeper znode for a specific datastream task's lock
    * The lock is ephemeral node and it should not be stored under task node
    *
-   * <pre>Example: /{cluster}/connectors/{connectorType}/lock/{taskName}</pre>
+   * <pre>Example: /{cluster}/connectors/{connectorType}/lock/{task-prefix}/{taskName}</pre>
    * @param cluster Brooklin cluster name
    * @param connectorType Connector
+   * @param datastreamTaskPrefix Datastream task prefix name
    * @param datastreamTask Datastream task name
-\   */
-  public static String datastreamTaskLock(String cluster, String connectorType, String datastreamTask) {
-    return String.format(DATASTREAM_TASK_LOCK, cluster, connectorType, datastreamTask).replaceAll("//", "/");
+   * @return datastream task lock node
+   */
+  public static String datastreamTaskLock(String cluster, String connectorType, String datastreamTaskPrefix, String datastreamTask) {
+    return String.format(DATASTREAM_TASK_LOCK, cluster, connectorType, datastreamTaskPrefix, datastreamTask).replaceAll("//", "/");
   }
 
 
@@ -295,7 +315,7 @@ public final class KeyBuilder {
    * @param cluster Brooklin cluster name
    * @param connectorType Connector
    * @param datastreamGroupName Datastream group name
-   * @return
+   * @return target assignment path
    */
   public static String getTargetAssignmentPath(String cluster, String connectorType, String datastreamGroupName) {
     return String.format(TARGET_ASSIGNMENTS, cluster, connectorType, datastreamGroupName).replaceAll("//", "/'");
@@ -305,7 +325,7 @@ public final class KeyBuilder {
    * Get all partition movement information
    * @param cluster Brooklin cluster name
    * @param connectorType Connector
-   * @return
+   * @return target assignment base
    */
   public static String getTargetAssignmentBase(String cluster, String connectorType) {
     return String.format(TARGET_ASSIGNMENT_BASE, cluster, connectorType).replaceAll("//", "/'");

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -24,6 +24,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -114,25 +115,24 @@ public class ZkAdapter {
 
   private final String _defaultTransportProviderName;
 
+  private final ZkAdapterListener _listener;
+  private final Random randomGenerator = new Random();
   private final String _zkServers;
   private final String _cluster;
   private final int _sessionTimeoutMs;
   private final int _connectionTimeoutMs;
   private final int _operationRetryTimeoutMs;
-  private ZkClient _zkclient;
+  private final long _debounceTimerMs;
 
+  private ZkClient _zkclient;
   private String _instanceName;
   private String _liveInstanceName;
   private String _hostname;
   private Set<String> _connectorTypes = new HashSet<>();
 
   private volatile boolean _isLeader = false;
-  private final ZkAdapterListener _listener;
-
   // the current znode this node is listening to
   private String _currentSubscription = null;
-
-  private final Random randomGenerator = new Random();
 
   private ZkLeaderElectionListener _leaderElectionListener = null;
   private ZkBackedTaskListProvider _assignmentList = null;
@@ -146,6 +146,12 @@ public class ZkAdapter {
   // Cache all live DatastreamTasks per instance for assignment strategy
   private Map<String, Set<DatastreamTask>> _liveTaskMap = new HashMap<>();
 
+  // cleanup orphan lock in separate thread.
+  private final ScheduledExecutorService _scheduledExecutorServiceOrphanLockCleanup = Executors.newScheduledThreadPool(1,
+      new ThreadFactoryBuilder().setDaemon(true).setNameFormat("OrphanLockCleanupScheduler-%d").build());
+  private List<String> _finalOrphanLockList = new ArrayList<>();
+  private Future<?> _orphanLockCleanupFuture = CompletableFuture.completedFuture("completed");
+
   /**
    * Constructor
    * @param zkServers ZooKeeper server address to connect to
@@ -155,15 +161,17 @@ public class ZkAdapter {
    * @param connectionTimeoutMs Connection timeout to use for the connection with the ZooKeeper server
    * @param operationRetryTimeoutMs Timeout to use for retrying failed retriable operations. A value lesser than 0 is
    *                         considered as retry forever until a connection has been reestablished.
+   * @param debounceTimerMs debounce timer to be used to delay the lock clean up.
    * @param listener ZKAdapterListener implementation to receive callbacks based on various znode changes
    */
   public ZkAdapter(String zkServers, String cluster, String defaultTransportProviderName, int sessionTimeoutMs,
-      int connectionTimeoutMs, int operationRetryTimeoutMs, ZkAdapterListener listener) {
+      int connectionTimeoutMs, int operationRetryTimeoutMs, long debounceTimerMs, ZkAdapterListener listener) {
     _zkServers = zkServers;
     _cluster = cluster;
     _sessionTimeoutMs = sessionTimeoutMs;
     _connectionTimeoutMs = connectionTimeoutMs;
     _operationRetryTimeoutMs = operationRetryTimeoutMs;
+    _debounceTimerMs = debounceTimerMs;
     _listener = listener;
     _defaultTransportProviderName = defaultTransportProviderName;
   }
@@ -179,8 +187,9 @@ public class ZkAdapter {
    */
   @VisibleForTesting
   public ZkAdapter(String zkServers, String cluster, String defaultTransportProviderName, int sessionTimeoutMs,
-      int connectionTimeoutMs, ZkAdapterListener listener) {
-    this(zkServers, cluster, defaultTransportProviderName, sessionTimeoutMs, connectionTimeoutMs, -1, listener);
+      int connectionTimeoutMs, long debounceTimerMs, ZkAdapterListener listener) {
+    this(zkServers, cluster, defaultTransportProviderName, sessionTimeoutMs, connectionTimeoutMs, -1,
+        debounceTimerMs, listener);
   }
 
   /**
@@ -259,7 +268,6 @@ public class ZkAdapter {
     LOG.info("Instance " + _instanceName + " becomes leader");
 
     _datastreamList = new ZkBackedDMSDatastreamList();
-    //_liveInstancesProvider = new ZkBackedLiveInstanceListProvider();
     _targetAssignmentProvider = new ZkTargetAssignmentProvider(_connectorTypes);
 
     // Load all existing tasks when we just become the new leader. This is needed
@@ -316,11 +324,6 @@ public class ZkAdapter {
       _datastreamList.close();
       _datastreamList = null;
     }
-
-    /*if (_liveInstancesProvider != null) {
-      _liveInstancesProvider.close();
-      _liveInstancesProvider = null;
-    }*/
 
     if (_targetAssignmentProvider != null) {
       _targetAssignmentProvider.close();
@@ -833,6 +836,14 @@ public class ZkAdapter {
     return new HashSet<>(_zkclient.getChildren(KeyBuilder.connector(_cluster, connector)));
   }
 
+  @VisibleForTesting
+  Map<String, Set<String>> getAllConnectorTaskLocks(String connector) {
+    return _zkclient.getChildren(KeyBuilder.datastreamTaskLockRoot(_cluster, connector))
+        .stream()
+        .collect(Collectors.toMap(Function.identity(),
+            x -> new HashSet<>(_zkclient.getChildren(KeyBuilder.datastreamTaskLockPrefix(_cluster, connector, x)))));
+  }
+
   /**
    * Save the error message for an instance in ZooKeeper under {@code /{cluster}/instances/{instanceName}/errors}
    */
@@ -1012,22 +1023,18 @@ public class ZkAdapter {
    * NOTE: this should be called after the valid tasks have been reassigned or become safe to discard per
    * strategy requirement.
    * This is a costly operation which involves getting all children of /cluster/connectors from Zookeeper. So,
-   * it should be called only once the leader gets
-   * elected and has finished the assignment and cleaned up dead
-   * Tasks. Ideally, we should not find anything in this check to clean up.
+   * it should be called only once the leader gets elected and has finished the assignment and cleaned up dead
+   * tasks. Ideally, we should not find anything in this check to clean up.
    * @param cleanUpOrphanTasksInConnector Boolean whether orphan tasks should be removed from zookeeper or just
    *                                      print warning logs.
+   * @return total orphan task nodes identified/cleaned.
    */
   public int cleanUpOrphanConnectorTasks(boolean cleanUpOrphanTasksInConnector) {
     if (!_isLeader) {
       return 0;
     }
 
-    Map<String, Set<DatastreamTask>> assignmentsByInstance = getAllAssignedDatastreamTasks();
-
-    Set<DatastreamTask> validTasks =
-        assignmentsByInstance.values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
-
+    Set<DatastreamTask> validTasks = getDatastreamTasks();
     List<String> allConnectors = getAllConnectors();
     int orphanCount = 0;
     for (String connector : allConnectors) {
@@ -1050,6 +1057,130 @@ public class ZkAdapter {
       orphanCount += connectorTaskList.size();
     }
     return orphanCount;
+  }
+
+  private Set<DatastreamTask> getDatastreamTasks() {
+    return getAllAssignedDatastreamTasks().values().stream().flatMap(Collection::stream).collect(Collectors.toSet());
+  }
+
+  /**
+   * Identify orphan connector task locks for which there is no corresponding connector task node present and schedule
+   * the clean up after the debounce timer. There is no way for the leader to know that the task corresponding to the
+   * lock has stopped or not. It makes sense to clear it after the debounce timer.
+   *
+   * NOTE: this should be called after the valid tasks have been reassigned or become safe to discard per
+   * strategy requirement.
+   *
+   * This is a costly operation which involves getting all children of /cluster/connectors/lock from Zookeeper. So,
+   * it should be called only once the leader get elected and has finished the assignment and cleaned up dead tasks.
+   * @param cleanUpOrphanTaskLocksInConnector Boolean whether orphan task locks should be removed from zookeeper or just
+   *                                      print warning logs.
+   * @return total orphan task locks identified/cleaned.
+   */
+  public int cleanUpOrphanConnectorTaskLocks(boolean cleanUpOrphanTaskLocksInConnector) {
+    // do not perform this operation if not a leader or another operation is going on.
+    if (!_isLeader || !_orphanLockCleanupFuture.isDone()) {
+      return 0;
+    }
+
+    Set<DatastreamTask> validTasks = getDatastreamTasks();
+    List<String> allConnectors = getAllConnectors();
+
+    int orphanCount = 0;
+    for (String connector : allConnectors) {
+      Map<String, Set<String>> locksByTaskPrefix = getAllConnectorTaskLocks(connector);
+
+      Set<String> validTaskNamesSet = validTasks.stream()
+          .filter(x -> x.getConnectorType().equals(connector))
+          .map(DatastreamTask::getDatastreamTaskName)
+          .collect(Collectors.toSet());
+
+      List<String> orphanLockList = new ArrayList<>();
+
+      locksByTaskPrefix.forEach((taskPrefix, taskList) -> {
+        // if all the task locks in the task prefix needs to be cleaned up, delete the task prefix node as well.
+        AtomicBoolean deleteTaskPrefixNode = new AtomicBoolean(true);
+        taskList.forEach(taskName -> {
+          if (!validTaskNamesSet.contains(taskName)) {
+            orphanLockList.add(KeyBuilder.datastreamTaskLock(_cluster, connector, taskPrefix, taskName));
+          } else {
+            deleteTaskPrefixNode.set(false);
+          }
+        });
+
+        if (deleteTaskPrefixNode.get()) {
+          orphanLockList.add(KeyBuilder.datastreamTaskLockPrefix(_cluster, connector, taskPrefix));
+        }
+      });
+
+      if (orphanLockList.size() > 0) {
+        LOG.warn("Found orphan task locks: {} in connector: {}", orphanLockList, connector);
+        if (cleanUpOrphanTaskLocksInConnector) {
+          _finalOrphanLockList.addAll(orphanLockList);
+        }
+        orphanCount += orphanLockList.size();
+      }
+    }
+
+    if (cleanUpOrphanTaskLocksInConnector) {
+      // waiting for the debounce time to ensure that the task thread should stop processing by then.
+      _orphanLockCleanupFuture = _scheduledExecutorServiceOrphanLockCleanup.schedule(this::cleanUpOrphanLocks,
+          _debounceTimerMs, TimeUnit.MILLISECONDS);
+    }
+    return orphanCount;
+  }
+
+  private void cleanUpOrphanLocks() {
+    _finalOrphanLockList.forEach(t -> {
+      LOG.info("Deleting task lock node {}", t);
+      _zkclient.delete(t);
+    });
+    _finalOrphanLockList.clear();
+  }
+
+  /*
+   * wait for the task lock to release and delete if the lock is owned by dead owner
+   */
+  private void waitForTaskReleaseOrForceIfOwnerIsDead(DatastreamTask task, long timeoutMs, String lockPath) {
+    boolean deadOwner = false;
+    if (_zkclient.exists(lockPath)) {
+      String owner = _zkclient.readData(lockPath, true);
+      if (owner != null && owner.equals(_instanceName)) {
+        LOG.info("{} already owns the lock on {}", _instanceName, task);
+        //release the lock.
+        return;
+      }
+
+      long waitTimeout = timeoutMs;
+      // if the timeout is greater than debounce timer, only then identify and clean the task lock.
+      if (timeoutMs >= _debounceTimerMs) {
+        // check if the owner is dead.
+        if (_liveInstancesProvider != null && !getLiveInstances().contains(owner)) {
+          LOG.info("dead owner {} found for the lock on the task {}", owner, task.getDatastreamTaskName());
+          deadOwner = true;
+        } else {
+          waitForTaskRelease(task, timeoutMs - _debounceTimerMs, lockPath);
+          if (!_zkclient.exists(lockPath)) {
+            return;
+          }
+          owner = _zkclient.readData(lockPath, true);
+          if (owner != null && _liveInstancesProvider != null && !getLiveInstances().contains(owner)) {
+            LOG.info("dead owner {} found for the lock on the task {} after waiting {} ms",
+                owner, task.getDatastreamTaskName(), timeoutMs - _debounceTimerMs);
+            deadOwner = true;
+          }
+        }
+        waitTimeout = _debounceTimerMs;
+      }
+
+      waitForTaskRelease(task, waitTimeout, lockPath);
+      if (deadOwner && _zkclient.exists(lockPath)) {
+        String tempOwner = _zkclient.readData(lockPath, true);
+        if (tempOwner != null && tempOwner.equals(owner)) {
+          _zkclient.delete(lockPath);
+        }
+      }
+    }
   }
 
   private void waitForTaskRelease(DatastreamTask task, long timeoutMs, String lockPath) {
@@ -1088,73 +1219,38 @@ public class ZkAdapter {
    * @see #releaseTask(DatastreamTaskImpl)
    */
   public void acquireTask(DatastreamTaskImpl task, Duration timeout) {
-    _zkclient.ensurePath(KeyBuilder.datastreamTaskLockRoot(_cluster, task.getConnectorType()));
-    String lockPath = KeyBuilder.datastreamTaskLock(_cluster, task.getConnectorType(), task.getDatastreamTaskName());
+    _zkclient.ensurePath(KeyBuilder.datastreamTaskLockPrefix(_cluster, task.getConnectorType(), task.getTaskPrefix()));
+    String lockPath = KeyBuilder.datastreamTaskLock(_cluster, task.getConnectorType(), task.getTaskPrefix(), task.getDatastreamTaskName());
     String owner = null;
-    boolean deadOwner = false;
     if (_zkclient.exists(lockPath)) {
-      owner = _zkclient.ensureReadData(lockPath);
-      if (owner.equals(_instanceName)) {
+      owner = _zkclient.readData(lockPath, true);
+      if (owner != null && owner.equals(_instanceName)) {
         LOG.info("{} already owns the lock on {}", _instanceName, task);
         return;
       }
 
-      Duration debounceTimer = Duration.ofSeconds(30);
-      Duration waitTimeout = debounceTimer;
-      if (_liveInstancesProvider != null && !getLiveInstances().contains(owner)) {
-        if (timeout.minus(debounceTimer).toMillis() >= 0) {
-          deadOwner = true;
-        } else {
-          waitTimeout = timeout;
-        }
-      } else {
-        if (timeout.minus(debounceTimer).toMillis() >= 0) {
-          waitForTaskRelease(task, timeout.toMillis() - debounceTimer.toMillis(), lockPath);
-          if (!_zkclient.exists(lockPath)) {
-            _zkclient.create(lockPath, _instanceName, CreateMode.PERSISTENT);
-            LOG.info("{} successfully acquired the lock on {}", _instanceName, task);
-            return;
-          }
-          owner = _zkclient.ensureReadData(lockPath);
-          if (_liveInstancesProvider != null && !getLiveInstances().contains(owner)) {
-            deadOwner = true;
-          }
-        }
-      }
-      waitForTaskRelease(task, waitTimeout.toMillis(), lockPath);
+      waitForTaskReleaseOrForceIfOwnerIsDead(task, timeout.toMillis(), lockPath);
     }
 
     if (!_zkclient.exists(lockPath)) {
       _zkclient.create(lockPath, _instanceName, CreateMode.PERSISTENT);
-      LOG.info("{} successfully acquired the lock on {}", _instanceName, task);
-    } else {
-      if (deadOwner) {
-        String tempOwner = _zkclient.ensureReadData(lockPath);
-        if (!tempOwner.equals(owner)) {
-          LOG.warn("Owner for the lock changed from dead owner: {} to {}. Not able to clear the lock. Retry again.", owner, tempOwner);
-          owner = tempOwner;
-        } else {
-          _zkclient.delete(lockPath);
-          _zkclient.create(lockPath, _instanceName, CreateMode.PERSISTENT);
-          owner = _zkclient.ensureReadData(lockPath);
-          if (owner.equals(_instanceName)) {
-            LOG.info("{} successfully acquired the lock on {} by kicking out {}", _instanceName, task, owner);
-            return;
-          }
-        }
+      owner = _zkclient.readData(lockPath, true);
+      if ((owner != null && owner.equals(_instanceName))) {
+        LOG.info("{} successfully acquired the lock on {}", _instanceName, task);
+        return;
       }
-
-      String msg = String.format("%s failed to acquire task %s in %dms, current owner: %s", _instanceName, task,
-          timeout.toMillis(), owner);
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, msg, null);
     }
+
+    String msg = String.format("%s failed to acquire task %s in %dms, current owner: %s", _instanceName, task,
+        timeout.toMillis(), owner);
+    ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, msg, null);
   }
 
   /**
    * Check if the task is currently locked
    */
-  public boolean checkIsTaskLocked(String connectorType, String taskName) {
-    String lockPath = KeyBuilder.datastreamTaskLock(_cluster, connectorType, taskName);
+  public boolean checkIsTaskLocked(String connectorType, String taskPrefix, String taskName) {
+    String lockPath = KeyBuilder.datastreamTaskLock(_cluster, connectorType, taskPrefix, taskName);
     return (_zkclient.exists(lockPath));
   }
 
@@ -1165,9 +1261,9 @@ public class ZkAdapter {
    */
   public void waitForDependencies(DatastreamTaskImpl task, Duration timeout) {
     task.getDependencies().forEach(previousTask -> {
-        String lockPath = KeyBuilder.datastreamTaskLock(_cluster, task.getConnectorType(), previousTask);
+      String lockPath = KeyBuilder.datastreamTaskLock(_cluster, task.getConnectorType(), task.getTaskPrefix(), previousTask);
       if (_zkclient.exists(lockPath)) {
-        waitForTaskRelease(task, timeout.toMillis(), lockPath);
+        waitForTaskReleaseOrForceIfOwnerIsDead(task, timeout.toMillis(), lockPath);
       }
     });
   }
@@ -1263,20 +1359,23 @@ public class ZkAdapter {
    * @see #acquireTask(DatastreamTaskImpl, Duration)
    */
   public void releaseTask(DatastreamTaskImpl task) {
-    String lockPath = KeyBuilder.datastreamTaskLock(_cluster, task.getConnectorType(), task.getDatastreamTaskName());
+    String lockPath =
+        KeyBuilder.datastreamTaskLock(_cluster, task.getConnectorType(), task.getTaskPrefix(), task.getDatastreamTaskName());
     if (!_zkclient.exists(lockPath)) {
-      LOG.info("There is no lock on {}", task);
+      LOG.info("There is no lock on {}-{}/{}", task.getConnectorType(), task.getTaskPrefix(), task.getDatastreamTaskName());
       return;
     }
 
     String owner = _zkclient.ensureReadData(lockPath);
     if (!owner.equals(_instanceName)) {
-      LOG.warn("{} does not have the lock on {}", _instanceName, task);
+      LOG.warn("{} does not have the lock on {}-{}/{}", _instanceName, task.getConnectorType(), task.getTaskPrefix(),
+          task.getDatastreamTaskName());
       return;
     }
 
     _zkclient.delete(lockPath);
-    LOG.info("{} successfully released the lock on {}", _instanceName, task);
+    LOG.info("{} successfully released the lock on {}-{}/{}", _instanceName, task.getConnectorType(), task.getTaskPrefix(),
+        task.getDatastreamTaskName());
   }
 
   private Map<String, String> getHostInstanceMap() {
@@ -1658,6 +1757,8 @@ public class ZkAdapter {
   @VisibleForTesting
   void onSessionExpired() {
     LOG.error("Zookeeper session expired.");
+    //cancel the lock clean up
+    _orphanLockCleanupFuture.cancel(true);
     onBecomeFollower();
     connect();
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -61,7 +61,7 @@ public class TestDatastreamTask {
     task.addDependency("task0");
     ZkAdapter mockZkAdapter = mock(ZkAdapter.class);
     task.setZkAdapter(mockZkAdapter);
-    when(mockZkAdapter.checkIsTaskLocked(anyString(), anyString())).thenReturn(false);
+    when(mockZkAdapter.checkIsTaskLocked(anyString(), anyString(), anyString())).thenReturn(false);
     DatastreamTaskImpl task2 = new DatastreamTaskImpl(task, new ArrayList<>());
   }
 
@@ -74,7 +74,7 @@ public class TestDatastreamTask {
     task.addDependency("task0");
     ZkAdapter mockZkAdapter = mock(ZkAdapter.class);
     task.setZkAdapter(mockZkAdapter);
-    when(mockZkAdapter.checkIsTaskLocked(anyString(), anyString())).thenReturn(true);
+    when(mockZkAdapter.checkIsTaskLocked(anyString(), anyString(), anyString())).thenReturn(true);
     DatastreamTaskImpl task2 = new DatastreamTaskImpl(task, new ArrayList<>());
     Assert.assertEquals(new HashSet<>(task2.getDependencies()), ImmutableSet.of(task.getDatastreamTaskName()));
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
@@ -230,7 +230,7 @@ public class TestStickyPartitionAssignment {
         DatastreamTaskImpl task = new DatastreamTaskImpl(datastreams.get(0).getDatastreams());
         ZkAdapter mockZkAdapter = mock(ZkAdapter.class);
         task.setZkAdapter(mockZkAdapter);
-        when(mockZkAdapter.checkIsTaskLocked(anyString(), anyString())).thenReturn(isTaskLocked);
+        when(mockZkAdapter.checkIsTaskLocked(anyString(), anyString(), anyString())).thenReturn(isTaskLocked);
         set.add(task);
       }
       assignment.put("instance" + i, set);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
@@ -39,6 +39,7 @@ public class TestZookeeperCheckpointProvider {
   private EmbeddedZookeeper _zookeeper;
 
   private final String defaultTransportProviderName = "test";
+  private static final long DEBOUNCE_TIMER_MS = 1000;
 
   @BeforeMethod
   public void setup(Method method) throws IOException {
@@ -55,7 +56,7 @@ public class TestZookeeperCheckpointProvider {
   @Test
   public void testUnassign() {
     ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster", defaultTransportProviderName, ZkClient.DEFAULT_SESSION_TIMEOUT,
-        ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
+        ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, null);
     adapter.connect();
     ZookeeperCheckpointProvider checkpointProvider = new ZookeeperCheckpointProvider(adapter);
     Datastream ds1 = generateDatastream(1);
@@ -84,7 +85,7 @@ public class TestZookeeperCheckpointProvider {
   @Test
   public void testCommitAndReadCheckpoints() {
     ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster", defaultTransportProviderName, ZkClient.DEFAULT_SESSION_TIMEOUT,
-        ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
+        ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, null);
     adapter.connect();
     ZookeeperCheckpointProvider checkpointProvider = new ZookeeperCheckpointProvider(adapter);
     DatastreamTaskImpl datastreamTask1 = new DatastreamTaskImpl(Collections.singletonList(generateDatastream(1)));

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -15,8 +15,8 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-
 import java.util.concurrent.TimeUnit;
+
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,6 +50,8 @@ import static org.mockito.Mockito.spy;
 public class TestZkAdapter {
   private static final Logger LOG = LoggerFactory.getLogger(com.linkedin.datastream.server.zk.TestZkAdapter.class);
   private static final int ZK_WAIT_IN_MS = 500;
+  private static final long ZK_DEBOUNCE_TIMER_MS = 1000;
+
 
   private final String defaultTransportProviderName = "test";
   private EmbeddedZookeeper _embeddedZookeeper;
@@ -100,7 +102,7 @@ public class TestZkAdapter {
 
   private ZkAdapter createZkAdapter(String testCluster) {
     return new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
-        ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null);
+        ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, ZK_DEBOUNCE_TIMER_MS, null);
   }
 
   @Test
@@ -133,10 +135,12 @@ public class TestZkAdapter {
     //
     // start two ZkAdapters, which is corresponding to two Coordinator instances
     //
-    ZkAdapter adapter1 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName, 1000, 15000, null);
+    ZkAdapter adapter1 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
+        1000, 15000, ZK_DEBOUNCE_TIMER_MS, null);
     adapter1.connect();
 
-    ZkAdapter adapter2 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName, 1000, 15000, null);
+    ZkAdapter adapter2 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
+        1000, 15000, ZK_DEBOUNCE_TIMER_MS, null);
     adapter2.connect();
 
     //
@@ -161,7 +165,8 @@ public class TestZkAdapter {
     //
     adapter2.disconnect();
     // now a new client goes online
-    ZkAdapter adapter3 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName, 1000, 15000, null);
+    ZkAdapter adapter3 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
+        1000, 15000, ZK_DEBOUNCE_TIMER_MS, null);
     adapter3.connect();
 
     //
@@ -322,8 +327,6 @@ public class TestZkAdapter {
     // Create all the Datastreams to be referenced by the tasks
     DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, "task1", "task2", "task3");
 
-    List<DatastreamTask> tasks = new ArrayList<>();
-
     //
     // simulate assigning:
     //   to instance1: [task1]
@@ -383,7 +386,7 @@ public class TestZkAdapter {
     DatastreamGroup datastreamGroup = new DatastreamGroup(Arrays.asList(datastreams));
 
     adapter1.connect();
-    PollUtils.poll(() -> adapter1.isLeader(), 50, 5000);
+    PollUtils.poll(adapter1::isLeader, 50, 5000);
     List<String> instances = adapter1.getLiveInstances();
     String hostName = instances.get(0).substring(0, instances.get(0).lastIndexOf('-'));
 
@@ -419,7 +422,7 @@ public class TestZkAdapter {
 
     adapter1.connect();
     adapter2.connect();
-    PollUtils.poll(() -> adapter1.isLeader(), 50, 5000);
+    PollUtils.poll(adapter1::isLeader, 50, 5000);
     PollUtils.poll(() -> !adapter2.isLeader(), 50, 5000);
 
     List<String> hostnames = ImmutableList.of("host000-000", "host001-000");
@@ -531,7 +534,7 @@ public class TestZkAdapter {
   public void testTaskAcquireRelease() {
     String testCluster = "testTaskAcquireRelease";
     String connectorType = "connectorType";
-    Duration timeout = Duration.ofMinutes(1);
+    Duration timeout = Duration.ofSeconds(1);
 
     ZkAdapter adapter1 = createZkAdapter(testCluster);
     adapter1.connect();
@@ -575,7 +578,7 @@ public class TestZkAdapter {
   public void testTaskAcquireReleaseOwnerUncleanShutdown() {
     String testCluster = "testTaskAcquireReleaseOwnerUncleanShutdown";
     String connectorType = "connectorType";
-    Duration timeout = Duration.ofMinutes(1);
+    Duration timeout = Duration.ofSeconds(10);
 
     ZkAdapter adapter1 = createZkAdapter(testCluster);
     adapter1.connect();
@@ -613,7 +616,7 @@ public class TestZkAdapter {
   public void testTaskAcquireReleaseOwnerUncleanBounce() {
     String testCluster = "testTaskAcquireReleaseOwnerUncleanBounce";
     String connectorType = "connectorType";
-    Duration timeout = Duration.ofMinutes(1);
+    Duration timeout = Duration.ofSeconds(15);
 
     ZkAdapter adapter1 = createZkAdapter(testCluster);
     adapter1.connect();
@@ -688,7 +691,7 @@ public class TestZkAdapter {
     Assert.assertTrue(expectException(() -> task2.acquire(Duration.ofMillis(100)), true));
 
     //Verify the task2 can be locked after task1 is released
-    Thread acquireThread = new Thread(() -> task2.acquire(Duration.ofSeconds(4)));
+    Thread acquireThread = new Thread(() -> task2.acquire(Duration.ofSeconds(10)));
     Thread releaseThread = new Thread(task1::release);
 
     acquireThread.start();
@@ -698,21 +701,21 @@ public class TestZkAdapter {
   }
 
   private ZkClientInterceptingAdapter createInterceptingZkAdapter(String testCluster) {
-    return createInterceptingZkAdapter(testCluster, ZkClient.DEFAULT_SESSION_TIMEOUT);
+    return createInterceptingZkAdapter(testCluster, ZkClient.DEFAULT_SESSION_TIMEOUT, (int) (ZK_DEBOUNCE_TIMER_MS * 2));
   }
 
-  private ZkClientInterceptingAdapter createInterceptingZkAdapter(String testCluster, int sessionTimeoutMs) {
+  private ZkClientInterceptingAdapter createInterceptingZkAdapter(String testCluster, int sessionTimeoutMs, long debounceTimerMs) {
     return spy(new ZkClientInterceptingAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
-        sessionTimeoutMs, ZkClient.DEFAULT_CONNECTION_TIMEOUT, null));
+        sessionTimeoutMs, ZkClient.DEFAULT_CONNECTION_TIMEOUT,  debounceTimerMs, null));
   }
 
   private static class ZkClientInterceptingAdapter extends ZkAdapter {
     private ZkClient _zkClient;
 
     public ZkClientInterceptingAdapter(String zkConnectionString, String testCluster, String defaultTransportProviderName,
-        int defaultSessionTimeoutMs, int defaultConnectionTimeoutMs, ZkAdapterListener listener) {
+        int defaultSessionTimeoutMs, int defaultConnectionTimeoutMs, long debounceTimerMs, ZkAdapterListener listener) {
       super(zkConnectionString, testCluster, defaultTransportProviderName, defaultSessionTimeoutMs,
-          defaultConnectionTimeoutMs, listener);
+          defaultConnectionTimeoutMs, debounceTimerMs, listener);
     }
 
     @Override
@@ -732,7 +735,7 @@ public class TestZkAdapter {
     String connectorType = "connectorType";
     Duration timeout = Duration.ofMinutes(1);
 
-    ZkClientInterceptingAdapter adapter = createInterceptingZkAdapter(testCluster, 5000);
+    ZkClientInterceptingAdapter adapter = createInterceptingZkAdapter(testCluster, 5000, ZK_DEBOUNCE_TIMER_MS);
     adapter.connect();
 
     DatastreamTaskImpl task = new DatastreamTaskImpl();
@@ -759,7 +762,7 @@ public class TestZkAdapter {
     //
     // start two ZkAdapters, which is corresponding to two Coordinator instances
     //
-    ZkClientInterceptingAdapter adapter1 = createInterceptingZkAdapter(testCluster, 5000);//new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName, 1000, 15000, null);
+    ZkClientInterceptingAdapter adapter1 = createInterceptingZkAdapter(testCluster, 5000, ZK_DEBOUNCE_TIMER_MS * 10);
     adapter1.connect();
 
     DatastreamTaskImpl task = new DatastreamTaskImpl();
@@ -771,32 +774,39 @@ public class TestZkAdapter {
     updateInstanceAssignment(adapter1, adapter1.getInstanceName(), tasks);
 
     LOG.info("Acquire from instance1 should succeed");
-    Duration timeout = Duration.ofSeconds(10);
+    Duration timeout = Duration.ofSeconds(3);
     Assert.assertTrue(expectException(() -> adapter1.acquireTask(task, timeout), false));
-    String owner = adapter1.getZkClient().readData(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(), task.getDatastreamTaskName()));
+    String owner = adapter1.getZkClient().readData(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(),
+        task.getTaskPrefix(), task.getDatastreamTaskName()));
 
-    ZkClientInterceptingAdapter adapter2 = createInterceptingZkAdapter(testCluster, 5000);// new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName, 1000, 15000, null);
+    ZkClientInterceptingAdapter adapter2 = createInterceptingZkAdapter(testCluster, 5000, ZK_DEBOUNCE_TIMER_MS * 10);
     adapter2.connect();
     simulateSessionExpiration(adapter1);
 
-    Thread.sleep(5000);
+    Thread.sleep(1000);
     Assert.assertTrue(expectException(() -> adapter1._zkClient.waitUntilConnected(5, TimeUnit.SECONDS), false));
 
-    adapter2.getZkClient().exists(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(), task.getDatastreamTaskName()));
+    // adapter2 not able to acquire lock
+    adapter2.getZkClient().exists(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(),
+        task.getTaskPrefix(), task.getDatastreamTaskName()));
     Assert.assertTrue(expectException(() -> adapter2.acquireTask(task, timeout), true));
 
-    adapter2.getZkClient().exists(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(), task.getDatastreamTaskName()));
-    String owner2 = adapter2.getZkClient().readData(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(), task.getDatastreamTaskName()));
+    adapter2.getZkClient().exists(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(),
+        task.getTaskPrefix(), task.getDatastreamTaskName()));
+    String owner2 = adapter2.getZkClient().readData(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(),
+        task.getTaskPrefix(), task.getDatastreamTaskName()));
     Assert.assertEquals(owner, owner2);
 
+    // adapter 2 able to acquire lock
+    Assert.assertTrue(expectException(() -> adapter2.acquireTask(task, Duration.ofSeconds(15)), false));
 
-    Assert.assertTrue(expectException(() -> adapter2.acquireTask(task, Duration.ofSeconds(30)), false));
-
-    adapter2.getZkClient().exists(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(), task.getDatastreamTaskName()));
-    owner2 = adapter2.getZkClient().readData(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(), task.getDatastreamTaskName()));
+    adapter2.getZkClient().exists(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(),
+        task.getTaskPrefix(), task.getDatastreamTaskName()));
+    owner2 = adapter2.getZkClient().readData(KeyBuilder.datastreamTaskLock(testCluster, task.getConnectorType(),
+        task.getTaskPrefix(), task.getDatastreamTaskName()));
     Assert.assertNotEquals(owner, owner2);
-
   }
+
   private void simulateSessionExpiration(ZkClientInterceptingAdapter adapter) {
     long sessionId = adapter.getSessionId();
     LOG.info("Closing/expiring session: " + sessionId);
@@ -804,7 +814,7 @@ public class TestZkAdapter {
   }
 
   @Test
-  public void testDeleteTasksWithPrefix() {
+  public void testDeleteTasksWithPrefix() throws InterruptedException {
     String testCluster = "testDeleteTaskWithPrefix";
     String connectorType = "connectorType";
 
@@ -828,6 +838,7 @@ public class TestZkAdapter {
       dsTask.setConnectorType(connectorType);
       dsTask.setZkAdapter(adapter);
       tasks.add(dsTask);
+      adapter.acquireTask(dsTask, Duration.ofSeconds(2));
     }
     updateInstanceAssignment(adapter, adapter.getInstanceName(), tasks);
     adapter.acquireTask(lockTask, Duration.ofSeconds(2));
@@ -854,7 +865,13 @@ public class TestZkAdapter {
     leftOverTasks = zkClient.getChildren(KeyBuilder.connector(testCluster, connectorType));
     Assert.assertEquals(leftOverTasks.size(), 3);
 
-    adapter.cleanUpOrphanConnectorTasks(true);
+    //Verify orphan locks, lockTask is the only orphan task.
+    // expected 1 * 2, because its the only node, it needs to delete the prefix node as well.
+    Assert.assertEquals(adapter.cleanUpOrphanConnectorTaskLocks(false), 1 * 2);
+    Map<String, Set<String>> taskLocks = adapter.getAllConnectorTaskLocks(connectorType);
+    Assert.assertEquals(taskLocks.size(), 11);
+    Assert.assertEquals(taskLocks.get("taskPrefix0").size(), 1);
+    Assert.assertEquals(taskLocks.get("taskPrefixlock").size(), 1);
 
     leftOverTasks = zkClient.getChildren(KeyBuilder.connector(testCluster, connectorType));
     Assert.assertEquals(leftOverTasks.size(), 3);
@@ -870,6 +887,16 @@ public class TestZkAdapter {
     Assert.assertEquals(leftOverTasks.size(), 3);
 
     adapter.cleanUpOrphanConnectorTasks(true);
+    Assert.assertEquals(adapter.cleanUpOrphanConnectorTaskLocks(true), 11 * 2);
+    taskLocks = adapter.getAllConnectorTaskLocks(connectorType);
+    Assert.assertEquals(taskLocks.size(), 11);
+    Assert.assertEquals(taskLocks.get("taskPrefix0").size(), 1);
+    Assert.assertEquals(taskLocks.get("taskPrefixlock").size(), 1);
+
+    //Thread sleep to wait for debounce timer orphan lock cleanup.
+    Thread.sleep(5000);
+    taskLocks = adapter.getAllConnectorTaskLocks(connectorType);
+    Assert.assertEquals(taskLocks.size(), 0);
 
     leftOverTasks = zkClient.getChildren(KeyBuilder.connector(testCluster, connectorType));
     Assert.assertEquals(leftOverTasks.size(), 1);


### PR DESCRIPTION
During zookeeper session expiry, the ephemeral nodes gets automatically deleted by the  zookeeper server. Task locks currently creates ephemeral nodes which allows only one brooklin instance to process the task. Another instance will have to wait to acquire the lock. The lock is important for the connectors which have to manage their own synchronization like partition managed Kafka mirror maker connector which does not rely on kafka for partition management. So, if the lock gets deleted because of session expiry, the current owner will take some time to identify the session expiry scenario and stop all the tasks, but the new task owner will not be aware whether current owner has stopped or not and will immediately get the lock (since ephemeral lock node on zk is already deleted.). To avoid that, we are making the task locks persistent and will let the anyone trying to acquire the lock, force release the lock if it is owned by the dead owner (not part of the cluster) after the configurable debounce timer. The coordinator of the instance which had zk session expiry will be responsible to bring down all the tasks within the debounce timer. 

Making the debounce timer configurable to ensure that we can setup a longer timeout value, in case required in future.
