### PR TITLE
[DISCARD] Elastic task assignment should get and store the numTasks in ZooKeeper

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/strategy/AssignmentStrategy.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/strategy/AssignmentStrategy.java
@@ -8,6 +8,7 @@ package com.linkedin.datastream.server.api.strategy;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import org.apache.commons.lang.NotImplementedException;
@@ -49,9 +50,11 @@ public interface AssignmentStrategy {
    * @param datastreams all data streams defined in Datastream Management Service to be assigned
    * @param instances all live instances
    * @param currentAssignment existing assignment
+   * @param datastreamGroupNumTasksMap mapping of DatastreamGroup to its numTasks, either populated from ZK or cached
+   *                                   by the AssignmentStrategy
    */
   Map<String, Set<DatastreamTask>> assign(List<DatastreamGroup> datastreams, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignment);
+      Map<String, Set<DatastreamTask>> currentAssignment, Map<String, Integer> datastreamGroupNumTasksMap);
 
 
   /**
@@ -101,5 +104,17 @@ public interface AssignmentStrategy {
   default Map<String, List<DatastreamTask>> getTasksToCleanUp(List<DatastreamGroup> datastreams,
       Map<String, Set<DatastreamTask>> currentAssignment) {
     return Collections.emptyMap();
+  }
+
+  /**
+   * Get the cached number of tasks for a given DatastreamGroup. Returns 0 for assignment strategies that do not
+   * cache the number of tasks from ZK
+   *
+   * @param datastreamGroup The DatastreamGroup for which to return the cached numTasks
+   * @return the number of tasks for the DatastreamGroup cached by the assignment strategy. Returns Optional.empty() if
+   *         the DatastreamGroup's cached data is not present.
+   */
+  default Optional<Integer> getCachedNumTasksForDatastreamGroup(DatastreamGroup datastreamGroup) {
+    return Optional.of(0);
   }
 }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -409,6 +409,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
         if (DatastreamStatus.READY.equals(datastream.getStatus()) || DatastreamStatus.PAUSED.equals(datastream.getStatus())) {
           d.setStatus(DatastreamStatus.STOPPED);
           _store.updateDatastream(d.getName(), d, true);
+          _store.deleteDatastreamNumTasks(d.getName());
         } else {
           LOG.warn("Cannot stop datastream {}, as it is not in READY/PAUSED state. State: {}", d, datastream.getStatus());
         }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -55,4 +55,10 @@ public interface DatastreamStore {
    */
   void updatePartitionAssignments(String key, Datastream datastream, HostTargetAssignment hostTargetAssignment,
       boolean notifyLeader) throws DatastreamException;
+
+  /**
+   * Delete the numTasks znode of the datastream associated with the provided key
+   * @param key datastream name of the original datastream to be updated
+   */
+  void deleteDatastreamNumTasks(String key);
 }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
@@ -197,6 +197,21 @@ public class ZookeeperBackedDatastreamStore implements DatastreamStore {
     }
   }
 
