### PR TITLE
Fix the BMM event processing time metric to be in nanoseconds instead of milliseconds

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -376,8 +376,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
           _kafkaTopicPartitionTracker.onPartitionsPolled(records);
 
           Instant readTime = Instant.now();
-          long readTimeInNanos = System.nanoTime();
-          processRecords(records, readTime, readTimeInNanos);
+          processRecords(records, readTime, System.nanoTime());
           recordsPolled = records.count();
         }
         maybeCommitOffsets(_consumer, false);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -526,7 +526,9 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     }
 
     if (_enableAdditionalMetrics) {
-      _consumerMetrics.updatePerEventProcessingTimeMs(records.count() == 0 ? 0 : processingTimeMillis / records.count());
+      // Convert processingTimeMillis to microsecond precision as otherwise the per event time can be so small that
+      // it gets counted as 0 milliseconds. Note that we are still getting at most millisecond precision here.
+      _consumerMetrics.updatePerEventProcessingTimeMicros(records.count() == 0 ? 0 : (processingTimeMillis * 1000) / records.count());
     }
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -376,7 +376,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
           _kafkaTopicPartitionTracker.onPartitionsPolled(records);
 
           Instant readTime = Instant.now();
-          processRecords(records, readTime);
+          long readTimeInNanos = System.nanoTime();
+          processRecords(records, readTime, readTimeInNanos);
           recordsPolled = records.count();
         }
         maybeCommitOffsets(_consumer, false);
@@ -515,20 +516,21 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
    * Processes the Kafka consumer records by translating them and sending them to the event producer.
    * @param records the Kafka consumer records
    * @param readTime the time at which the records were successfully polled from Kafka
+   * @param readTimeInNanos the time at which the records were successfully polled from Kafka in nanoseconds. This can
+   *                        only be used for elapsed time calculations and has no meaning by itself
    */
-  protected void processRecords(ConsumerRecords<?, ?> records, Instant readTime) {
+  protected void processRecords(ConsumerRecords<?, ?> records, Instant readTime, long readTimeInNanos) {
     // send the batch out the other end
     translateAndSendBatch(records, readTime);
 
-    long processingTimeMillis = System.currentTimeMillis() - readTime.toEpochMilli();
-    if (processingTimeMillis > _processingDelayLogThresholdMillis) {
+    if ((System.currentTimeMillis() - readTime.toEpochMilli()) > _processingDelayLogThresholdMillis) {
       _consumerMetrics.updateProcessingAboveThreshold(1);
     }
 
     if (_enableAdditionalMetrics) {
-      // Convert processingTimeMillis to microsecond precision as otherwise the per event time can be so small that
-      // it gets counted as 0 milliseconds. Note that we are still getting at most millisecond precision here.
-      _consumerMetrics.updatePerEventProcessingTimeMicros(records.count() == 0 ? 0 : (processingTimeMillis * 1000) / records.count());
+      // Using millisecond precision is not good enough here. Per event processing time can be less than a millisecond
+      long processingTimeNanos = System.nanoTime() - readTimeInNanos;
+      _consumerMetrics.updatePerEventProcessingTimeNanos(records.count() == 0 ? 0 : processingTimeNanos / records.count());
     }
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
@@ -43,7 +43,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
   // keeps track of how long processing takes between polls
   public static final String TIME_SPENT_BETWEEN_POLLS_MS = "timeSpentBetweenPollsMs";
   // keeps track of process + send time per event returned from poll()
-  public static final String PER_EVENT_PROCESSING_TIME_MS = "perEventProcessingTimeMs";
+  public static final String PER_EVENT_PROCESSING_TIME_MICROS = "perEventProcessingTimeMicros";
 
   private static final Map<String, AtomicLong> AGGREGATED_NUM_TOPICS = new ConcurrentHashMap<>();
   private static final Map<String, AtomicLong> AGGREGATED_NUM_CONFIG_PAUSED_PARTITIONS = new ConcurrentHashMap<>();
@@ -62,7 +62,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
 
   private final Histogram _pollDurationMsMetric;
   private final Histogram _timeSpentBetweenPollsMsMetric;
-  private final Histogram _perEventProcessingTimeMsMetric;
+  private final Histogram _perEventProcessingTimeMicrosMetric;
 
   KafkaBasedConnectorTaskMetrics(String className, String metricsKey, Logger errorLogger,
       boolean enableAdditionalMetrics) {
@@ -81,8 +81,8 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
         DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, POLL_DURATION_MS, Histogram.class) : null;
     _timeSpentBetweenPollsMsMetric = enableAdditionalMetrics ?
         DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, TIME_SPENT_BETWEEN_POLLS_MS, Histogram.class) : null;
-    _perEventProcessingTimeMsMetric = enableAdditionalMetrics ?
-        DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, PER_EVENT_PROCESSING_TIME_MS, Histogram.class) : null;
+    _perEventProcessingTimeMicrosMetric = enableAdditionalMetrics ?
+        DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, PER_EVENT_PROCESSING_TIME_MICROS, Histogram.class) : null;
 
     AtomicLong aggNumConfigPausedPartitions =
         AGGREGATED_NUM_CONFIG_PAUSED_PARTITIONS.computeIfAbsent(className, k -> new AtomicLong(0));
