### PR TITLE
Pull in some Kafka consumer metrics for the AbstractKafkaBasedConnectorTask

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -353,6 +353,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
     try {
       _consumer = createKafkaConsumer(_consumerProps);
+      _consumerMetrics.registerKafkaConsumerMetrics(_consumer,
+          _consumerProps.getProperty(ConsumerConfig.CLIENT_ID_CONFIG));
       consumerSubscribe();
 
       ConsumerRecords<?, ?> records;

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
@@ -7,11 +7,18 @@ package com.linkedin.datastream.connectors.kafka;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
 
+import org.apache.commons.lang3.StringUtils;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
 import org.slf4j.Logger;
 
 import com.codahale.metrics.Histogram;
@@ -45,6 +52,10 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
   public static final String TIME_SPENT_BETWEEN_POLLS_MS = "timeSpentBetweenPollsMs";
   // keeps track of process + send time per event returned from poll() in nanoseconds
   public static final String PER_EVENT_PROCESSING_TIME_NANOS = "perEventProcessingTimeNs";
+  // keeps track of the sum of how far the safe offset is behind the watermark for all TopicPartitions
+  public static final String CONSUMER_OFFSET_WATERMARK_SPAN = "consumerOffsetWatermarkSpan";
+  // keeps track of how many times the consumer had OffsetOutOfRangeException or NoOffsetForPartitionException
+  public static final String CONSUMER_LICLOSEST_DATA_LOSS_ESTIMATION = "consumerLiclosestDataLossEstimation";
 
   private static final Map<String, AtomicLong> AGGREGATED_NUM_TOPICS = new ConcurrentHashMap<>();
   private static final Map<String, AtomicLong> AGGREGATED_NUM_CONFIG_PAUSED_PARTITIONS = new ConcurrentHashMap<>();
@@ -74,6 +85,8 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
   private final Histogram _timeSpentBetweenPollsMsMetric;
   private final Histogram _perEventProcessingTimeNanosMetric;
   private final String _fullMetricsKey;
+
+  private boolean _kafkaConsumerMetricsRegistered = false;
 
   KafkaBasedConnectorTaskMetrics(String className, String metricsKey, Logger errorLogger,
       boolean enableAdditionalMetrics) {
@@ -130,6 +143,43 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     DYNAMIC_METRICS_MANAGER.registerGauge(_className, AGGREGATE, NUM_TOPICS, aggNumTopics::get);
   }
 
+  /**
+   * Register some of the Kafka consumer metrics of interest. This cannot be done as part of the constructor
+   * as the Kafka consumer may be created at a later time than this object.
+   * @param consumer the Kafka consumer for which to register the metrics
+   * @param clientId the Kafka consumer's client.id
+   */
+  public void registerKafkaConsumerMetrics(Consumer<?, ?> consumer, String clientId) {
+    if (consumer == null || StringUtils.isBlank(clientId)) {
+      _errorLogger.warn("Cannot register the Kafka consumer metrics, either the consumer is null or the client.id is blank");
+      return;
+    }
+
+    Supplier<Double> watermarkSpanSupplier = () -> getConsumerOffsetWatermarkSpanMetric(consumer, clientId);
+    DYNAMIC_METRICS_MANAGER.registerGauge(_className, _key, CONSUMER_OFFSET_WATERMARK_SPAN, watermarkSpanSupplier);
+
+    Supplier<Double> offsetResetSupplier = () -> getConsumerLiclosestDataLossEstimationMetric(consumer, clientId);
+    DYNAMIC_METRICS_MANAGER.registerGauge(_className, _key, CONSUMER_LICLOSEST_DATA_LOSS_ESTIMATION, offsetResetSupplier);
+
+    _kafkaConsumerMetricsRegistered = true;
+  }
+
+  private double getConsumerOffsetWatermarkSpanMetric(Consumer<?, ?> consumer, String clientId) {
+    return getConsumerMetricValue(consumer, clientId, "consumer-offset-watermark-span");
+
+  }
+
+  private double getConsumerLiclosestDataLossEstimationMetric(Consumer<?, ?> consumer, String clientId) {
+    return getConsumerMetricValue(consumer, clientId, "consumer-liclosest-data-loss-estimation");
+  }
+
+  private double getConsumerMetricValue(Consumer<?, ?> consumer, String clientId, String metricName) {
+    Map<String, String> tags = new HashMap<>(2);
+    tags.put("client-id", clientId);
+    MetricName name = new MetricName(metricName, "lnkd", "", tags);
+    return Optional.ofNullable(consumer).map(c -> c.metrics().get(name)).map(Metric::value).orElse(0.0);
+  }
+
   @Override
   public void deregisterMetrics() {
     // this is called when a datastream task is closed/shutdown
@@ -150,6 +200,11 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, POLL_DURATION_MS);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, TIME_SPENT_BETWEEN_POLLS_MS);
       DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, PER_EVENT_PROCESSING_TIME_NANOS);
