### PR TITLE
Add a configurable max tasks per instance threshold

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -713,11 +713,12 @@ public class TestCoordinator {
     String testCluster = "testCoordinationMaxTasksPerInstance";
     String testConnectorType = "testConnectorType";
     Properties properties = new Properties();
+    // Set max tasks per instance to 5, since some instances will get 6 tasks if 4 datastreams with 4 tasks each are
+    // created across 3 instances. With 4 instances, the tasks per instance will be less than 5.
     properties.put(CoordinatorConfig.CONFIG_MAX_DATASTREAM_TASKS_PER_INSTANCE, "5");
     Coordinator instance1 = createCoordinator(_zkConnectionString, testCluster, properties);
 
     TestHookConnector connector1 = new TestHookConnector("connector1", testConnectorType);
-    //Question why the multicast strategy is within one coordinator rather than shared between list of coordinators
     instance1.addConnector(testConnectorType, connector1, new StickyMulticastStrategy(Optional.of(4), Optional.of(2)), false,
         new SourceBasedDeduper(), null);
     instance1.start();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1326,7 +1326,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   @VisibleForTesting
   void validateNewAssignment(Map<String, List<DatastreamTask>> newAssignmentsByInstance) {
     if (_config.getMaxDatastreamTasksPerInstance() > 0) {
-      // If the cluster was configured to limit the max tasks per instance, check if any instances have a higher
+      // If the cluster is configured to limit the max tasks per instance, check if any instances have a higher
       // number of tasks than expected, and fail the leader assignment on violation of this limit. This can be useful
       // to prevent other issues such as OOMs due to high memory usage which may be seen if we exceed the supportable
       // number of tasks per instance.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1323,7 +1323,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
   }
 
-  private void validateNewAssignment(Map<String, List<DatastreamTask>> newAssignmentsByInstance) {
+  @VisibleForTesting
+  void validateNewAssignment(Map<String, List<DatastreamTask>> newAssignmentsByInstance) {
     if (_config.getMaxDatastreamTasksPerInstance() > 0) {
       // If the cluster was configured to limit the max tasks per instance, check if any instances have a higher
       // number of tasks than expected, and fail the leader assignment on violation of this limit. This can be useful

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -48,6 +48,7 @@ import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamConstants;
 import com.linkedin.datastream.common.DatastreamDestination;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
+import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.DatastreamStatus;
 import com.linkedin.datastream.common.DatastreamTransientException;
 import com.linkedin.datastream.common.DatastreamUtils;
@@ -1322,6 +1323,23 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
   }
 
+  private void validateNewAssignment(Map<String, List<DatastreamTask>> newAssignmentsByInstance) {
+    if (_config.getMaxDatastreamTasksPerInstance() > 0) {
+      // If the cluster was configured to limit the max tasks per instance, check if any instances have a higher
+      // number of tasks than expected, and fail the leader assignment on violation of this limit. This can be useful
+      // to prevent other issues such as OOMs due to high memory usage which may be seen if we exceed the supportable
+      // number of tasks per instance.
+      Map<String, Integer> instancesWithTaskCountAboveThreshold = newAssignmentsByInstance.entrySet().stream()
+          .filter(e -> !e.getKey().equals(PAUSED_INSTANCE) && (e.getValue().size() > _config.getMaxDatastreamTasksPerInstance()))
+          .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().size()));
+      if (instancesWithTaskCountAboveThreshold.size() > 0) {
+        throw new DatastreamRuntimeException(String.format("Too many tasks assigned to some instances, max tasks per "
+                + "instance: %d, instances above the threshold: %s", _config.getMaxDatastreamTasksPerInstance(),
+            instancesWithTaskCountAboveThreshold));
+      }
+    }
+  }
+
   private Map<String, List<DatastreamTask>> performAssignment(List<String> liveInstances,
       Map<String, Set<DatastreamTask>> previousAssignmentByInstance, List<DatastreamGroup> datastreamGroups) {
     Map<String, List<DatastreamTask>> newAssignmentsByInstance = new HashMap<>();
@@ -1369,6 +1387,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         });
       }
     }
+
+    validateNewAssignment(newAssignmentsByInstance);
 
     return newAssignmentsByInstance;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -27,6 +27,7 @@ public final class CoordinatorConfig {
   public static final String CONFIG_HEARTBEAT_PERIOD_MS = PREFIX + "heartbeatPeriodMs";
   public static final String CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK = PREFIX + "zkCleanUpOrphanConnectorTask";
   public static final String CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK_LOCK = PREFIX + "zkCleanUpOrphanConnectorTaskLock";
+  public static final String CONFIG_MAX_DATASTREAM_TASKS_PER_INSTANCE = PREFIX + "maxDatastreamTasksPerInstance";
 
   private final String _cluster;
   private final String _zkAddress;
@@ -40,6 +41,7 @@ public final class CoordinatorConfig {
   private final String _defaultTransportProviderName;
   private final boolean _zkCleanUpOrphanConnectorTask;
   private final boolean _zkCleanUpOrphanConnectorTaskLock;
+  private final int _maxDatastreamTasksPerInstance;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -59,6 +61,7 @@ public final class CoordinatorConfig {
     _defaultTransportProviderName = _properties.getString(CONFIG_DEFAULT_TRANSPORT_PROVIDER, "");
     _zkCleanUpOrphanConnectorTask = _properties.getBoolean(CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK, false);
     _zkCleanUpOrphanConnectorTaskLock = _properties.getBoolean(CONFIG_ZK_CLEANUP_ORPHAN_CONNECTOR_TASK_LOCK, false);
+    _maxDatastreamTasksPerInstance = _properties.getInt(CONFIG_MAX_DATASTREAM_TASKS_PER_INSTANCE, 0);
   }
 
   public Properties getConfigProperties() {
@@ -99,6 +102,10 @@ public final class CoordinatorConfig {
 
   public boolean getZkCleanUpOrphanConnectorTaskLock() {
     return _zkCleanUpOrphanConnectorTaskLock;
+  }
+
+  public int getMaxDatastreamTasksPerInstance() {
+    return _maxDatastreamTasksPerInstance;
   }
 
   public long getDebounceTimerMs() {


### PR DESCRIPTION
We've run into issues where too many tasks get assigned to a given instance resulting in OOMs. This PR adds a configurable option to limit the number of tasks per instance at the cluster level. This works the same way irrespective of the assignment strategy used, and is at a global level for all tasks (across multiple connector types). A value of 0 indicates that this is disabled.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