@@ -123,7 +123,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     if (_pollDurationMsMetric != null) {
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, POLL_DURATION_MS);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, TIME_SPENT_BETWEEN_POLLS_MS);
-      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, PER_EVENT_PROCESSING_TIME_MS);
+      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, PER_EVENT_PROCESSING_TIME_MICROS);
     }
   }
 
@@ -208,12 +208,12 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
   }
 
   /**
-   * Update the event processing time in millis
+   * Update the event processing time in micros
    * @param val Value to update
    */
-  public void updatePerEventProcessingTimeMs(long val) {
-    if (_perEventProcessingTimeMsMetric != null) {
-      _perEventProcessingTimeMsMetric.update(val);
+  public void updatePerEventProcessingTimeMicros(long val) {
+    if (_perEventProcessingTimeMicrosMetric != null) {
+      _perEventProcessingTimeMicrosMetric.update(val);
     }
   }
 
@@ -232,7 +232,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     metrics.add(new BrooklinGaugeInfo(prefix + NUM_TOPICS));
     metrics.add(new BrooklinHistogramInfo(prefix + POLL_DURATION_MS));
     metrics.add(new BrooklinHistogramInfo(prefix + TIME_SPENT_BETWEEN_POLLS_MS));
-    metrics.add(new BrooklinHistogramInfo(prefix + PER_EVENT_PROCESSING_TIME_MS));
+    metrics.add(new BrooklinHistogramInfo(prefix + PER_EVENT_PROCESSING_TIME_MICROS));
     return Collections.unmodifiableList(metrics);
   }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
@@ -42,8 +42,8 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
   public static final String POLL_DURATION_MS = "pollDurationMs";
   // keeps track of how long processing takes between polls
   public static final String TIME_SPENT_BETWEEN_POLLS_MS = "timeSpentBetweenPollsMs";
-  // keeps track of process + send time per event returned from poll()
-  public static final String PER_EVENT_PROCESSING_TIME_MICROS = "perEventProcessingTimeMicros";
+  // keeps track of process + send time per event returned from poll() in nanoseconds
+  public static final String PER_EVENT_PROCESSING_TIME_NANOS = "perEventProcessingTimeNs";
 
   private static final Map<String, AtomicLong> AGGREGATED_NUM_TOPICS = new ConcurrentHashMap<>();
   private static final Map<String, AtomicLong> AGGREGATED_NUM_CONFIG_PAUSED_PARTITIONS = new ConcurrentHashMap<>();
@@ -62,7 +62,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
 
   private final Histogram _pollDurationMsMetric;
   private final Histogram _timeSpentBetweenPollsMsMetric;
-  private final Histogram _perEventProcessingTimeMicrosMetric;
+  private final Histogram _perEventProcessingTimeNanosMetric;
 
   KafkaBasedConnectorTaskMetrics(String className, String metricsKey, Logger errorLogger,
       boolean enableAdditionalMetrics) {
@@ -81,8 +81,8 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
         DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, POLL_DURATION_MS, Histogram.class) : null;
     _timeSpentBetweenPollsMsMetric = enableAdditionalMetrics ?
         DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, TIME_SPENT_BETWEEN_POLLS_MS, Histogram.class) : null;
