### PR TITLE
Move stopped latch countdown to after the post shutdown hook

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -398,7 +398,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       _datastreamTask.setStatus(DatastreamTaskStatus.error(e.toString() + ExceptionUtils.getFullStackTrace(e)));
       throw new DatastreamRuntimeException(e);
     } finally {
-      _stoppedLatch.countDown();
       if (null != _consumer) {
         try {
           _consumer.close();
@@ -407,6 +406,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         }
       }
       postShutdownHook();
+      _stoppedLatch.countDown();
       _logger.info("{} stopped", _taskName);
     }
   }


### PR DESCRIPTION
Move stopped latch countdown to after the post shutdown hook so that we don't miss the interrupt signal when the task is interrupted.
We saw a case where a task got stuck in while trying to release the lock due to losing connection with Zookeeper. An hour  later, the task was able to connect to Zookeeper. This task missed the interrupt signal since the stopped countdown latch had already been downed.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
