### PR TITLE
Add flushless config to EventProducer to allow disabling periodic flush on send

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
@@ -39,4 +39,12 @@ public interface DatastreamEventProducer {
    * As such, it is not efficient to be invoked very frequently.
    */
   void flush();
+
+  /**
+   * Enable periodic flush on send
+   *
+   * @param enableFlushOnSend Whether to enable flushing on send or not
+   */
+  default void flushOnSend(boolean enableFlushOnSend) {
+  }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamEventProducer.java
@@ -45,6 +45,6 @@ public interface DatastreamEventProducer {
    *
    * @param enableFlushOnSend Whether to enable flushing on send or not
    */
-  default void flushOnSend(boolean enableFlushOnSend) {
+  default void enablePeriodicFlushOnSend(boolean enableFlushOnSend) {
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
@@ -44,6 +44,7 @@ public class FlushlessEventProducerHandler<T extends Comparable<T>> {
    */
   public FlushlessEventProducerHandler(DatastreamEventProducer eventProducer) {
     _eventProducer = eventProducer;
+    _eventProducer.flushOnSend(false);
   }
 
   /**

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/FlushlessEventProducerHandler.java
@@ -44,7 +44,7 @@ public class FlushlessEventProducerHandler<T extends Comparable<T>> {
    */
   public FlushlessEventProducerHandler(DatastreamEventProducer eventProducer) {
     _eventProducer = eventProducer;
-    _eventProducer.flushOnSend(false);
+    _eventProducer.enablePeriodicFlushOnSend(false);
   }
 
   /**

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -423,7 +423,7 @@ public class EventProducer implements DatastreamEventProducer {
   }
 
   @Override
-  public void flushOnSend(boolean enableFlushOnSend) {
+  public void enablePeriodicFlushOnSend(boolean enableFlushOnSend) {
     _enableFlushOnSend = enableFlushOnSend;
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -49,7 +49,6 @@ public class EventProducer implements DatastreamEventProducer {
   public static final String CONFIG_FLUSH_INTERVAL_MS = "flushIntervalMs";
   public static final String CONFIG_ENABLE_PER_TOPIC_METRICS = "enablePerTopicMetrics";
   public static final String CONFIG_ENABLE_PER_TOPIC_EVENT_LATENCY_METRICS = "enablePerTopicEventLatencyMetrics";
-  public static final String CONFIG_IS_FLUSHLESS_MODE_ENABLED = "isFlushlessModeEnabled";
 
   // Default flush interval, It is intentionally kept at low frequency. If a particular connectors wants
   // a more frequent flush (high traffic connectors), it can perform that on it's own.
@@ -82,7 +81,6 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String DEFAULT_WARN_LOG_LATENCY_THRESHOLD_MS = "1500000000"; // 25000 minutes, ~17 days
   private static final String DEFAULT_NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_ENABLED = "false";
   private static final String DEFAULT_NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_FREQUENCY_MS = "300000"; // 5 minutes
-  private static final String DEFAULT_IS_FLUSHLESS_MODE_ENABLED = Boolean.FALSE.toString();
   private static final long LATENCY_SLIDING_WINDOW_LENGTH_MS = Duration.ofMinutes(3).toMillis();
   private static final long LONG_FLUSH_WARN_THRESHOLD_MS = Duration.ofMinutes(5).toMillis();
 
@@ -106,12 +104,12 @@ public class EventProducer implements DatastreamEventProducer {
   private final boolean _skipMessageOnSerializationErrors;
   private final boolean _enablePerTopicMetrics;
   private final boolean _enablePerTopicEventLatencyMetrics;
-  private final boolean _isFlushlessModeEnabled;
   private final Duration _flushInterval;
 
   private Instant _lastFlushTime = Instant.now();
   private long _lastEventsOutsideAltSlaLogTimeMs = System.currentTimeMillis();
   private Map<TopicPartition, Integer> _trackEventsOutsideAltSlaMap = new HashMap<>();
+  private boolean _enableFlushOnSend = true;
 
   /**
    * Construct an EventProducer instance.
@@ -168,11 +166,7 @@ public class EventProducer implements DatastreamEventProducer {
         Boolean.parseBoolean(config.getProperty(CONFIG_ENABLE_PER_TOPIC_EVENT_LATENCY_METRICS,
             Boolean.FALSE.toString()));
 
-    _isFlushlessModeEnabled =
-        Boolean.parseBoolean(config.getProperty(CONFIG_IS_FLUSHLESS_MODE_ENABLED, DEFAULT_IS_FLUSHLESS_MODE_ENABLED));
-
-    _logger.info("Created event producer with customCheckpointing={}, isFlushlessModeEnabled={}", customCheckpointing,
-        _isFlushlessModeEnabled);
+    _logger.info("Created event producer with customCheckpointing={}", customCheckpointing);
 
     _dynamicMetricsManager = DynamicMetricsManager.getInstance();
     // provision some metrics to force them to create
@@ -248,7 +242,7 @@ public class EventProducer implements DatastreamEventProducer {
 
     // Force a periodic flush if flushless mode isn't enabled, in case the connector is not calling flush at
     // regular intervals
-    if (!_isFlushlessModeEnabled && Instant.now().isAfter(_lastFlushTime.plus(_flushInterval))) {
+    if (_enableFlushOnSend && Instant.now().isAfter(_lastFlushTime.plus(_flushInterval))) {
       flush();
     }
   }
@@ -426,6 +420,11 @@ public class EventProducer implements DatastreamEventProducer {
         _logger.warn("Flush took {} ms", flushLatencyMs);
       }
     }
+  }
+
+  @Override
+  public void flushOnSend(boolean enableFlushOnSend) {
+    _enableFlushOnSend = enableFlushOnSend;
   }
 
   /**


### PR DESCRIPTION
BMM has a flushless mode, where the connector keeps track of all acknowledged sends for every TopicPartition and commits offsets based on these. The EventProducer tries to flush periodically on send, and this lands up calling flush even in flushless mode. This PR adds the capability to configure the EventProducer as flushless.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
