### PR TITLE
Add sourcePartition to the record metadata. EventProducer should track high latency TopicPartitions via source partition

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
@@ -36,4 +36,7 @@ public class BrooklinEnvelopeMetadataConstants {
 
   // Timestamp of the event when it was written in the last leg (i.e. the Source of the connector)
   public static final String SOURCE_TIMESTAMP = "SourceTimestamp";
+
+  // Source partition number from where the event was generated
+  public static final String SOURCE_PARTITION = "SourcePartition";
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorTask.java
@@ -141,6 +141,7 @@ public class KafkaConnectorTask extends AbstractKafkaBasedConnectorTask {
       metadata.put(BrooklinEnvelopeMetadataConstants.EVENT_TIMESTAMP, String.valueOf(readTime.toEpochMilli()));
       eventsSourceTimestamp = fromKafka.timestamp();
     }
+    metadata.put(BrooklinEnvelopeMetadataConstants.SOURCE_PARTITION, partitionStr);
 
     BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null,
         fromKafka.headers(), metadata);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -241,6 +241,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     String offsetStr = String.valueOf(offset);
     metadata.put(KAFKA_ORIGIN_OFFSET, offsetStr);
     metadata.put(BrooklinEnvelopeMetadataConstants.EVENT_TIMESTAMP, String.valueOf(eventsSourceTimestamp));
