### PR TITLE
Fix multiple issues found in the partition movement code

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -503,8 +503,11 @@ public class DatastreamTaskImpl implements DatastreamTask {
   /**
    * Add a precedent task to this task
    */
-  public void addDependency(String taskName) {
-    _dependencies.add(taskName);
+  public void addDependency(DatastreamTaskImpl task) {
+    if (!task.isLocked()) {
+      throw new DatastreamTransientException("task " + task.getDatastreamTaskName() + " is not locked, "
+          + "the previous movement/assignment has not been picked up");
+    }
+    _dependencies.add(task.getDatastreamTaskName());
   }
-
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -6,6 +6,7 @@
 package com.linkedin.datastream.server.assignment;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -151,11 +152,13 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
   /**
    * Move a partition for a datastream group according to the targetAssignment. As we are only allowed to mutate the
    * task once. It follow the steps
-   * Step 1) get the partitions that to be moved, and find out their source task
-   * Step 2) If the instance is the one we want to move, we find out the task which we should assign the partition
+   * Step 1) Preprocess the targetAssignment to remove any partitions with no-op moves (partition currently assigned
+   *         to the same instance where the partition is to be moved)
+   * Step 2) Get the partitions that are to be moved, and find their source task
+   * Step 3) If the instance is the one we want to move, we choose a task to which we should assign the partition
    *         from that instance
-   * Step 3) Scan the current assignment, compute new task if the old task belongs to these source tasks or if it
-   *         is the target task we want to move to
+   * Step 4) Scan the current assignment, compute the new task if the old task belongs to this source tasks or if it
+   *         is the target task we want to move the partition to
    *
    * @param currentAssignment the old assignment
    * @param targetAssignment the target assignment retrieved from Zookeeper
@@ -170,8 +173,26 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
 
     DatastreamGroup dg = partitionsMetadata.getDatastreamGroup();
 
+    // Pre-process the targetAssignment to filter out partitions that are supposed to move to the target instance that
+    // they are already on to avoid unnecessary partition movements. That is, if partition1 is currently on instance1
+    // and is supposed to move to instance1, remove it from the targetAssignment as this should be a no-op.
+    Map<String, Set<String>> preprocessedTargetAssignment = new HashMap<>();
+    targetAssignment.forEach((instance, partitions) -> {
+      Set<DatastreamTask> tasks = currentAssignment.get(instance);
+      Set<String> partitionsAcrossAllDatastreamTasks = tasks.stream().filter(dg::belongsTo)
+          .map(DatastreamTask::getPartitionsV2).flatMap(Collection::stream).collect(Collectors.toSet());
+
+      Set<String> updatedTargetPartitionList = new HashSet<>(partitions);
+      updatedTargetPartitionList.removeAll(partitionsAcrossAllDatastreamTasks);
+
+      preprocessedTargetAssignment.computeIfAbsent(instance,
+          val -> updatedTargetPartitionList.isEmpty() ? null : updatedTargetPartitionList);
+    });
+
+    LOG.info("The preprocessed targetAssignment: {}", preprocessedTargetAssignment);
+
     Set<String> allToReassignPartitions = new HashSet<>();
-    targetAssignment.values().forEach(allToReassignPartitions::addAll);
+    preprocessedTargetAssignment.values().forEach(allToReassignPartitions::addAll);
     allToReassignPartitions.retainAll(partitionsMetadata.getPartitions());
 
     // construct a map to store the tasks and if it contain the partitions that can be released
@@ -179,8 +200,8 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
     Map<String, Set<String>> confirmedPartitionsTaskMap = new HashMap<>();
 
     // construct a map to store the partition and its source task
-    // map: <partitions that need to be released, source taskName>
-    Map<String, String> partitionToSourceTaskMap = new HashMap<>();
+    // map: <partitions that need to be released, source task>
+    Map<String, DatastreamTaskImpl> partitionToSourceTaskMap = new HashMap<>();
 
     // We first confirm that the partitions in the target assignment which can be removed, and we find out its source task
     // If the partitions cannot be found from any task, we ignore these partitions
@@ -190,15 +211,18 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
         if (dg.belongsTo(task)) {
           Set<String> toMovePartitions = new HashSet<>(task.getPartitionsV2());
           toMovePartitions.retainAll(allToReassignPartitions);
-          confirmedPartitionsTaskMap.put(task.getDatastreamTaskName(), toMovePartitions);
-          toMovePartitions.forEach(p -> partitionToSourceTaskMap.put(p, task.getDatastreamTaskName()));
+          if (!toMovePartitions.isEmpty()) {
+            // Only update the confirmedPartitionsTaskMap if a partition is indeed being deleted from it
+            confirmedPartitionsTaskMap.put(task.getDatastreamTaskName(), toMovePartitions);
+            toMovePartitions.forEach(p -> partitionToSourceTaskMap.put(p, (DatastreamTaskImpl) task));
+          }
         }
       });
     });
 
     Set<String> tasksToMutate = confirmedPartitionsTaskMap.keySet();
     Set<String> toReleasePartitions = new HashSet<>();
-    confirmedPartitionsTaskMap.values().forEach(v -> toReleasePartitions.addAll(v));
+    confirmedPartitionsTaskMap.values().forEach(toReleasePartitions::addAll);
 
     // Compute new assignment from the current assignment
     Map<String, Set<DatastreamTask>> newAssignment = new HashMap<>();
@@ -208,15 +232,14 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
 
       // check if this instance has any partition to be added
       final Set<String> toAddedPartitions = new HashSet<>();
-      if (targetAssignment.containsKey(instance)) {
+      if (preprocessedTargetAssignment.containsKey(instance)) {
         // filter the target assignment by the partitions which have a confirmed source
-        Set<String> p = targetAssignment.get(instance).stream()
+        Set<String> p = preprocessedTargetAssignment.get(instance).stream()
             .filter(toReleasePartitions::contains).collect(Collectors.toSet());
         toAddedPartitions.addAll(p);
       }
 
-      Set<DatastreamTask> dgTasks = tasks.stream().filter(dg::belongsTo)
-          .collect(Collectors.toSet());
+      Set<DatastreamTask> dgTasks = tasks.stream().filter(dg::belongsTo).collect(Collectors.toSet());
       if (toAddedPartitions.size() > 0 && dgTasks.isEmpty()) {
         String errorMsg = String.format("No task is available in the target instance %s", instance);
         LOG.error(errorMsg);
@@ -228,37 +251,39 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
           .reduce((task1, task2) -> task1.getPartitionsV2().size() < task2.getPartitionsV2().size() ? task1 : task2)
           .get() : null;
 
-        // compute new assignment for that instance
-        Set<DatastreamTask> newAssignedTask = tasks.stream().map(task -> {
-          if (!dg.belongsTo(task)) {
-            return task;
-          }
-          boolean partitionChanged = false;
-          List<String> newPartitions = new ArrayList<>(task.getPartitionsV2());
-          Set<String> extraDependencies = new HashSet<>();
+      // compute new assignment for that instance
+      Set<DatastreamTask> newAssignedTask = tasks.stream().map(task -> {
+        if (!dg.belongsTo(task)) {
+          return task;
+        }
 
-          // release the partitions
-          if (tasksToMutate.contains(task.getDatastreamTaskName())) {
-            newPartitions.removeAll(toReleasePartitions);
-            partitionChanged = true;
-          }
+        boolean partitionChanged = false;
+        List<String> newPartitions = new ArrayList<>(task.getPartitionsV2());
+        Set<DatastreamTaskImpl> extraDependencies = new HashSet<>();
 
-          // add new partitions
-          if (targetTask != null && task.getDatastreamTaskName().equals(targetTask.getDatastreamTaskName())) {
-            newPartitions.addAll(toAddedPartitions);
-            partitionChanged = true;
-            // add source task for these partitions into extra dependency
-            toReleasePartitions.forEach(p -> extraDependencies.add(partitionToSourceTaskMap.get(p)));
-          }
+        // release the partitions
+        if (tasksToMutate.contains(task.getDatastreamTaskName())) {
+          newPartitions.removeAll(toReleasePartitions);
+          partitionChanged = true;
+        }
 
-          if (partitionChanged) {
-            DatastreamTaskImpl newTask = new DatastreamTaskImpl((DatastreamTaskImpl) task, newPartitions);
-            extraDependencies.forEach(t -> newTask.addDependency(t));
-            return newTask;
-          } else {
-            return task;
-          }
-        }).collect(Collectors.toSet());
+        // add new partitions
+        if (targetTask != null && task.getDatastreamTaskName().equals(targetTask.getDatastreamTaskName())) {
+          newPartitions.addAll(toAddedPartitions);
+          partitionChanged = true;
+          // add the source task for these partitions into the extra dependency list
+          toAddedPartitions.forEach(p -> extraDependencies.add(partitionToSourceTaskMap.get(p)));
+        }
+
+        if (partitionChanged) {
+          DatastreamTaskImpl newTask = new DatastreamTaskImpl((DatastreamTaskImpl) task, newPartitions);
+          extraDependencies.forEach(newTask::addDependency);
+          return newTask;
+        } else {
+          return task;
+        }
+      }).collect(Collectors.toSet());
+
       newAssignment.put(instance, newAssignedTask);
     });
 


### PR DESCRIPTION
This PR fixes multiple issues in the partition movement code:

- If a task has no change in partitions, do not create a new task. Earlier all tasks were getting added to the tasks to mutate list,  even if it did not contain any partitions going away or getting added
- If the target instance receives a partition which it already owns, this should be a no-op, and the partition should remain in it's original task.
- Only add task dependencies for partitions getting added to that task rather than all partition being moved. E.g. earlier if p1 and p2 were to be moved, and p1 got added to task1, then p1's task and p2's task were both added as dependencies. Only p1's task should be added as a dependency to task1.
- When adding extra dependencies, ensure that these are locked too (like we do with the predecessor task)

This PR does not change the overall logic of this piece.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
