### PR TITLE
Add a PollDurationMs metric to AbstractKafkaBasedConnectorTask

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -106,7 +106,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected final boolean _pausePartitionOnError;
   protected final Duration _pauseErrorPartitionDuration;
   protected final long _processingDelayLogThresholdMillis;
-  protected final boolean _enablePollDurationMsMetric;
+  protected final boolean _enablePollDurationMillisMetric;
   protected final Optional<Map<Integer, Long>> _startOffsets;
 
   protected volatile String _taskName;
@@ -170,7 +170,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _maxRetryCount = config.getRetryCount();
     _pausePartitionOnError = config.getPausePartitionOnError();
     _pauseErrorPartitionDuration = config.getPauseErrorPartitionDuration();
-    _enablePollDurationMsMetric = config.getEnablePollDurationMsMetric();
+    _enablePollDurationMillisMetric = config.getEnablePollDurationMillisMetric();
     _startOffsets = Optional.ofNullable(_datastream.getMetadata().get(DatastreamMetadataConstants.START_POSITION))
         .map(json -> JsonUtils.fromJson(json, new TypeReference<Map<Integer, Long>>() {
         }));
@@ -489,7 +489,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       }
       _consumerMetrics.updateNumPolls(1);
       _consumerMetrics.updateEventCountsPerPoll(records.count());
