### PR TITLE
Improvements to reducer for Topic Partitions diagnostics

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -5,7 +5,9 @@
  */
 package com.linkedin.datastream.connectors.kafka;
 
+import java.net.InetAddress;
 import java.net.URI;
+import java.net.UnknownHostException;
 import java.nio.charset.Charset;
 import java.time.Duration;
 import java.time.OffsetDateTime;
@@ -477,8 +479,16 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
         datastreams.forEach(datastream -> datastreamNames.add(datastream.getName()));
 
         KafkaTopicPartitionTracker tracker = connectorTaskEntry.getConnectorTask().getKafkaTopicPartitionTracker();
+
+        String hostname = null;
+        try {
+          hostname = InetAddress.getLocalHost().getHostName();
+        } catch (UnknownHostException ex) {
+          _logger.warn("Hostname not found");
+        }
+
         KafkaTopicPartitionStatsResponse response = new KafkaTopicPartitionStatsResponse(tracker.getConsumerGroupId(),
-          tracker.getTopicPartitions(), datastreamNames);
+                hostname, tracker.getTopicPartitions(), datastreamNames);
         serializedResponses.add(response);
       });
     }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -142,7 +142,8 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
       eventsSourceTimestamp = fromKafka.timestamp();
     }
 
-    BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null, metadata);
+    BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null,
+        fromKafka.headers(), metadata);
     DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();
     builder.addEvent(envelope);
     builder.setEventsSourceTimestamp(eventsSourceTimestamp);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaTopicPartitionStatsResponse.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaTopicPartitionStatsResponse.java
@@ -19,6 +19,8 @@ import org.codehaus.jackson.annotate.JsonProperty;
  */
 public class KafkaTopicPartitionStatsResponse {
 
+  private final String _sourceInstance;
+
   private final String _consumerGroupId;
 
   private final Map<String, Set<Integer>> _topicPartitions;
@@ -32,6 +34,7 @@ public class KafkaTopicPartitionStatsResponse {
     _consumerGroupId = consumerGroupId;
     _topicPartitions = new HashMap<>();
     _datastreams = new HashSet<>();
+    _sourceInstance = null;
   }
 
   /**
@@ -41,15 +44,21 @@ public class KafkaTopicPartitionStatsResponse {
    */
   @JsonCreator
   public KafkaTopicPartitionStatsResponse(@JsonProperty("consumerGroupId") String consumerGroupId,
+      @JsonProperty("sourceInstance") String sourceInstance,
       @JsonProperty("topicPartitions") Map<String, Set<Integer>> topicPartitions,
       @JsonProperty("datastreams") Set<String> datastreams) {
     _consumerGroupId = consumerGroupId;
+    _sourceInstance = sourceInstance;
     _topicPartitions = topicPartitions;
     _datastreams = datastreams;
   }
 
   public String getConsumerGroupId() {
     return _consumerGroupId;
+  }
+
+  public String getSourceInstance() {
+    return _sourceInstance;
   }
 
   public Map<String, Set<Integer>> getTopicPartitions() {

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaTopicPartitionStats.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaTopicPartitionStats.java
@@ -116,26 +116,26 @@ public class TestKafkaTopicPartitionStats extends BaseKafkaZkTest {
     // build instance 1 results
     List<KafkaTopicPartitionStatsResponse> responseList1 = new ArrayList<>();
     responseList1.add(
-        new KafkaTopicPartitionStatsResponse(consumerGroup1, Collections.singletonMap(topic3, Collections.singleton(0)),
-            Collections.singleton("test1Stream")));
+        new KafkaTopicPartitionStatsResponse(consumerGroup1, instance1, Collections.singletonMap(topic3,
+                Collections.singleton(0)), Collections.singleton("test1Stream")));
     responseList1.add(
-        new KafkaTopicPartitionStatsResponse(consumerGroup1, Collections.singletonMap(topic3, Collections.singleton(2)),
-            Collections.singleton("test1Stream")));
+        new KafkaTopicPartitionStatsResponse(consumerGroup1, instance1, Collections.singletonMap(topic3,
+                Collections.singleton(2)), Collections.singleton("test1Stream")));
     responseList1.add(
-        new KafkaTopicPartitionStatsResponse(consumerGroup2, Collections.singletonMap(topic4, Collections.singleton(1)),
-            Collections.singleton("test2Stream")));
+        new KafkaTopicPartitionStatsResponse(consumerGroup2, instance1, Collections.singletonMap(topic4,
+                Collections.singleton(1)), Collections.singleton("test2Stream")));
 
     // build instance 2 results
     List<KafkaTopicPartitionStatsResponse> responseList2 = new ArrayList<>();
     responseList2.add(
-        new KafkaTopicPartitionStatsResponse(consumerGroup2, Collections.singletonMap(topic4, Collections.singleton(0)),
-            Collections.singleton("test2Stream")));
+        new KafkaTopicPartitionStatsResponse(consumerGroup2, instance2, Collections.singletonMap(topic4,
+                Collections.singleton(0)), Collections.singleton("test2Stream")));
     responseList2.add(
-        new KafkaTopicPartitionStatsResponse(consumerGroup2, Collections.singletonMap(topic4, Collections.singleton(2)),
-            Collections.singleton("test2Stream")));
+        new KafkaTopicPartitionStatsResponse(consumerGroup2, instance2, Collections.singletonMap(topic4,
+                Collections.singleton(2)), Collections.singleton("test2Stream")));
     responseList2.add(
-        new KafkaTopicPartitionStatsResponse(consumerGroup1, Collections.singletonMap(topic3, Collections.singleton(1)),
-            Collections.singleton("test1Stream")));
+        new KafkaTopicPartitionStatsResponse(consumerGroup1, instance2, Collections.singletonMap(topic3,
+                Collections.singleton(1)), Collections.singleton("test1Stream")));
 
     Map<String, String> responseMap = new HashMap<>();
     responseMap.put(instance1, JsonUtils.toJson(responseList1));
@@ -145,10 +145,11 @@ public class TestKafkaTopicPartitionStats extends BaseKafkaZkTest {
     List<KafkaTopicPartitionStatsResponse> responseList =
         JsonUtils.fromJson(json, new TypeReference<List<KafkaTopicPartitionStatsResponse>>() {
         });
-    Assert.assertEquals(responseList.size(), 2, "Should have received info from 2 instances");
+    Assert.assertEquals(responseList.size(), 6, "Should have received flattened list with 6 responses");
 
     responseList.forEach(response -> {
       Assert.assertNotNull(response.getTopicPartitions());
+      Assert.assertNotNull(response.getSourceInstance());
       if (response.getTopicPartitions().containsKey(topic3)) {
         response.getTopicPartitions().get(topic3).removeAll(ImmutableSet.of(0, 1, 2));
         Assert.assertTrue(response.getTopicPartitions().get(topic3).isEmpty());


### PR DESCRIPTION
Reducer for topic partitions diagnostics endpoint doesn't retain the information about hosts processing each topic partition. This pull request addresses that by changing the logic that merges partition lists in reducer code, as well as by adding a field for `sourceInstance` in `KafkaTopicPartitionStatsResponse.`

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
