### PR TITLE
Pre-commit and post-commit hooks in AbstractKafkaMirrorMakerConnectorTask

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -634,8 +634,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       return true;
     }, COMMIT_RETRY_INTERVAL_MILLIS, COMMIT_RETRY_TIMEOUT_MILLIS);
 
-    postCommitHook(result, lastKafkaExceptionRef.get());
-
     if (!result) {
       String msg = "Commit failed after several retries, Giving up.";
       _logger.error(msg);
@@ -782,19 +780,12 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   /**
    * Pre commit hook for all operations that need to be performed before committing offsets.
+   * <p>
+   *   Note: An unhandled exception in pre-commit hook may result in an interrupted commit. Classes overriding the hook
+   *   are expected to handle exceptions.
+   * </p>
    */
   protected void preCommitHook() { }
-
-  /**
-   * Post commit hook for all operations that need to be performed after committing offsets.
-   * <p>
-   *     Note: A commit attempt can be declared successful even when there's an exception. This can happen when a commit
-   *     exception is thrown during task shutdown.
-   * </p>
-   * @param success Indicates whether the commit attempt was successful or not.
-   * @param exception Exception caught during a commit attempt.
-   */
-  protected void postCommitHook(boolean success, KafkaException exception) { }
 
   /**
    * The method, given a datastream task - checks if there is any update in the existing task.

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -21,7 +21,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
@@ -610,7 +609,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected void commitWithRetries(Consumer<?, ?> consumer, Optional<Map<TopicPartition, OffsetAndMetadata>> offsets)
       throws DatastreamRuntimeException {
     preCommitHook();
-    AtomicReference<KafkaException> lastKafkaExceptionRef = new AtomicReference<>(null);
     boolean result = PollUtils.poll(() -> {
       try {
         if (offsets.isPresent()) {
@@ -621,7 +619,6 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         }
         _logger.info("Commit succeeded.");
       } catch (KafkaException e) {
-        lastKafkaExceptionRef.set(e);
         if (_shutdown) {
           _logger.info("Caught KafkaException in commitWithRetries while shutting down, so exiting.", e);
           return true;

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -21,8 +21,8 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-
 import java.util.concurrent.atomic.AtomicReference;
+
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.Validate;
 import org.apache.commons.lang.exception.ExceptionUtils;


### PR DESCRIPTION
Sometimes it's necessary to perform pre-commit or post-commit operations in BMM connectors tasks. One could override/extend abstract method `maybeCommitOffsets()` for that purpose, but that method is called each time messages are polled and sent, and not always a call to `maybeCommitOffsets` results in offsets actually being committed.
The changes in this pull request introduce dedicated pre-commit and post-commit hooks that are called before and after a commit attempt. The default implementation of `preCommitHook()` is a no-op, while the default implementation of `postCommitHook()` logs an error if the commit failed and throws an exception. Please note that the latter behavior was previously part of the `commitWithRetries()` method.

Update: Post-commit hook has been removed after discussing with @vmaheshw and @somandal. There's no use case for it now and it can be added back when there is one.