-      if (_enablePollDurationMsMetric) {
+      if (_enablePollDurationMillisMetric) {
         _dynamicMetricsManager.createOrUpdateHistogram(_metricsPrefix, _datastreamName, POLL_DURATION_MS,
             pollDurationMillis);
       }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -52,9 +52,7 @@ import com.linkedin.datastream.common.JsonUtils;
 import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.connectors.CommonConnectorMetrics;
 import com.linkedin.datastream.kafka.KafkaDatastreamMetadataConstants;
-import com.linkedin.datastream.metrics.BrooklinHistogramInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
-import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.server.DatastreamEventProducer;
 import com.linkedin.datastream.server.DatastreamProducerRecord;
 import com.linkedin.datastream.server.DatastreamTask;
@@ -76,8 +74,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG_LATEST = "latest";
   public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG_EARLIEST = "earliest";
-
-  private static final String POLL_DURATION_MS = "pollDurationMs";
 
   protected long _lastCommittedTime = System.currentTimeMillis();
   protected int _eventsProcessedCount = 0;
@@ -113,9 +109,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected final DatastreamEventProducer _producer;
   protected Consumer<?, ?> _consumer;
   protected final Set<TopicPartition> _consumerAssignment = new HashSet<>();
-
-  protected final String _metricsPrefix;
-  protected final DynamicMetricsManager _dynamicMetricsManager;
 
   // TopicPartitions which have seen exceptions on send. Access to this map must be synchronized.
   // A ConcurrentHashMap is not used here due to the need for having more than one operation performed together as an
@@ -178,9 +171,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _pollTimeoutMillis = config.getPollTimeoutMillis();
     _retrySleepDuration = config.getRetrySleepDuration();
     _commitTimeout = config.getCommitTimeout();
-    _metricsPrefix = metricsPrefix;
-    _consumerMetrics = createKafkaBasedConnectorTaskMetrics(_metricsPrefix, _datastreamName, _logger);
-    _dynamicMetricsManager = DynamicMetricsManager.getInstance();
+    _consumerMetrics = createKafkaBasedConnectorTaskMetrics(metricsPrefix, _datastreamName, _logger,
+        _enablePollDurationMillisMetric);
 
     _pollAttempts = new AtomicInteger();
     _groupIdConstructor = groupIdConstructor;
@@ -194,8 +186,13 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   protected KafkaBasedConnectorTaskMetrics createKafkaBasedConnectorTaskMetrics(String metricsPrefix, String key,
       Logger errorLogger) {
+    return createKafkaBasedConnectorTaskMetrics(metricsPrefix, key, errorLogger, false);
+  }
+
+  protected KafkaBasedConnectorTaskMetrics createKafkaBasedConnectorTaskMetrics(String metricsPrefix, String key,
+      Logger errorLogger, boolean enablePollDurationMillisMetric) {
     KafkaBasedConnectorTaskMetrics consumerMetrics =
-        new KafkaBasedConnectorTaskMetrics(metricsPrefix, key, errorLogger);
+        new KafkaBasedConnectorTaskMetrics(metricsPrefix, key, errorLogger, enablePollDurationMillisMetric);
     consumerMetrics.createEventProcessingMetrics();
     consumerMetrics.createPollMetrics();
     consumerMetrics.createPartitionMetrics();
@@ -490,8 +487,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       _consumerMetrics.updateNumPolls(1);
       _consumerMetrics.updateEventCountsPerPoll(records.count());
       if (_enablePollDurationMillisMetric) {
-        _dynamicMetricsManager.createOrUpdateHistogram(_metricsPrefix, _datastreamName, POLL_DURATION_MS,
-            pollDurationMillis);
+        _consumerMetrics.updatePollDurationMs(pollDurationMillis);
       }
       if (!records.isEmpty()) {
         _consumerMetrics.updateEventsProcessedRate(records.count());
@@ -942,7 +938,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     metrics.addAll(KafkaBasedConnectorTaskMetrics.getEventPollMetrics(prefix));
     metrics.addAll(KafkaBasedConnectorTaskMetrics.getPartitionSpecificMetrics(prefix));
     metrics.addAll(KafkaBasedConnectorTaskMetrics.getKafkaBasedConnectorTaskSpecificMetrics(prefix));
-    metrics.add(new BrooklinHistogramInfo(prefix + POLL_DURATION_MS));
     return metrics;
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -31,7 +31,7 @@ public class KafkaBasedConnectorConfig {
   public static final String CONFIG_RETRY_SLEEP_DURATION_MILLIS = "retrySleepDurationMs";
   public static final String CONFIG_PAUSE_PARTITION_ON_ERROR = "pausePartitionOnError";
   public static final String CONFIG_PAUSE_ERROR_PARTITION_DURATION_MILLIS = "pauseErrorPartitionDurationMs";
-  public static final String CONFIG_ENABLE_POLL_DURATION_MS_METRIC = "enablePollDurationMsMetric";
+  public static final String CONFIG_ENABLE_POLL_DURATION_MILLIS_METRIC = "enablePollDurationMsMetric";
   public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
   public static final String NON_GOOD_STATE_THRESHOLD_MILLIS = "nonGoodStateThresholdMs";
   public static final String PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = "processingDelayLogThreshold";
@@ -47,7 +47,7 @@ public class KafkaBasedConnectorConfig {
   private static final int DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS = 300;
   private static final long DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = Duration.ofMinutes(1).toMillis();
   private static final long DEFAULT_COMMIT_TIMEOUT_MILLIS = Duration.ofSeconds(30).toMillis();
-  private static final boolean DEFAULT_ENABLE_POLL_DURATION_MS_METRIC = Boolean.TRUE;
+  private static final boolean DEFAULT_ENABLE_POLL_DURATION_MILLIS_METRIC = Boolean.TRUE;
 
   private final Properties _consumerProps;
   private final VerifiableProperties _connectorProps;
@@ -63,7 +63,7 @@ public class KafkaBasedConnectorConfig {
   private final boolean _pausePartitionOnError;
   private final Duration _pauseErrorPartitionDuration;
   private final long _processingDelayLogThresholdMillis;
-  private final boolean _enablePollDurationMsMetric;
+  private final boolean _enablePollDurationMillisMetric;
 
   private final int _daemonThreadIntervalSeconds;
   private final long _nonGoodStateThresholdMillis;
@@ -101,8 +101,8 @@ public class KafkaBasedConnectorConfig {
     _processingDelayLogThresholdMillis =
         verifiableProperties.getLong(PROCESSING_DELAY_LOG_THRESHOLD_MILLIS,
             DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS);
-    _enablePollDurationMsMetric = verifiableProperties.getBoolean(CONFIG_ENABLE_POLL_DURATION_MS_METRIC,
-        DEFAULT_ENABLE_POLL_DURATION_MS_METRIC);
+    _enablePollDurationMillisMetric = verifiableProperties.getBoolean(CONFIG_ENABLE_POLL_DURATION_MILLIS_METRIC,
+        DEFAULT_ENABLE_POLL_DURATION_MILLIS_METRIC);
     _enablePartitionAssignment = verifiableProperties.getBoolean(ENABLE_PARTITION_ASSIGNMENT, Boolean.FALSE);
 
     String factory =
@@ -152,8 +152,8 @@ public class KafkaBasedConnectorConfig {
     return _pauseErrorPartitionDuration;
   }
 
-  public boolean getEnablePollDurationMsMetric() {
-    return _enablePollDurationMsMetric;
+  public boolean getEnablePollDurationMillisMetric() {
+    return _enablePollDurationMillisMetric;
   }
 
   /**

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -31,6 +31,7 @@ public class KafkaBasedConnectorConfig {
   public static final String CONFIG_RETRY_SLEEP_DURATION_MILLIS = "retrySleepDurationMs";
   public static final String CONFIG_PAUSE_PARTITION_ON_ERROR = "pausePartitionOnError";
   public static final String CONFIG_PAUSE_ERROR_PARTITION_DURATION_MILLIS = "pauseErrorPartitionDurationMs";
+  public static final String CONFIG_ENABLE_POLL_DURATION_MS_METRIC = "enablePollDurationMsMetric";
   public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
   public static final String NON_GOOD_STATE_THRESHOLD_MILLIS = "nonGoodStateThresholdMs";
   public static final String PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = "processingDelayLogThreshold";
@@ -46,6 +47,7 @@ public class KafkaBasedConnectorConfig {
   private static final int DEFAULT_DAEMON_THREAD_INTERVAL_SECONDS = 300;
   private static final long DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = Duration.ofMinutes(1).toMillis();
   private static final long DEFAULT_COMMIT_TIMEOUT_MILLIS = Duration.ofSeconds(30).toMillis();
+  private static final boolean DEFAULT_ENABLE_POLL_DURATION_MS_METRIC = Boolean.TRUE;
 
   private final Properties _consumerProps;
   private final VerifiableProperties _connectorProps;
@@ -61,6 +63,7 @@ public class KafkaBasedConnectorConfig {
   private final boolean _pausePartitionOnError;
   private final Duration _pauseErrorPartitionDuration;
   private final long _processingDelayLogThresholdMillis;
+  private final boolean _enablePollDurationMsMetric;
 
   private final int _daemonThreadIntervalSeconds;
   private final long _nonGoodStateThresholdMillis;
@@ -98,6 +101,8 @@ public class KafkaBasedConnectorConfig {
     _processingDelayLogThresholdMillis =
         verifiableProperties.getLong(PROCESSING_DELAY_LOG_THRESHOLD_MILLIS,
             DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS);
+    _enablePollDurationMsMetric = verifiableProperties.getBoolean(CONFIG_ENABLE_POLL_DURATION_MS_METRIC,
+        DEFAULT_ENABLE_POLL_DURATION_MS_METRIC);
     _enablePartitionAssignment = verifiableProperties.getBoolean(ENABLE_PARTITION_ASSIGNMENT, Boolean.FALSE);
 
     String factory =
@@ -145,6 +150,10 @@ public class KafkaBasedConnectorConfig {
 
   public Duration getPauseErrorPartitionDuration() {
     return _pauseErrorPartitionDuration;
+  }
+
+  public boolean getEnablePollDurationMsMetric() {
+    return _enablePollDurationMsMetric;
   }
 
   /**

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
@@ -56,8 +56,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
   private final AtomicLong _numAutoPausedPartitionsAwaitingDestTopic = new AtomicLong(0);
   private final AtomicLong _numTopics = new AtomicLong(0);
 
-  private final boolean _enablePollDurationMillisMetric;
-  private final Histogram _pollDurationMs;
+  private final Histogram _pollDurationMsMetric;
 
   KafkaBasedConnectorTaskMetrics(String className, String metricsKey, Logger errorLogger,
       boolean enablePollDurationMillisMetric) {
@@ -72,8 +71,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
         _numAutoPausedPartitionsAwaitingDestTopic::get);
     DYNAMIC_METRICS_MANAGER.registerGauge(_className, _key, NUM_TOPICS, _numTopics::get);
 
-    _enablePollDurationMillisMetric = enablePollDurationMillisMetric;
-    _pollDurationMs = _enablePollDurationMillisMetric ?
+    _pollDurationMsMetric = enablePollDurationMillisMetric ?
         DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, POLL_DURATION_MS, Histogram.class) : null;
 
     AtomicLong aggNumConfigPausedPartitions =
@@ -112,7 +110,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, NUM_AUTO_PAUSED_PARTITIONS_WAITING_FOR_DEST_TOPIC);
     DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, NUM_TOPICS);
 
-    if (_enablePollDurationMillisMetric) {
+    if (_pollDurationMsMetric != null) {
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, POLL_DURATION_MS);
     }
   }
@@ -182,8 +180,8 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
    * @param val Value to update
    */
   public void updatePollDurationMs(long val) {
-    if (_pollDurationMs != null) {
-      _pollDurationMs.update(val);
+    if (_pollDurationMsMetric != null) {
+      _pollDurationMsMetric.update(val);
     }
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -53,7 +53,6 @@ import com.linkedin.datastream.metrics.BrooklinCounterInfo;
 import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
 import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
-import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.metrics.MetricsAware;
 import com.linkedin.datastream.server.DatastreamProducerRecord;
 import com.linkedin.datastream.server.DatastreamProducerRecordBuilder;
@@ -104,7 +103,6 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   public static final String DOMAIN_TOPIC_MANAGER = "topicManager";
   public static final String TOPIC_MANAGER_METRICS_PREFIX = "TopicManager";
 
-  protected final DynamicMetricsManager _dynamicMetricsManager;
   protected final String _connectorName;
 
   private final KafkaConsumerFactory<?, ?> _consumerFactory;
@@ -147,7 +145,6 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     _enablePartitionAssignment = config.getEnablePartitionAssignment();
     _destinationTopicPrefix = task.getDatastreams().get(0).getMetadata()
         .getOrDefault(DatastreamMetadataConstants.DESTINATION_TOPIC_PREFIX, DEFAULT_DESTINATION_TOPIC_PREFIX);
-    _dynamicMetricsManager = DynamicMetricsManager.getInstance();
 
     if (_enablePartitionAssignment) {
       LOG.info("Enable Brooklin partition assignment");

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -53,6 +53,7 @@ import com.linkedin.datastream.metrics.BrooklinCounterInfo;
 import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
 import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.metrics.MetricsAware;
 import com.linkedin.datastream.server.DatastreamProducerRecord;
 import com.linkedin.datastream.server.DatastreamProducerRecordBuilder;
@@ -103,6 +104,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   public static final String DOMAIN_TOPIC_MANAGER = "topicManager";
   public static final String TOPIC_MANAGER_METRICS_PREFIX = "TopicManager";
 
+  protected final DynamicMetricsManager _dynamicMetricsManager;
   protected final String _connectorName;
 
   private final KafkaConsumerFactory<?, ?> _consumerFactory;
@@ -145,6 +147,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     _enablePartitionAssignment = config.getEnablePartitionAssignment();
     _destinationTopicPrefix = task.getDatastreams().get(0).getMetadata()
         .getOrDefault(DatastreamMetadataConstants.DESTINATION_TOPIC_PREFIX, DEFAULT_DESTINATION_TOPIC_PREFIX);
+    _dynamicMetricsManager = DynamicMetricsManager.getInstance();
 
     if (_enablePartitionAssignment) {
       LOG.info("Enable Brooklin partition assignment");

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaBasedConnectorTaskMetrics.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaBasedConnectorTaskMetrics.java
@@ -45,9 +45,9 @@ public class TestKafkaBasedConnectorTaskMetrics {
   @Test
   public void testConnectorPollMetrics() {
     KafkaBasedConnectorTaskMetrics connectorConsumer1 =
-        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER1_NAME, LOG);
+        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER1_NAME, LOG, true);
     KafkaBasedConnectorTaskMetrics connectorConsumer2 =
-        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER2_NAME, LOG);
+        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER2_NAME, LOG, true);
 
     connectorConsumer1.createPollMetrics();
     connectorConsumer2.createPollMetrics();
@@ -55,6 +55,7 @@ public class TestKafkaBasedConnectorTaskMetrics {
     connectorConsumer1.updateNumPolls(5);
     connectorConsumer1.updateEventCountsPerPoll(10);
     connectorConsumer1.updateEventCountsPerPoll(40);
+    connectorConsumer1.updatePollDurationMs(50000);
     connectorConsumer2.updateNumConfigPausedPartitions(15);
     connectorConsumer2.updateNumAutoPausedPartitionsOnInFlightMessages(25);
     connectorConsumer2.updateNumAutoPausedPartitionsOnError(35);
@@ -65,6 +66,8 @@ public class TestKafkaBasedConnectorTaskMetrics {
         + KafkaBasedConnectorTaskMetrics.NUM_AUTO_PAUSED_PARTITIONS_ON_ERROR)).getValue(), 0);
     Assert.assertEquals((long) ((Gauge) _metricsManager.getMetric(CLASS_NAME + DELIMITED_CONSUMER1_NAME
         + KafkaBasedConnectorTaskMetrics.NUM_AUTO_PAUSED_PARTITIONS_ON_INFLIGHT_MESSAGES)).getValue(), 0);
+    Assert.assertEquals(((Histogram) _metricsManager.getMetric(CLASS_NAME + DELIMITED_CONSUMER1_NAME
+        + KafkaBasedConnectorTaskMetrics.POLL_DURATION_MS)).getCount(), 1);
 
     Assert.assertEquals(
         ((Meter) _metricsManager.getMetric(CLASS_NAME + DELIMITED_CONSUMER1_NAME + "numPolls")).getCount(), 5);
@@ -84,9 +87,9 @@ public class TestKafkaBasedConnectorTaskMetrics {
   @Test
   public void testConnectorPartitionMetrics() {
     KafkaBasedConnectorTaskMetrics connectorConsumer1 =
-        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER1_NAME, LOG);
+        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER1_NAME, LOG, false);
     KafkaBasedConnectorTaskMetrics connectorConsumer2 =
-        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER2_NAME, LOG);
+        new KafkaBasedConnectorTaskMetrics(CLASS_NAME, CONSUMER2_NAME, LOG, false);
 
     connectorConsumer1.createPartitionMetrics();
     connectorConsumer2.createPartitionMetrics();

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -117,7 +117,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
 
     DatastreamTaskImpl task = new DatastreamTaskImpl(Arrays.asList(datastream1, datastream2));
     KafkaBasedConnectorTaskMetrics consumerMetrics =
-        new KafkaBasedConnectorTaskMetrics(TestKafkaConnectorTask.class.getName(), "testConsumer", LOG);
+        new KafkaBasedConnectorTaskMetrics(TestKafkaConnectorTask.class.getName(), "testConsumer", LOG, true);
     consumerMetrics.createEventProcessingMetrics();
 
     String defaultGrpId =

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -135,6 +135,15 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     validateTaskConsumerAssignment(connectorTask,
         Sets.newHashSet(new TopicPartition(yummyTopic, 0), new TopicPartition(saltyTopic, 0)));
 
+    // Verify that metrics created through DynamicMetricsManager match those returned by getMetricInfos() given the
+    // connector name of interest.
+    MetricsTestUtils.verifyMetrics(new MetricsAware() {
+      @Override
+      public List<BrooklinMetricInfo> getMetricInfos() {
+        return KafkaMirrorMakerConnectorTask.getMetricInfos("");
+      }
+    }, DynamicMetricsManager.getInstance());
+
     connectorTask.stop();
     Assert.assertTrue(connectorTask.awaitStop(CONNECTOR_AWAIT_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS),
         "did not shut down on time");


### PR DESCRIPTION
Adding a PollDurationMs metric to track how long KafkaConsumer poll() blocks for Kafka based connectors. This can be disabled via a config.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
