### PR TITLE
Remove stale createKafkaBasedConnectorTaskMetrics() overload

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -185,11 +185,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   }
 
   protected KafkaBasedConnectorTaskMetrics createKafkaBasedConnectorTaskMetrics(String metricsPrefix, String key,
-      Logger errorLogger) {
-    return createKafkaBasedConnectorTaskMetrics(metricsPrefix, key, errorLogger, false);
-  }
-
-  protected KafkaBasedConnectorTaskMetrics createKafkaBasedConnectorTaskMetrics(String metricsPrefix, String key,
       Logger errorLogger, boolean enablePollDurationMillisMetric) {
     KafkaBasedConnectorTaskMetrics consumerMetrics =
         new KafkaBasedConnectorTaskMetrics(metricsPrefix, key, errorLogger, enablePollDurationMillisMetric);


### PR DESCRIPTION
Remove stale `createKafkaBasedConnectorTaskMetrics()` overload since it is
no longer invoked, rendering overriding impls in subtypes broken.