### PR TITLE
[issue 788] make start offsets take effect when set in KafkaConnectorTask

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -74,6 +74,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
 
   public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG_LATEST = "latest";
   public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG_EARLIEST = "earliest";
+  public static final String CONSUMER_AUTO_OFFSET_RESET_CONFIG_NONE = "none";
 
   protected long _lastCommittedTime = System.currentTimeMillis();
   protected int _eventsProcessedCount = 0;
@@ -104,7 +105,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected final Duration _pauseErrorPartitionDuration;
   protected final long _processingDelayLogThresholdMillis;
   protected final boolean _enableAdditionalMetrics;
-  protected final Optional<Map<Integer, Long>> _startOffsets;
+  protected final Map<Integer, Long> _startOffsets;
 
   protected volatile String _taskName;
   protected final DatastreamEventProducer _producer;
@@ -147,12 +148,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _taskName = task.getDatastreamTaskName();
 
     _consumerProps = config.getConsumerProps();
-    if (_datastream.getMetadata().containsKey(KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY)) {
-      String strategy = _datastream.getMetadata().get(KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY);
-      _logger.info("Datastream contains consumer config override for {} with value {}",
-          ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, strategy);
-      _consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, strategy);
-    }
+
     if (Boolean.TRUE.toString()
         .equals(_datastream.getMetadata().get(KafkaDatastreamMetadataConstants.USE_PASSTHROUGH_COMPRESSION))) {
       _consumerProps.put("enable.shallow.iterator", Boolean.TRUE.toString());
@@ -165,9 +161,38 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
     _pausePartitionOnError = config.getPausePartitionOnError();
     _pauseErrorPartitionDuration = config.getPauseErrorPartitionDuration();
     _enableAdditionalMetrics = config.getEnableAdditionalMetrics();
-    _startOffsets = Optional.ofNullable(_datastream.getMetadata().get(DatastreamMetadataConstants.START_POSITION))
-        .map(json -> JsonUtils.fromJson(json, new TypeReference<Map<Integer, Long>>() {
-        }));
+
+    _startOffsets = new HashMap<>();
+    String json = _datastream.getMetadata().get(DatastreamMetadataConstants.START_POSITION);
+    if (StringUtils.isNotBlank(json)) {
+      _startOffsets.putAll(JsonUtils.fromJson(json, new TypeReference<Map<Integer, Long>>() {
+      }));
+    }
+
+    // if this datastream wants to use specific start offsets, we need to have the auto.offset.reset config
+    // set to "none" in the kafka consumer configs, so that the Kafka consumer throws NoOffsetForPartitionException
+    // upon first poll, to be handled by seeking to the startOffsets
+    if (!_startOffsets.isEmpty()) {
+      if (_datastream.getMetadata().containsKey(KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY)) {
+        _logger.info("Datastream contains metadata for both {} and {}, which are mutually exclusive. Ignoring the "
+                + "{}=\"{}\" metadata, as start offsets require it to be set to \"none\"",
+            DatastreamMetadataConstants.START_POSITION,
+            KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY,
+            KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY,
+            _datastream.getMetadata().get(KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY));
+      }
+      _logger.info("Datastream contains startOffsets, setting {} = \"{}\" in consumer configs "
+              + "(overriding the configs value of \"{}\")",
+          ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_NONE,
+          getConsumerAutoOffsetResetConfig());
+      _consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_NONE);
+    } else if (_datastream.getMetadata().containsKey(KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY)) {
+        String strategy = _datastream.getMetadata().get(KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY);
+        _logger.info("Datastream contains consumer config override for {} with value {}",
+            ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, strategy);
+        _consumerProps.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, strategy);
+    }
+
     _offsetCommitInterval = config.getCommitIntervalMillis();
     _pollTimeoutMillis = config.getPollTimeoutMillis();
     _retrySleepDuration = config.getRetrySleepDuration();
@@ -675,9 +700,9 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   private void seekToStartPosition(Consumer<?, ?> consumer, Set<TopicPartition> partitions, String strategy) {
     // We would like to consume from latest when there is no offset. However, if we rewind due to exception, we want
     // to rewind to earliest to make sure the messages which are added after we start consuming don't get skipped
-    if (_startOffsets.isPresent()) {
-      _logger.info("Datastream is configured with StartPosition. Trying to start from {}", _startOffsets.get());
-      seekToOffset(consumer, partitions, _startOffsets.get());
+    if (!_startOffsets.isEmpty()) {
+      _logger.info("Datastream is configured with StartPosition. Trying to start from {}", _startOffsets);
+      seekToOffset(consumer, partitions, _startOffsets);
     } else {
       if (CONSUMER_AUTO_OFFSET_RESET_CONFIG_LATEST.equals(strategy)) {
         _logger.info("Datastream was not configured with StartPosition. Seeking to end for partitions: {}", partitions);
@@ -1034,5 +1059,10 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       consumerMetrics.updateErrorRate(1, "Can't find group ID", e);
       throw e;
     }
+  }
+
+  @VisibleForTesting
+  public String getConsumerAutoOffsetResetConfig() {
+    return _consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "");
   }
 }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorTask.java
