### PR TITLE
Reduce excessive logging of the full datastream task object

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -168,8 +168,8 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       _minInFlightMessagesThreshold =
           config.getConnectorProps().getLong(CONFIG_MIN_IN_FLIGHT_MSGS_THRESHOLD, DEFAULT_MIN_IN_FLIGHT_MSGS_THRESHOLD);
       LOG.info("Flushless mode is enabled for task: {}, with flowControlEnabled={}, minInFlightMessagesThreshold={}, "
-              + "maxInFlightMessagesThreshold={}", task, _flowControlEnabled, _minInFlightMessagesThreshold,
-          _maxInFlightMessagesThreshold);
+              + "maxInFlightMessagesThreshold={}", task.getDatastreamTaskName(), _flowControlEnabled,
+          _minInFlightMessagesThreshold, _maxInFlightMessagesThreshold);
     }
 
     // create topic manager
@@ -281,10 +281,8 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       _flushlessProducer.send(datastreamProducerRecord, topic, partition, sourceCheckpoint.getOffset(),
           ((metadata, exception) -> {
             if (exception != null) {
-              _logger.warn(
-                  String.format("Detected exception being throw from flushless send callback for source "
-                      + "topic-partition: %s with metadata: %s, exception: ", srcTopicPartition, metadata),
-                  exception);
+              LOG.warn(String.format("Detected exception being throw from flushless send callback for source "
+                      + "topic-partition: %s with metadata: %s, exception: ", srcTopicPartition, metadata), exception);
               updateSendFailureTopicPartitionExceptionMap(srcTopicPartition, exception);
             } else {
               _consumerMetrics.updateBytesProcessedRate(numBytes);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -310,14 +310,16 @@ public class DatastreamTaskImpl implements DatastreamTask {
       // Need to confirm the dependencies for task are not locked
       _dependencies.forEach(predecessor -> {
         if (_zkAdapter.checkIsTaskLocked(this.getConnectorType(), this.getTaskPrefix(), predecessor)) {
-          String msg = String.format("previous task %s failed to release lock in %dms", predecessor, timeout.toMillis());
+          String msg = String.format("previous task %s failed to release lock in %dms for task %s", predecessor,
+              timeout.toMillis(), this.getDatastreamTaskName());
           throw new DatastreamRuntimeException(msg);
         }
       });
 
       _zkAdapter.acquireTask(this, timeout);
     } catch (Exception e) {
-      LOG.error("Failed to acquire task: " + this, e);
+      LOG.error(String.format("Failed to acquire task: %s with dependencies: %s", this.getDatastreamTaskName(),
+          String.join(",", this.getDependencies())), e);
       setStatus(DatastreamTaskStatus.error("Acquire failed, exception: " + e));
       throw e;
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -1252,7 +1252,8 @@ public class ZkAdapter {
     if (_zkclient.exists(lockPath)) {
       owner = _zkclient.readData(lockPath, true);
       if (owner != null && owner.equals(_instanceName)) {
-        LOG.info("{} already owns the lock on {}", _instanceName, task);
+        LOG.info("{} already owns the lock on {}, with dependencies {}", _instanceName, task.getDatastreamTaskName(),
+            task.getDependencies());
         return;
       }
 
@@ -1261,12 +1262,14 @@ public class ZkAdapter {
 
     if (!_zkclient.exists(lockPath)) {
       _zkclient.create(lockPath, _instanceName, CreateMode.PERSISTENT);
-      LOG.info("{} successfully acquired the lock on {}", _instanceName, task);
+      LOG.info("{} successfully acquired the lock on {} with dependencies: {}", _instanceName,
+          task.getDatastreamTaskName(), task.getDependencies());
       return;
     }
 
-    String msg = String.format("%s failed to acquire task %s in %dms, current owner: %s", _instanceName, task,
-        timeout.toMillis(), owner);
+    String msg = String.format("%s failed to acquire task %s in %dms, current owner: %s, dependencies: %s",
+        _instanceName, task.getDatastreamTaskName(), timeout.toMillis(), owner,
+        String.join(",", task.getDependencies()));
     ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, msg, null);
   }
 


### PR DESCRIPTION
BMM partition-managed streams store the full TopicPartition list. Printing the full datastream task everywhere can result in us filling up the logs very quickly. This PR attempts to reduce logging the full datastream task details everywhere. Some logs with the full datastream task have been left as is in case they assist with debugging.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
