### PR TITLE
Shut down Kafka producer on flush TimeoutException

### DIFF
--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
@@ -300,9 +300,9 @@ class KafkaProducerWrapper<K, V> {
         if (_kafkaProducer != null) {
           _kafkaProducer.flush(_producerFlushTimeoutMs, TimeUnit.MILLISECONDS);
         }
-      } catch (InterruptException e) {
+      } catch (InterruptException | TimeoutException e) {
         // The KafkaProducer object should not be reused on an interrupted flush
-        _log.warn("Kafka producer flush interrupted, closing producer {}.", _kafkaProducer);
+        _log.warn("Kafka producer flush interrupted/timed out, closing producer {}.", _kafkaProducer);
         shutdownProducer();
         throw e;
       }


### PR DESCRIPTION
When flush() times out, it continues to try processing the outstanding sends. We should close and reset the producer on flush() timeout so that we don't keep timing out on task restart for non-recoverable issues such as deleted topics (where we have seen flush get stuck in the past), and also clear out the outstanding sends.