### PR TITLE
Shutdown the producer on IllegalStateException as Kafka's bounded flush method wraps flush exceptions into this type

### DIFF
--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaProducerWrapper.java
@@ -30,7 +30,6 @@ import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.Metric;
 import org.apache.kafka.common.MetricName;
-import org.apache.kafka.common.errors.InterruptException;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -372,9 +371,9 @@ class KafkaProducerWrapper<K, V> {
     if (producer != null) {
       try {
         producer.flush(_producerFlushTimeoutMs, TimeUnit.MILLISECONDS);
-      } catch (InterruptException | TimeoutException | IllegalStateException e) {
-        // The KafkaProducer object should not be reused on an interrupted/timed out flush. With the bounded flush
-        // method, the actual exception is wrapped into a generic IllegalStateException.
+      } catch (Exception e) {
+        // The KafkaProducer object should not be reused on an interrupted/timed out flush. To be safe, we try to
+        // close the producer on any exception.
         try {
           _producerLock.lock();
           if (producer == _kafkaProducer) {

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaProducerWrapper.java
@@ -59,6 +59,11 @@ public class TestKafkaProducerWrapper {
     testFlushBehaviorOnException(TimeoutException.class, "random-topic-42");
   }
 
+  @Test
+  public void testFlushIllegalStateException() throws Exception {
+    testFlushBehaviorOnException(IllegalStateException.class, "new-topic-42");
+  }
+
   private void testFlushBehaviorOnException(Class<? extends Throwable> exceptionClass, String topicName)
       throws Exception {
     DynamicMetricsManager.createInstance(new MetricRegistry(), getClass().getSimpleName());


### PR DESCRIPTION
Noticed that just catching InterruptException and TimeoutException are not sufficient. The full stacktrace returned by Kafka when using bounded flush wraps the actual exception into an IllegalStateException. Thus we are not actually able to close the producer without catching an IllegalStateException.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