+  @Override
+  public void deleteDatastreamNumTasks(String key) {
+    Validate.notNull(key, "null key");
+
+    String path = KeyBuilder.datastreamNumTasks(_cluster, key);
+
+    if (!_zkClient.exists(path)) {
+      LOG.warn("Trying to delete znode of datastream numTasks that does not exist. Datastream name: " + key);
+      return;
+    }
+
+    LOG.info("Deleting the zk path {} ", path);
+    _zkClient.delete(path);
+  }
+
   private void notifyLeaderOfDataChange() {
     String dmsPath = KeyBuilder.datastreams(_cluster);
     // Update the /dms to notify that coordinator needs to act on a deleted or changed datastream.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -53,7 +53,7 @@ public class BroadcastStrategy implements AssignmentStrategy {
 
   @Override
   public Map<String, Set<DatastreamTask>> assign(List<DatastreamGroup> datastreams, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignment) {
+      Map<String, Set<DatastreamTask>> currentAssignment, Map<String, Integer> datastreamGroupNumTasksMap) {
 
     int totalAssignedTasks = currentAssignment.values().stream().mapToInt(Set::size).sum();
     LOG.info("Assigning {} datastreams to {} instances with {} tasks", datastreams.size(), instances.size(),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -64,7 +64,7 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
 
   @Override
   public Map<String, Set<DatastreamTask>> assign(List<DatastreamGroup> datastreams, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignment) {
+      Map<String, Set<DatastreamTask>> currentAssignment, Map<String, Integer> datastreamGroupNumTasksMap) {
     LOG.info("Assign called with datastreams: {}, instances: {}, currentAssignment: {}", datastreams,
         instances, currentAssignment);
     // if there are no live instances, return empty assignment

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -91,7 +91,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
 
   @Override
   public Map<String, Set<DatastreamTask>> assign(List<DatastreamGroup> datastreams, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignment) {
+      Map<String, Set<DatastreamTask>> currentAssignment, Map<String, Integer> datastreamGroupNumTasksMap) {
 
     int totalAssignedTasks = currentAssignment.values().stream().mapToInt(Set::size).sum();
     LOG.info("Begin assign {} datastreams to {} instances with {} tasks", datastreams.size(), instances.size(),
@@ -127,7 +127,8 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
 
     // STEP 1: keep assignments from previous instances, if possible.
     for (DatastreamGroup dg : datastreams) {
-      int numTasks = constructExpectedNumberOfTasks(dg, instances, Collections.unmodifiableMap(currentAssignmentCopy));
+      int numTasks = constructExpectedNumberOfTasks(dg, instances,
+          datastreamGroupNumTasksMap.getOrDefault(dg.getTaskPrefix(), 0));
       setTaskCountForDatastreamGroup(dg.getTaskPrefix(), numTasks);
       Set<DatastreamTask> allAliveTasks = new HashSet<>();
       for (String instance : instances) {
@@ -251,7 +252,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
   }
 
   protected int constructExpectedNumberOfTasks(DatastreamGroup dg, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignmentCopy) {
+      Integer numTasksFromCacheOrZk) {
     return getNumTasks(dg, instances.size());
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -91,6 +91,11 @@ public final class KeyBuilder {
   private static final String TARGET_ASSIGNMENTS = TARGET_ASSIGNMENT_BASE + "/%s";
 
   /**
+   * numTasks information stored for each datastream using elastic task assignment
+   */
+  private static final String DATASTREAM_NUMTASKS = DATASTREAM + "/numTasks";
+
+  /**
    * Get the root level ZooKeeper znode of a Brooklin cluster
    * @param clusterName Brooklin cluster name
    */
@@ -193,6 +198,19 @@ public final class KeyBuilder {
   }
 
   /**
+   * Get the ZooKeeeper znode for numTasks of a specific datastream in a Brooklin cluster
+   * This node will only be present for datastreams using elastic task assignment
+   *
+   * <pre>Example: /{cluster}/dms/{datastreamName}/numTasks</pre>
+   *
+   * @param cluster Brooklin cluster name
+   * @param stream Datastream name
+   */
+  public static String datastreamNumTasks(String cluster, String stream) {
+    return String.format(DATASTREAM_NUMTASKS, cluster, stream);
+  }
+
+  /**
    * Get the ZooKeeper znode for a specific connector enabled in a Brooklin cluster
    * @param cluster Brooklin cluster name
    * @param connectorType Connector
@@ -268,7 +286,6 @@ public final class KeyBuilder {
     // taskId could be empty space, which can result in "//" in the path
     return String.format(DATASTREAM_TASK_STATE_KEY, cluster, connectorType, datastreamTask, key).replaceAll("//", "/");
   }
-
 
   /**
    * Get the ZooKeeper path to store lock

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -1294,6 +1294,57 @@ public class ZkAdapter {
   }
 
   /**
+   * Check if the numTasks node exists for a given datastream
+   */
+  public boolean checkIfNumTasksExistForDatastream(String stream) {
+    String numTasksPath = KeyBuilder.datastreamNumTasks(_cluster, stream);
+    return _zkclient.exists(numTasksPath);
+  }
+
+  /**
+   * Create or update the numTasks node for a given datastream
+   */
+  public void createOrUpdateNumTasksForDatastream(String stream, int numTasks) {
+    _zkclient.ensurePath(KeyBuilder.datastream(_cluster, stream));
+    String numTasksPath = KeyBuilder.datastreamNumTasks(_cluster, stream);
+    if (!_zkclient.exists(numTasksPath)) {
+      _zkclient.create(numTasksPath, String.valueOf(numTasks), CreateMode.PERSISTENT);
+      LOG.info("{} successfully created the numTasks znode for datastream {} with value {}", _instanceName, stream,
+          numTasks);
+      return;
+    }
+    _zkclient.writeData(numTasksPath, String.valueOf(numTasks));
+  }
+
+  /**
+   * Get the numTasks node for a given datastream
+   */
+  public int getNumTasksForDatastream(String stream) {
+    String numTasksPath = KeyBuilder.datastreamNumTasks(_cluster, stream);
+
+    if (!_zkclient.exists(numTasksPath)) {
+      return 0;
+    }
+
+    return Integer.parseInt(_zkclient.readData(numTasksPath));
+  }
+
+  /**
+   * Delete the numTasks node for a given datastream
+   */
+  public void deleteNumTasksForDatastream(String stream) {
+    String numTasksPath = KeyBuilder.datastreamNumTasks(_cluster, stream);
+
+    if (!_zkclient.exists(numTasksPath)) {
+      LOG.warn("trying to delete znode of datastream numTasks that does not exist. Datastream name: " + stream);
+      return;
+    }
+
+    LOG.info("Deleting the zk path {} ", numTasksPath);
+    _zkclient.delete(numTasksPath);
+  }
+
+  /**
    * Clean up partition movement info for a particular datastream
    * @param connectorType Connector name
    * @param datastreamGroupName the name of datastream group

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -1314,6 +1314,8 @@ public class ZkAdapter {
       return;
     }
     _zkclient.writeData(numTasksPath, String.valueOf(numTasks));
+    LOG.info("{} successfully updated the numTasks znode for datastream {} with value {}", _instanceName, stream,
+        numTasks);
   }
 
   /**
@@ -1336,7 +1338,7 @@ public class ZkAdapter {
     String numTasksPath = KeyBuilder.datastreamNumTasks(_cluster, stream);
 
     if (!_zkclient.exists(numTasksPath)) {
-      LOG.warn("trying to delete znode of datastream numTasks that does not exist. Datastream name: " + stream);
+      LOG.warn("Trying to delete znode of datastream numTasks that does not exist. Datastream name: " + stream);
       return;
     }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -70,7 +71,8 @@ public class TestLoadbalancingStrategy {
     List<DatastreamGroup> datastreams = Collections.singletonList(new DatastreamGroup(Collections.singletonList(ds1)));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>(),
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
     }
@@ -87,7 +89,8 @@ public class TestLoadbalancingStrategy {
     strategyProps.put(LoadbalancingStrategy.CFG_MIN_TASKS, "12");
     LoadbalancingStrategy strategy = new LoadbalancingStrategy(strategyProps);
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>(),
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 4);
     }
@@ -102,7 +105,8 @@ public class TestLoadbalancingStrategy {
     List<DatastreamGroup> datastreams = Collections.singletonList(new DatastreamGroup(Collections.singletonList(ds1)));
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>(),
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     List<String> sortedInstances = Arrays.asList(instances);
     Collections.sort(sortedInstances);
@@ -122,7 +126,8 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>(),
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
@@ -131,7 +136,8 @@ public class TestLoadbalancingStrategy {
 
     String[] newInstances = new String[]{"instance1", "instance2"};
     Map<String, Set<DatastreamTask>> newAssignment =
-        strategy.assign(datastreams, Arrays.asList(newInstances), assignment);
+        strategy.assign(datastreams, Arrays.asList(newInstances), assignment,
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     Assert.assertEquals(newAssignment.get(newInstances[0]).size(), 3);
     Assert.assertEquals(newAssignment.get(newInstances[1]).size(), 3);
@@ -147,7 +153,8 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>(),
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
@@ -157,7 +164,8 @@ public class TestLoadbalancingStrategy {
     // Simulate some data corruption.
     assignment.get(instances[0]).clear();
     Map<String, Set<DatastreamTask>> newAssignment =
-        strategy.assign(datastreams, Arrays.asList(instances), assignment);
+        strategy.assign(datastreams, Arrays.asList(instances), assignment,
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     // For the moment the assumption is that the system will not create new tasks
     // and just re-distribute the existing tasks over all the instances.
@@ -176,7 +184,8 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>(),
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
@@ -185,7 +194,8 @@ public class TestLoadbalancingStrategy {
 
     String[] newInstances = new String[]{"instance1", "instance2", "instance3", "instance4"};
     Map<String, Set<DatastreamTask>> newAssignment =
-        strategy.assign(datastreams, Arrays.asList(newInstances), assignment);
+        strategy.assign(datastreams, Arrays.asList(newInstances), assignment,
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     for (String instance : newInstances) {
       Assert.assertEquals(newAssignment.get(instance).size(), 1);
@@ -202,7 +212,8 @@ public class TestLoadbalancingStrategy {
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
     Map<String, Set<DatastreamTask>> assignment =
-        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>());
+        strategy.assign(datastreams, Arrays.asList(instances), new HashMap<>(),
+            constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 2);
@@ -215,7 +226,8 @@ public class TestLoadbalancingStrategy {
     ds2.getSource().setPartitions(12);
     datastreams.add(new DatastreamGroup(Collections.singletonList(ds2)));
 
-    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, Arrays.asList(instances), assignment,
+        constructDatastreamGroupToNumTaskMapping(strategy, datastreams));
 
     for (String instance : instances) {
       Assert.assertEquals(newAssignment.get(instance).size(), 4);
@@ -235,7 +247,8 @@ public class TestLoadbalancingStrategy {
         datastreams.stream().map(x -> new DatastreamGroup(Collections.singletonList(x))).collect(Collectors.toList());
     LoadbalancingStrategy strategy = new LoadbalancingStrategy();
     ZkAdapter adapter = createMockAdapter();
-    Map<String, Set<DatastreamTask>> assignment = strategy.assign(dgs, Arrays.asList(instances), new HashMap<>());
+    Map<String, Set<DatastreamTask>> assignment = strategy.assign(dgs, Arrays.asList(instances), new HashMap<>(),
+        constructDatastreamGroupToNumTaskMapping(strategy, dgs));
 
     for (String instance : instances) {
       Assert.assertEquals(assignment.get(instance).size(), 4);
@@ -245,10 +258,22 @@ public class TestLoadbalancingStrategy {
     dgs = new ArrayList<>(dgs);
     dgs.remove(1);
 
-    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(dgs, Arrays.asList(instances), assignment);
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(dgs, Arrays.asList(instances), assignment,
+        constructDatastreamGroupToNumTaskMapping(strategy, dgs));
 
     for (String instance : instances) {
       Assert.assertEquals(newAssignment.get(instance).size(), 2);
     }
+  }
+
+  private Map<String, Integer> constructDatastreamGroupToNumTaskMapping(LoadbalancingStrategy strategy,
+      List<DatastreamGroup> datastreamGroups) {
+    Map<String, Integer> datastreamGroupNumTasksMap = new HashMap<>();
+    for (DatastreamGroup dg : datastreamGroups) {
+      String taskPrefix = dg.getTaskPrefix();
+      Optional<Integer> cachedNumTasks = strategy.getCachedNumTasksForDatastreamGroup(dg);
+      datastreamGroupNumTasksMap.put(taskPrefix, cachedNumTasks.orElse(0));
+    }
+    return datastreamGroupNumTasksMap;
   }
 }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -188,4 +188,19 @@ public class DatastreamTestUtils {
       dsStore.updateDatastream(datastream.getName(), datastream, true);
     }
   }
+
+  /**
+   * Deletes the datastreams' numTasks znode from ZooKeeper if present.
+   * @param zkClient ZooKeeper client
+   * @param cluster name of the datastream cluster
+   * @param datastreams list of datastreams
+   */
+  public static void deleteDatastreamsNumTasks(ZkClient zkClient, String cluster, String... datastreams) {
+    for (String datastreamName : datastreams) {
+      zkClient.ensurePath(KeyBuilder.datastreams(cluster));
+      CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, cluster);
+      ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, cluster);
+      dsStore.deleteDatastreamNumTasks(datastreamName);
+    }
+  }
 }


### PR DESCRIPTION
Elastic task assignment elastically figures out the number of tasks needed for supporting a limited number of partitions per task. This PR stores this information in ZooKeeper for persistence across leader changes and across assignments.

There is no access to the ZkAdapter object from within the AssignmentStrategies, so this PR gets around this by adding APIs to get the cached numTasks from the AssignmentStrategy, fetch from ZK if this is not present, and update ZK if the expected numTasks changes. This also only triggers for datastreams where elastic task assignment is enabled.

The ZK node is created under: <cluster>/dms/<datastream name>/numTasks, where <datastream name> matches the datastream's TASK_PREFIX.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