+    }
+
+    if (_kafkaConsumerMetricsRegistered) {
+      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, CONSUMER_OFFSET_WATERMARK_SPAN);
+      DYNAMIC_METRICS_MANAGER.unregisterMetric(_className, _key, CONSUMER_LICLOSEST_DATA_LOSS_ESTIMATION);
     }
   }
 
@@ -257,6 +312,8 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     metrics.add(new BrooklinGaugeInfo(prefix + NUM_AUTO_PAUSED_PARTITIONS_ON_INFLIGHT_MESSAGES));
     metrics.add(new BrooklinGaugeInfo(prefix + NUM_AUTO_PAUSED_PARTITIONS_WAITING_FOR_DEST_TOPIC));
     metrics.add(new BrooklinGaugeInfo(prefix + NUM_TOPICS));
+    metrics.add(new BrooklinGaugeInfo(prefix + CONSUMER_OFFSET_WATERMARK_SPAN));
+    metrics.add(new BrooklinGaugeInfo(prefix + CONSUMER_LICLOSEST_DATA_LOSS_ESTIMATION));
     metrics.add(new BrooklinHistogramInfo(prefix + POLL_DURATION_MS));
     metrics.add(new BrooklinHistogramInfo(prefix + TIME_SPENT_BETWEEN_POLLS_MS));
     metrics.add(new BrooklinHistogramInfo(prefix + PER_EVENT_PROCESSING_TIME_NANOS));

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
@@ -62,7 +62,6 @@ import com.linkedin.datastream.testutil.DatastreamTestUtils;
 
 import static com.linkedin.datastream.connectors.kafka.mirrormaker.KafkaMirrorMakerConnectorTestUtils.POLL_PERIOD_MS;
 import static com.linkedin.datastream.connectors.kafka.mirrormaker.KafkaMirrorMakerConnectorTestUtils.POLL_TIMEOUT_MS;
-import static com.linkedin.datastream.connectors.kafka.mirrormaker.KafkaMirrorMakerConnectorTestUtils.getDefaultConfig;
 
 
 /**
@@ -91,6 +90,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     config.put(KafkaBasedConnectorConfig.CONFIG_RETRY_SLEEP_DURATION_MILLIS, "1000");
     config.put(KafkaBasedConnectorConfig.CONFIG_PAUSE_ERROR_PARTITION_DURATION_MILLIS,
         String.valueOf(Duration.ofSeconds(5).toMillis()));
+    config.put(KafkaBasedConnectorConfig.DOMAIN_KAFKA_CONSUMER + "." + ConsumerConfig.CLIENT_ID_CONFIG, "client-id-42");
     override.ifPresent(config::putAll);
     return config;
   }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -1,5 +1,5 @@
 ext {
-    LIKafkaVersion = "1.0.52"
+    LIKafkaVersion = "1.0.58"
     apacheHttpClientVersion = "4.5.3"
     avroVersion = "1.7.7"
     commonsCliVersion = "1.2"


### PR DESCRIPTION
This PR pulls in the following Kafka consumer metrics:

- consumer-offset-watermark-span
- consumer-liclosest-data-loss-estimation

These metrics are not present in JMX, so they need to be manually pulled in via the consumer.metrics() API.
This PR also bumps up the LiKafkaVersion to ensure that the above metrics are present.