-    _perEventProcessingTimeMicrosMetric = enableAdditionalMetrics ?
-        DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, PER_EVENT_PROCESSING_TIME_MICROS, Histogram.class) : null;
+    _perEventProcessingTimeNanosMetric = enableAdditionalMetrics ?
+        DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, PER_EVENT_PROCESSING_TIME_NANOS, Histogram.class) : null;
 
     AtomicLong aggNumConfigPausedPartitions =
         AGGREGATED_NUM_CONFIG_PAUSED_PARTITIONS.computeIfAbsent(className, k -> new AtomicLong(0));
@@ -123,7 +123,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     if (_pollDurationMsMetric != null) {
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, POLL_DURATION_MS);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, TIME_SPENT_BETWEEN_POLLS_MS);
-      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, PER_EVENT_PROCESSING_TIME_MICROS);
+      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, PER_EVENT_PROCESSING_TIME_NANOS);
     }
   }
 
@@ -208,12 +208,12 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
   }
 
   /**
-   * Update the event processing time in micros
+   * Update the event processing time in nanos
    * @param val Value to update
    */
-  public void updatePerEventProcessingTimeMicros(long val) {
-    if (_perEventProcessingTimeMicrosMetric != null) {
-      _perEventProcessingTimeMicrosMetric.update(val);
+  public void updatePerEventProcessingTimeNanos(long val) {
+    if (_perEventProcessingTimeNanosMetric != null) {
+      _perEventProcessingTimeNanosMetric.update(val);
     }
   }
 
@@ -232,7 +232,7 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     metrics.add(new BrooklinGaugeInfo(prefix + NUM_TOPICS));
     metrics.add(new BrooklinHistogramInfo(prefix + POLL_DURATION_MS));
     metrics.add(new BrooklinHistogramInfo(prefix + TIME_SPENT_BETWEEN_POLLS_MS));
-    metrics.add(new BrooklinHistogramInfo(prefix + PER_EVENT_PROCESSING_TIME_MICROS));
+    metrics.add(new BrooklinHistogramInfo(prefix + PER_EVENT_PROCESSING_TIME_NANOS));
     return Collections.unmodifiableList(metrics);
   }
 }


### PR DESCRIPTION
Deployed this code in our certification environment and saw that the metric for event processing time was showing up as 0 in the 50 percentile graphs, and very tiny numbers in the 99 percentile graph. Reading some documentation indicated using System.nanoTime() for doing elapsed time calculations as it doesn't use the wall clock (which can lead to issues due to leap seconds, etc). Modified the metric to use nanoTime() instead. To be clear, the actual precision of this  depends on what is provided by the OS, but for our purposes we don't need exact precision, we just need meaningful graphs.

I have decided to keep readTime in processRecords() as is. The reason for this is twofold. First, we do calculation in a couple of locations using this, and some of these involve API changes to translate(). Secondly, nanoTime() by itself is not useful, it is only useful when subtracting from another nanoTime() measurement. Thus the following code snippet cannot be used:

```
    long eventsSourceTimestamp =
        fromKafka.timestampType() == TimestampType.LOG_APPEND_TIME ? fromKafka.timestamp() : readTime.toEpochMilli();
```

Since we do not have control over how translate() uses readTime, it is not a good idea to modify it to only take the readNanoTime.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
