### PR TITLE
Add way to enable per topic latency metrics along with datastream level event producer metrics

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -310,6 +310,8 @@ public class EventProducer implements DatastreamEventProducer {
       _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, _datastreamTask.getConnectorType(),
           EVENTS_LATENCY_MS_STRING, LATENCY_SLIDING_WINDOW_LENGTH_MS, sourceToDestinationLatencyMs);
 
+      // Only update the per topic latency metric here if 'enablePerTopicMetrics' is false, otherwise this will
+      // update the metric twice.
       if (_enablePerTopicEventLatencyMetrics && !_enablePerTopicMetrics) {
         _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, metadata.getTopic(),
             EVENTS_LATENCY_MS_STRING, LATENCY_SLIDING_WINDOW_LENGTH_MS, sourceToDestinationLatencyMs);


### PR DESCRIPTION
Currently there is a way to enable per topic metrics for all EventProducer metrics, but when this is enabled, per datastream metrics are no longer emitted. This PR adds a configurable knob to enable only the event latency metrics at a topic level, while also keeping all the datastream level metrics. This metric is extremely important in terms of monitoring. Having this can help quickly identify topics which are seeing higher lag, while also avoid the explosion of all topic level metrics and also allow us to monitor all metrics at the datastream level.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