+    metadata.put(BrooklinEnvelopeMetadataConstants.SOURCE_PARTITION, partitionStr);
     BrooklinEnvelope envelope = new BrooklinEnvelope(fromKafka.key(), fromKafka.value(), null,
         fromKafka.headers(), metadata);
     DatastreamProducerRecordBuilder builder = new DatastreamProducerRecordBuilder();

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
@@ -14,9 +14,10 @@ public class DatastreamRecordMetadata {
   private final int _partition;
   private final String _checkpoint;
   private final int _eventIndex;
+  private final int _sourcePartition;
 
   /**
-   * Construct an instance of DatastreamRecordMetadata. Defaults the event index to 0.
+   * Construct an instance of DatastreamRecordMetadata. Defaults the event index to 0 and source partition to -1.
    * @param  checkpoint checkpoint string
    * @param topic Kafka topic name
    * @param partition Kafka topic partition
@@ -26,6 +27,7 @@ public class DatastreamRecordMetadata {
     _topic = topic;
     _partition = partition;
     _eventIndex = 0;
+    _sourcePartition = -1;
   }
 
   /**
@@ -34,12 +36,14 @@ public class DatastreamRecordMetadata {
    * @param topic Kafka topic name
    * @param partition Kafka topic partition
    * @param eventIndex Index of event within {@link com.linkedin.datastream.server.DatastreamProducerRecord}
+   * @param sourcePartition Source Kafka topic partition
    */
-  public DatastreamRecordMetadata(String checkpoint, String topic, int partition, int eventIndex) {
+  public DatastreamRecordMetadata(String checkpoint, String topic, int partition, int eventIndex, int sourcePartition) {
     _checkpoint = checkpoint;
     _topic = topic;
     _partition = partition;
     _eventIndex = eventIndex;
+    _sourcePartition = sourcePartition;
   }
 
   /**
@@ -71,9 +75,16 @@ public class DatastreamRecordMetadata {
     return _eventIndex;
   }
 
+  /**
+   * Partition number from which the record was consumed.
+   */
+  public int getSourcePartition() {
+    return _sourcePartition;
+  }
+
   @Override
   public String toString() {
-    return String.format("Checkpoint: %s, Topic: %s, Partition: %d, Event Index: %d", _checkpoint, _topic, _partition,
-        _eventIndex);
+    return String.format("Checkpoint: %s, Topic: %s, Partition: %d, Event Index: %d, Source Partition: %d", _checkpoint,
+        _topic, _partition, _eventIndex, _sourcePartition);
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
@@ -20,7 +20,7 @@ public class DatastreamRecordMetadata {
    * Construct an instance of DatastreamRecordMetadata. Defaults the event index to 0 and source partition to -1.
    * @param  checkpoint checkpoint string
    * @param topic Kafka topic name
-   * @param partition Kafka topic partition
+   * @param partition Destination Kafka topic partition
    */
   public DatastreamRecordMetadata(String checkpoint, String topic, int partition) {
     _checkpoint = checkpoint;
@@ -34,7 +34,7 @@ public class DatastreamRecordMetadata {
    * Construct an instance of DatastreamRecordMetadata.
    * @param checkpoint checkpoint string
    * @param topic Kafka topic name
-   * @param partition Kafka topic partition
+   * @param partition Destination Kafka topic partition
    * @param eventIndex Index of event within {@link com.linkedin.datastream.server.DatastreamProducerRecord}
    * @param sourcePartition Source Kafka topic partition
    */
@@ -84,7 +84,7 @@ public class DatastreamRecordMetadata {
 
   @Override
   public String toString() {
-    return String.format("Checkpoint: %s, Topic: %s, Partition: %d, Event Index: %d, Source Partition: %d", _checkpoint,
-        _topic, _partition, _eventIndex, _sourcePartition);
+    return String.format("Checkpoint: %s, Topic: %s, Destination Partition: %d, Event Index: %d, Source Partition: %d",
+        _checkpoint, _topic, _partition, _eventIndex, _sourcePartition);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -265,7 +265,7 @@ public class EventProducer implements DatastreamEventProducer {
 
     if (_numEventsOutsideAltSlaLogEnabled) {
       if (sourceToDestinationLatencyMs > _availabilityThresholdAlternateSlaMs) {
-        TopicPartition topicPartition = new TopicPartition(metadata.getTopic(), metadata.getPartition());
+        TopicPartition topicPartition = new TopicPartition(metadata.getTopic(), metadata.getSourcePartition());
         int numEvents = _trackEventsOutsideAltSlaMap.getOrDefault(topicPartition, 0);
         _trackEventsOutsideAltSlaMap.put(topicPartition, numEvents + 1);
       }
@@ -273,8 +273,9 @@ public class EventProducer implements DatastreamEventProducer {
       long timeSinceLastLog = System.currentTimeMillis() - _lastEventsOutsideAltSlaLogTimeMs;
       if (timeSinceLastLog >= _numEventsOutsideAltSlaFrequencyMs) {
         _trackEventsOutsideAltSlaMap.forEach((topicPartition, numEvents) ->
-            _logger.warn("{} had {} event(s) with latency greater than alternate SLA of {} ms in the last {} ms",
-                topicPartition, numEvents, _availabilityThresholdAlternateSlaMs, timeSinceLastLog));
+            _logger.warn("{} had {} event(s) with latency greater than alternate SLA of {} ms in the last {} ms for "
+                    + "datastream {}", topicPartition, numEvents, _availabilityThresholdAlternateSlaMs,
+                timeSinceLastLog, getDatastreamName()));
         _trackEventsOutsideAltSlaMap.clear();
         _lastEventsOutsideAltSlaLogTimeMs = System.currentTimeMillis();
       }


### PR DESCRIPTION
We recently added a feature to track high latency TopicPartitions in the EventProducer and log them at X minute intervals. When we enabled this feature, we saw that though the task only consumed from one partition of a given topic, the logs indicated there were records with high latency for multiple partitions.

On further investigation, we found that the TopicPartition key used to track high latency events used the partition returned via the RecordMetadata in the send callback, which is the destination Kafka topic's partition. Since key based partitioning is often used, keys may land up being written to a different partition than the source. 

This latency log is only useful if it helps us identify the source TopicPartitions with the highest latency. This PR adds support to track the source TopicPartition using the BrooklinEnvelope's metadata, which can then be extracted when calling the send callback to ensure that the EventProducer has data about the source partition for tracking purposes. It is okay to default the source partition to -1 if no source partition is found as not all connectors may need this feature. This PR adds this support for the KafkaConnector and KafkaMirrorMakerConnector.

Earlier PR where we added eventIndex to the DatastreamRecordMetadata: https://github.com/linkedin/brooklin/pull/669

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
