### PR TITLE
Add a configurable feature to include the datastream name in the consumer client.id for BMM

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorConfig.java
@@ -32,6 +32,7 @@ public class KafkaBasedConnectorConfig {
   public static final String CONFIG_PAUSE_PARTITION_ON_ERROR = "pausePartitionOnError";
   public static final String CONFIG_PAUSE_ERROR_PARTITION_DURATION_MILLIS = "pauseErrorPartitionDurationMs";
   public static final String ENABLE_ADDITIONAL_METRICS = "enableAdditionalMetrics";
+  public static final String INCLUDE_DATASTREAM_NAME_IN_CONSUMER_CLIENT_ID = "includeDatastreamNameInConsumerClientId";
   public static final String DAEMON_THREAD_INTERVAL_SECONDS = "daemonThreadIntervalInSeconds";
   public static final String NON_GOOD_STATE_THRESHOLD_MILLIS = "nonGoodStateThresholdMs";
   public static final String PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = "processingDelayLogThreshold";
@@ -48,6 +49,7 @@ public class KafkaBasedConnectorConfig {
   private static final long DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS = Duration.ofMinutes(1).toMillis();
   private static final long DEFAULT_COMMIT_TIMEOUT_MILLIS = Duration.ofSeconds(30).toMillis();
   private static final boolean DEFAULT_ENABLE_ADDITIONAL_METRICS = Boolean.TRUE;
+  private static final boolean DEFAULT_INCLUDE_DATASTREAM_NAME_IN_CONSUMER_CLIENT_ID = Boolean.FALSE;
 
   private final Properties _consumerProps;
   private final VerifiableProperties _connectorProps;
@@ -64,6 +66,7 @@ public class KafkaBasedConnectorConfig {
   private final Duration _pauseErrorPartitionDuration;
   private final long _processingDelayLogThresholdMillis;
   private final boolean _enableAdditionalMetrics;
+  private final boolean _includeDatastreamNameInConsumerClientId;
 
   private final int _daemonThreadIntervalSeconds;
   private final long _nonGoodStateThresholdMillis;
@@ -103,6 +106,8 @@ public class KafkaBasedConnectorConfig {
             DEFAULT_PROCESSING_DELAY_LOG_THRESHOLD_MILLIS);
     _enableAdditionalMetrics = verifiableProperties.getBoolean(ENABLE_ADDITIONAL_METRICS,
         DEFAULT_ENABLE_ADDITIONAL_METRICS);
+    _includeDatastreamNameInConsumerClientId = verifiableProperties.getBoolean(
+        INCLUDE_DATASTREAM_NAME_IN_CONSUMER_CLIENT_ID, DEFAULT_INCLUDE_DATASTREAM_NAME_IN_CONSUMER_CLIENT_ID);
     _enablePartitionAssignment = verifiableProperties.getBoolean(ENABLE_PARTITION_ASSIGNMENT, Boolean.FALSE);
 
     String factory =
@@ -154,6 +159,10 @@ public class KafkaBasedConnectorConfig {
 
   public boolean getEnableAdditionalMetrics() {
     return _enableAdditionalMetrics;
+  }
+
+  public boolean getIncludeDatastreamNameInConsumerClientId() {
+    return _includeDatastreamNameInConsumerClientId;
   }
 
   /**


### PR DESCRIPTION
Currently for BMM the consumer client.id must be specified in the configs at the cluster + connector name level. This means that if multiple datastreams are created with the same connector type, they will all get the same client.id. This PR adds a configurable feature to append the datastream name to the client.id in the configs. The advantage of this is that Kafka consumer metrics (created based on client.id) can be created separately for every datastream rather than putting them all into the same bucket. This can help with debugging where we need Kafka consumer client metrics.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
