### PR TITLE
Fix HttpClientFactory to use daemon threads for Callbacks

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
@@ -167,9 +167,12 @@ public final class BaseRestClientFactory<T> {
   private void initHttpClientFactory() {
     ThreadFactory eventLoopThreadFactory = new DaemonNamedThreadFactory("R2 Nio Event Loop");
     ThreadFactory schedExecThreadFactory = new DaemonNamedThreadFactory("R2 Netty Scheduler");
+    ThreadFactory callbackThreadFactory = new DaemonNamedThreadFactory("R2 Callback");
+
     _httpClientFactory = new HttpClientFactory.Builder()
         .setNioEventLoopGroup(new NioEventLoopGroup(0, eventLoopThreadFactory))
         .setScheduleExecutorService(Executors.newSingleThreadScheduledExecutor(schedExecThreadFactory))
+        .setCallbackExecutor(Executors.newSingleThreadExecutor(callbackThreadFactory))
         .build();
   }
 


### PR DESCRIPTION
Currently, Brooklin HttpClientFactory uses non-daemon threads for
executing user callbacks. This means the Http client never shutdown
as Brooklin doesnt provide shutdown functionality and jvm cannot
shutdown as we have a regular thread constantly running. The fix
is to provide daemon thread for callbacks which enables jvm to
shutdown. Please note that other threadpools are already using
daemon threads and we are expected to use daemon threads for
callbacks.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