@@ -47,6 +47,7 @@ import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.DatastreamSource;
 import com.linkedin.datastream.common.JsonUtils;
 import com.linkedin.datastream.common.PollUtils;
+import com.linkedin.datastream.kafka.KafkaDatastreamMetadataConstants;
 import com.linkedin.datastream.kafka.factory.KafkaConsumerFactory;
 import com.linkedin.datastream.kafka.factory.KafkaConsumerFactoryImpl;
 import com.linkedin.datastream.server.DatastreamEventProducer;
@@ -146,7 +147,7 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
   }
 
   @Test
-  public void testConsumeWithStartingOffset() throws Exception {
+  public void testConsumeWithStartingOffsetAndNoResetStrategy() throws Exception {
     String topic = "pizza1";
     createTopic(_zkUtils, topic);
 
@@ -170,7 +171,57 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
     DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
     task.setEventProducer(datastreamProducer);
 
-    KafkaConnectorTask connectorTask = createKafkaConnectorTask(task);
+    KafkaConnectorTask connectorTask = createKafkaConnectorTaskWithAutoOffsetResetConfig(task, "earliest");
+
+    // validate auto.offset.reset config is overridden to none (given the start offsets)
+    Assert.assertEquals(connectorTask.getConsumerAutoOffsetResetConfig(), "none");
+
+
+    LOG.info("Sending third set of events");
+
+    //send 100 more msgs
+    produceEvents(_kafkaCluster, _zkUtils, topic, 1000, 100);
+
+    if (!PollUtils.poll(() -> datastreamProducer.getEvents().size() == 200, 100, POLL_TIMEOUT_MS)) {
+      Assert.fail("did not transfer 200 msgs within timeout. transferred " + datastreamProducer.getEvents().size());
+    }
+
+    connectorTask.stop();
+    Assert.assertTrue(connectorTask.awaitStop(CONNECTOR_AWAIT_STOP_TIMEOUT_MS, TimeUnit.MILLISECONDS),
+        "did not shut down on time");
+  }
+
+  @Test
+  public void testConsumeWithStartingOffsetAndResetStrategy() throws Exception {
+    String topic = "pizza1";
+    createTopic(_zkUtils, topic);
+
+    LOG.info("Sending first set of events");
+
+    //produce 100 msgs to topic before start
+    produceEvents(_kafkaCluster, _zkUtils, topic, 0, 100);
+    Map<Integer, Long> startOffsets = Collections.singletonMap(0, 100L);
+
+    LOG.info("Sending second set of events");
+
+    //produce 100 msgs to topic before start
+    produceEvents(_kafkaCluster, _zkUtils, topic, 100, 100);
+
+    //start
+    MockDatastreamEventProducer datastreamProducer = new MockDatastreamEventProducer();
+    Datastream datastream = getDatastream(_broker, topic);
+    // set system.start.position in the metadata
+    datastream.getMetadata().put(DatastreamMetadataConstants.START_POSITION, JsonUtils.toJson(startOffsets));
+    // set system.auto.offset.reset strategy in metadata to ensure it is ignored in presence of start offsets
+    datastream.getMetadata().put(KafkaDatastreamMetadataConstants.CONSUMER_OFFSET_RESET_STRATEGY, "earliest");
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+    task.setEventProducer(datastreamProducer);
+
+    KafkaConnectorTask connectorTask = createKafkaConnectorTaskWithAutoOffsetResetConfig(task, "earliest");
+
+    // validate auto.offset.reset config is overridden to none (given the start offsets)
+    Assert.assertEquals(connectorTask.getConsumerAutoOffsetResetConfig(), "none");
+
 
     LOG.info("Sending third set of events");
 
@@ -446,6 +497,14 @@ public class TestKafkaConnectorTask extends BaseKafkaZkTest {
     datastream.setMetadata(new StringMap());
     datastream.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(datastream));
     return datastream;
+  }
+
+  private KafkaConnectorTask createKafkaConnectorTaskWithAutoOffsetResetConfig(DatastreamTaskImpl task,
+      String autoOffsetResetStrategy) throws InterruptedException {
+    Properties consumerProperties = new Properties();
+    consumerProperties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetResetStrategy);
+    return createKafkaConnectorTask(task, new KafkaBasedConnectorConfigBuilder()
+        .setConsumerProps(consumerProperties).build());
   }
 
   private KafkaConnectorTask createKafkaConnectorTask(DatastreamTaskImpl task) throws InterruptedException {


### PR DESCRIPTION
Please see https://github.com/linkedin/brooklin/issues/788 for a description of the problem
this changes addresses this issue by overriding the auto.offset.reset kafka consumer config and sets it to none whenever start offsets are set in the AbstractKafkaBasedConnectorTask, so that the set start offsets takes effect while handling the NoCheckpointForPartitoinException upon first poll (given that auto.offset.reset=none)
Modified unit test to verify the override, also validated from the logs of the run that added overriding logs are emitted.