### PR TITLE
Added datastream name to consumer offsets for bmm diag

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -178,7 +178,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _pollAttempts = new AtomicInteger();
     _groupIdConstructor = groupIdConstructor;
     _kafkaTopicPartitionTracker = new KafkaTopicPartitionTracker(
-        getKafkaGroupId(_datastreamTask, _groupIdConstructor, _consumerMetrics, logger));
+        getKafkaGroupId(_datastreamTask, _groupIdConstructor, _consumerMetrics, logger), _datastreamName);
   }
 
   protected static String generateMetricsPrefix(String connectorName, String simpleClassName) {

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -503,7 +503,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
       _runningTasks.forEach((datastreamTask, connectorTaskEntry) -> {
         KafkaTopicPartitionTracker tracker = connectorTaskEntry.getConnectorTask().getKafkaTopicPartitionTracker();
         KafkaConsumerOffsetsResponse response = new KafkaConsumerOffsetsResponse(tracker.getConsumedOffsets(),
-            tracker.getCommittedOffsets(), tracker.getConsumerGroupId());
+            tracker.getCommittedOffsets(), tracker.getConsumerGroupId(), tracker.getDatastreamName());
         serializedResponses.add(response);
       });
     }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorDiagUtils.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorDiagUtils.java
@@ -63,11 +63,11 @@ public class KafkaConnectorDiagUtils {
       responseList.forEach(response -> {
         if (response.getConsumedOffsets() == null || response.getConsumedOffsets().isEmpty()) {
           logger.warn("Empty consumer offset map from instance {}. Ignoring the result", instance);
-        } else if (StringUtils.isBlank(response.getConsumerGroupId())) {
-          logger.warn("Invalid consumer group id from instance {}, Ignoring the result", instance);
+        } else if (StringUtils.isBlank(response.getDatastreamName())) {
+          logger.warn("Invalid datastream name from instance {}, Ignoring the result", instance);
         } else {
-          KafkaConsumerOffsetsResponse reducedResponse = result.computeIfAbsent(response.getConsumerGroupId(),
-              k -> new KafkaConsumerOffsetsResponse(response.getConsumerGroupId()));
+          KafkaConsumerOffsetsResponse reducedResponse = result.computeIfAbsent(response.getDatastreamName(),
+              k -> new KafkaConsumerOffsetsResponse(response.getConsumerGroupId(), response.getDatastreamName()));
 
           Map<String, Map<Integer, Long>> consumedOffsets = response.getConsumedOffsets();
           consumedOffsets.forEach((topic, partitionOffsets) -> {

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConsumerOffsetsResponse.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConsumerOffsetsResponse.java
@@ -16,6 +16,7 @@ import org.codehaus.jackson.annotate.JsonProperty;
  */
 public class KafkaConsumerOffsetsResponse {
   private final String _consumerGroupId;
+  private final String _datastreamName;
   private final Map<String, Map<Integer, Long>> _consumedOffsets;
   private final Map<String, Map<Integer, Long>> _committedOffsets;
 
@@ -24,32 +25,50 @@ public class KafkaConsumerOffsetsResponse {
    * @param consumedOffsets Consumed offsets for all topic partitions
    * @param committedOffsets Committed offsets for all topic partitions
    * @param consumerGroupId Consumer group ID
+   * @param datastreamName Datastream name
    */
   public KafkaConsumerOffsetsResponse(@JsonProperty("consumedOffsets") Map<String, Map<Integer, Long>> consumedOffsets,
       @JsonProperty("committedOffsets") Map<String, Map<Integer, Long>> committedOffsets,
-      @JsonProperty("consumerGroupId") String consumerGroupId) {
+      @JsonProperty("consumerGroupId") String consumerGroupId, @JsonProperty("datastreamName") String datastreamName) {
     _consumerGroupId = consumerGroupId;
     _consumedOffsets = consumedOffsets;
     _committedOffsets = committedOffsets;
+    _datastreamName = datastreamName;
   }
 
   /**
    * Constructor for {@link KafkaConsumerOffsetsResponse}
    * @param consumerGroupId Consumer group ID
    */
-  public KafkaConsumerOffsetsResponse(String consumerGroupId) {
-    this(new HashMap<>(), new HashMap<>(), consumerGroupId);
+  public KafkaConsumerOffsetsResponse(String consumerGroupId, String datastreamName) {
+    this(new HashMap<>(), new HashMap<>(), consumerGroupId, datastreamName);
   }
 
+  /**
+   * Gets the consumed offsets
+   */
   public Map<String, Map<Integer, Long>> getConsumedOffsets() {
     return _consumedOffsets;
   }
 
+  /**
+   * Gets the committed offsets
+   */
   public Map<String, Map<Integer, Long>> getCommittedOffsets() {
     return _committedOffsets;
   }
 
+  /**
+   * Gets consumer group identifier
+   */
   public String getConsumerGroupId() {
     return _consumerGroupId;
+  }
+
+  /**
+   * Gets the datastream name
+   */
+  public String getDatastreamName() {
+    return _datastreamName;
   }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaTopicPartitionTracker.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaTopicPartitionTracker.java
@@ -31,6 +31,7 @@ import org.jetbrains.annotations.NotNull;
 public class KafkaTopicPartitionTracker {
 
   private final String _consumerGroupId;
+  private final String _datastreamName;
 
   private final Map<String, Set<Integer>> _topicPartitions = new ConcurrentHashMap<>();
   private final Map<String, Map<Integer, Long>> _consumedOffsets = new ConcurrentHashMap<>();
@@ -40,9 +41,11 @@ public class KafkaTopicPartitionTracker {
    *  Constructor for KafkaTopicPartitionTracker
    *
    * @param consumerGroupId Identifier of the consumer group
+   * @param datastreamName Name of the datastream
    */
-  public KafkaTopicPartitionTracker(String consumerGroupId) {
+  public KafkaTopicPartitionTracker(String consumerGroupId, String datastreamName) {
     _consumerGroupId = consumerGroupId;
+    _datastreamName = datastreamName;
   }
 
   /**
@@ -147,7 +150,17 @@ public class KafkaTopicPartitionTracker {
     return Collections.unmodifiableMap(_committedOffsets);
   }
 
+  /**
+   * Gets the identifier for consumer group
+   */
   public final String getConsumerGroupId() {
     return _consumerGroupId;
+  }
+
+  /**
+   * Gets the datastream name
+   */
+  public final String getDatastreamName() {
+    return _datastreamName;
   }
 }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaConsumerOffsets.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaConsumerOffsets.java
@@ -86,10 +86,14 @@ public class TestKafkaConsumerOffsets extends BaseKafkaZkTest {
     String instance1 = "i1";
     String instance2 = "i2";
 
+    String datastream1 = "ds1";
+    String datastream2 = "ds2";
+    String datastream3 = "ds3";
+
     // constructing instance1 consumer offsets
     List<KafkaConsumerOffsetsResponse> responseList1 = new ArrayList<>();
 
-    // instance 1 consumer group 1
+    // instance 1; datastream 1
     Map<String, Map<Integer, Long>> topicPartitionOffsets1 = new HashMap<>();
 
     Map<Integer, Long> partitionOffsets1 = new HashMap<>();
@@ -102,9 +106,10 @@ public class TestKafkaConsumerOffsets extends BaseKafkaZkTest {
     partitionOffsets2.put(1, 10L);
     topicPartitionOffsets1.put(topic2, partitionOffsets2);
 
-    responseList1.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets1, topicPartitionOffsets1, consumerGroup1));
+    responseList1.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets1, topicPartitionOffsets1,
+            consumerGroup1, datastream1));
 
-    // instance 1 consumer group 2
+    // instance 1; datastream 2
     Map<String, Map<Integer, Long>> topicPartitionOffsets2 = new HashMap<>();
 
     Map<Integer, Long> partitionOffsets3 = new HashMap<>();
@@ -117,12 +122,13 @@ public class TestKafkaConsumerOffsets extends BaseKafkaZkTest {
     partitionOffsets4.put(1, 20L);
     topicPartitionOffsets2.put(topic2, partitionOffsets4);
 
-    responseList1.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets2, topicPartitionOffsets2, consumerGroup2));
+    responseList1.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets2, topicPartitionOffsets2,
+            consumerGroup2, datastream2));
 
     // constructing instance2 consumer offsets
     List<KafkaConsumerOffsetsResponse> responseList2 = new ArrayList<>();
 
-    // instance 2 consumer group 1
+    // instance 2; datastream 1
     Map<String, Map<Integer, Long>> topicPartitionOffsets3 = new HashMap<>();
 
     Map<Integer, Long> partitionOffsets5 = new HashMap<>();
@@ -130,15 +136,17 @@ public class TestKafkaConsumerOffsets extends BaseKafkaZkTest {
     partitionOffsets5.put(3, 10L);
     topicPartitionOffsets3.put(topic1, partitionOffsets5);
 
-    responseList2.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets3, topicPartitionOffsets3, consumerGroup1));
+    responseList2.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets3, topicPartitionOffsets3,
+            consumerGroup1, datastream1));
 
-    // instance 2 consumer group 3
+    // instance 2; datastream 3
     Map<String, Map<Integer, Long>> topicPartitionOffsets4 = new HashMap<>();
 
     Map<Integer, Long> partitionOffsets6 = new HashMap<>();
     partitionOffsets6.put(0, 30L);
     topicPartitionOffsets4.put(topic2, partitionOffsets6);
-    responseList2.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets4, topicPartitionOffsets4, consumerGroup3));
+    responseList2.add(new KafkaConsumerOffsetsResponse(topicPartitionOffsets4, topicPartitionOffsets4,
+            consumerGroup3, datastream3));
 
     // reducing responses and asserting correctness
     Map<String, String> responseMap = new HashMap<>();
@@ -149,7 +157,7 @@ public class TestKafkaConsumerOffsets extends BaseKafkaZkTest {
     List<KafkaConsumerOffsetsResponse> responseList =
         JsonUtils.fromJson(reducedMapJson, new TypeReference<List<KafkaConsumerOffsetsResponse>>() { });
 
-    Assert.assertEquals(responseList.size(), 3); // 3 consumer groups
+    Assert.assertEquals(responseList.size(), 3); // 3 datastreams expected
 
     KafkaConsumerOffsetsResponse cg1Response = responseList.stream().
         filter(r -> r.getConsumerGroupId().equals(consumerGroup1)).findAny().orElse(null);


### PR DESCRIPTION
`consumerGroupId` was being used to aggregate per topic-partition offsets across all hosts in a BMM cluster. It was wrong  because the same consumer group could be working with multiple datastreams in case of BMM. The changes in this pull request add `datastreamName` in `KafkaTopicPartitionTracker`. It is later used to aggregate the data instead of `consumerGroupId`.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
