### PR TITLE
Elastic task assignment should get and store the numTasks in ZooKeeper

### DIFF
--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -409,6 +409,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
         if (DatastreamStatus.READY.equals(datastream.getStatus()) || DatastreamStatus.PAUSED.equals(datastream.getStatus())) {
           d.setStatus(DatastreamStatus.STOPPED);
           _store.updateDatastream(d.getName(), d, true);
+          _store.deleteDatastreamNumTasks(d.getName());
         } else {
           LOG.warn("Cannot stop datastream {}, as it is not in READY/PAUSED state. State: {}", d, datastream.getStatus());
         }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -55,4 +55,10 @@ public interface DatastreamStore {
    */
   void updatePartitionAssignments(String key, Datastream datastream, HostTargetAssignment hostTargetAssignment,
       boolean notifyLeader) throws DatastreamException;
+
+  /**
+   * Delete the numTasks znode of the datastream associated with the provided key
+   * @param key datastream name of the original datastream whose numTasks znode is to be deleted
+   */
+  void deleteDatastreamNumTasks(String key);
 }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -58,7 +58,7 @@ public interface DatastreamStore {
 
   /**
    * Delete the numTasks znode of the datastream associated with the provided key
-   * @param key datastream name of the original datastream whose numTasks znode is to be deleted
+   * @param key Name of the original datastream whose numTasks znode is to be deleted
    */
   void deleteDatastreamNumTasks(String key);
 }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
@@ -197,6 +197,21 @@ public class ZookeeperBackedDatastreamStore implements DatastreamStore {
     }
   }
 
+  @Override
+  public void deleteDatastreamNumTasks(String key) {
+    Validate.notNull(key, "null key");
+
+    String path = KeyBuilder.datastreamNumTasks(_cluster, key);
+
+    if (!_zkClient.exists(path)) {
+      LOG.warn("Trying to delete znode of datastream for which numTasks does not exist. Datastream name: " + key);
+      return;
+    }
+
+    LOG.info("Deleting the zk path {} ", path);
+    _zkClient.delete(path);
+  }
+
   private void notifyLeaderOfDataChange() {
     String dmsPath = KeyBuilder.datastreams(_cluster);
     // Update the /dms to notify that coordinator needs to act on a deleted or changed datastream.

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -973,11 +973,12 @@ public class TestCoordinator {
     connectors.add(connector2);
     connectors.add(connector3);
 
-    int minTasks = 3;
+    int minTasks = 4;
     Datastream[] datastreams = DatastreamTestUtils.createDatastreams(testConnectorType, "datastream42", "datastream43");
     for (Datastream ds : datastreams) {
       ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(ds));
       ds.getMetadata().put(StickyPartitionAssignmentStrategy.CFG_MIN_TASKS, String.valueOf(minTasks));
+      ds.getMetadata().put(DatastreamMetadataConstants.IS_CONNECTOR_MANAGED_DESTINATION_KEY, "true");
     }
     DatastreamTestUtils.storeDatastreams(zkClient, testCluster, datastreams);
 

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -783,6 +783,7 @@ public class TestCoordinator {
     String testCluster = "testCoordinationSmoke";
     String testConnectorType = "testConnectorType";
     Coordinator instance1 = createCoordinator(_zkConnectionString, testCluster);
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
 
     int initialDelays = 100;
 
@@ -796,23 +797,22 @@ public class TestCoordinator {
 
     //Question why the multicast strategy is within one coordinator rather than shared between list of coordinators
     instance1.addConnector(testConnectorType, connector1, new StickyPartitionAssignmentStrategy(Optional.of(4),
-            Optional.of(2), Optional.empty()), false, new SourceBasedDeduper(), null);
+            Optional.of(2), Optional.empty(), zkClient, testCluster), false, new SourceBasedDeduper(), null);
     instance1.start();
 
     Coordinator instance2 = createCoordinator(_zkConnectionString, testCluster);
     TestHookConnector connector2 = createConnectorWithPartitionListener("connector2", testConnectorType, partitions, initialDelays);
     instance2.addConnector(testConnectorType, connector2, new StickyPartitionAssignmentStrategy(Optional.of(4),
-            Optional.of(2), Optional.empty()), false, new SourceBasedDeduper(), null);
+            Optional.of(2), Optional.empty(), zkClient, testCluster), false, new SourceBasedDeduper(), null);
     instance2.start();
 
     Coordinator instance3 = createCoordinator(_zkConnectionString, testCluster);
     TestHookConnector connector3 = createConnectorWithPartitionListener("connector3", testConnectorType, partitions, initialDelays);
     instance3.addConnector(testConnectorType, connector3, new StickyPartitionAssignmentStrategy(Optional.of(4),
-            Optional.of(2), Optional.empty()), false,
+            Optional.of(2), Optional.empty(), zkClient, testCluster), false,
         new SourceBasedDeduper(), null);
     instance3.start();
 
-    ZkClient zkClient = new ZkClient(_zkConnectionString);
     List<TestHookConnector> connectors = new ArrayList<>();
     connectors.add(connector1);
     connectors.add(connector2);
@@ -928,6 +928,81 @@ public class TestCoordinator {
     return datastreamMap;
   }
 
+  @Test
+  public void testCoordinationWithElasticTaskAssignmentPartitionAssignment() throws Exception {
+    String testCluster = "testCoordinationSmokeElasticTask";
+    String testConnectorType = "testConnectorType";
+    Coordinator instance1 = createCoordinator(_zkConnectionString, testCluster);
+
+    int initialDelays = 100;
+
+    List<String> partitions1 = ImmutableList.of("t-0", "t-1", "t-2", "t-3", "t-4", "t-5", "t-6", "t-7", "t-8");
+    List<String> partitions2 = ImmutableList.of("p-0", "p-1", "p-2", "p-3", "t-0");
+    Map<String, List<String>> partitions = new HashMap<>();
+    partitions.put("datastream42", partitions1);
+    partitions.put("datastream43", partitions2);
+
+    TestHookConnector connector1 = createConnectorWithPartitionListener("connector1", testConnectorType, partitions, initialDelays);
+
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+
+    int partitionsPerTask = 4;
+    int fullnessFactorPct = 50;
+    instance1.addConnector(testConnectorType, connector1, new StickyPartitionAssignmentStrategy(Optional.empty(),
+        Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask),
+        Optional.of(fullnessFactorPct), zkClient, testCluster), false, new SourceBasedDeduper(), null);
+    instance1.start();
+
+    Coordinator instance2 = createCoordinator(_zkConnectionString, testCluster);
+    TestHookConnector connector2 = createConnectorWithPartitionListener("connector2", testConnectorType, partitions, initialDelays);
+    instance2.addConnector(testConnectorType, connector2, new StickyPartitionAssignmentStrategy(Optional.empty(),
+        Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask),
+        Optional.of(fullnessFactorPct), zkClient, testCluster), false, new SourceBasedDeduper(), null);
+    instance2.start();
+
+    Coordinator instance3 = createCoordinator(_zkConnectionString, testCluster);
+    TestHookConnector connector3 = createConnectorWithPartitionListener("connector3", testConnectorType, partitions, initialDelays);
+    instance3.addConnector(testConnectorType, connector3, new StickyPartitionAssignmentStrategy(Optional.empty(),
+            Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask),
+            Optional.of(fullnessFactorPct), zkClient, testCluster), false,
+        new SourceBasedDeduper(), null);
+    instance3.start();
+
+    List<TestHookConnector> connectors = new ArrayList<>();
+    connectors.add(connector1);
+    connectors.add(connector2);
+    connectors.add(connector3);
+
+    int minTasks = 3;
+    Datastream[] datastreams = DatastreamTestUtils.createDatastreams(testConnectorType, "datastream42", "datastream43");
+    for (Datastream ds : datastreams) {
+      ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(ds));
+      ds.getMetadata().put(StickyPartitionAssignmentStrategy.CFG_MIN_TASKS, String.valueOf(minTasks));
+    }
+    DatastreamTestUtils.storeDatastreams(zkClient, testCluster, datastreams);
+
+    Assert.assertTrue(waitTillAssignmentIsComplete(9, WAIT_TIMEOUT_MS, connectors.toArray(new TestHookConnector[connectors.size()])));
+
+    final long interval = Math.min(WAIT_TIMEOUT_MS, 1000);
+
+    Assert.assertTrue(
+        PollUtils.poll(() -> {
+          // Verify all the partitions are assigned
+          Map<String, List<String>> assignment2 = collectDatastreamPartitions(connectors);
+          return assignment2.get("datastream42").size() == partitions1.size() && assignment2.get("datastream43").size() == partitions2.size();
+        }, interval, WAIT_TIMEOUT_MS));
+
+    instance1.stop();
+    instance2.stop();
+    instance3.stop();
+
+    DatastreamTestUtils.deleteDatastreamsNumTasks(zkClient, testCluster, "datastream42", "datastream43");
+
+    zkClient.close();
+    instance1.getDatastreamCache().getZkclient().close();
+    instance2.getDatastreamCache().getZkclient().close();
+    instance3.getDatastreamCache().getZkclient().close();
+  }
 
   /**
    * Test Datastream create with BYOT where destination is in use by another datastream
@@ -1124,14 +1199,15 @@ public class TestCoordinator {
     TestHookConnector connector2 = new TestHookConnector("connector2", connectorType2);
 
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster);
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
 
-    coordinator.addConnector(connectorType1, connector1, new StickyPartitionAssignmentStrategy(Optional.of(4), Optional.empty(), Optional.empty()), false,
+    coordinator.addConnector(connectorType1, connector1, new StickyPartitionAssignmentStrategy(Optional.of(4),
+            Optional.empty(), Optional.empty(), zkClient, testCluster), false,
         new SourceBasedDeduper(), null);
     coordinator.addConnector(connectorType2, connector2, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
     coordinator.start();
 
-    ZkClient zkClient = new ZkClient(_zkConnectionString);
     List<TestHookConnector> connectors = new ArrayList<>();
     connectors.add(connector1);
     connectors.add(connector2);

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -797,19 +797,19 @@ public class TestCoordinator {
 
     //Question why the multicast strategy is within one coordinator rather than shared between list of coordinators
     instance1.addConnector(testConnectorType, connector1, new StickyPartitionAssignmentStrategy(Optional.of(4),
-            Optional.of(2), Optional.empty(), zkClient, testCluster), false, new SourceBasedDeduper(), null);
+            Optional.of(2), Optional.empty(), testCluster), false, new SourceBasedDeduper(), null);
     instance1.start();
 
     Coordinator instance2 = createCoordinator(_zkConnectionString, testCluster);
     TestHookConnector connector2 = createConnectorWithPartitionListener("connector2", testConnectorType, partitions, initialDelays);
     instance2.addConnector(testConnectorType, connector2, new StickyPartitionAssignmentStrategy(Optional.of(4),
-            Optional.of(2), Optional.empty(), zkClient, testCluster), false, new SourceBasedDeduper(), null);
+            Optional.of(2), Optional.empty(), testCluster), false, new SourceBasedDeduper(), null);
     instance2.start();
 
     Coordinator instance3 = createCoordinator(_zkConnectionString, testCluster);
     TestHookConnector connector3 = createConnectorWithPartitionListener("connector3", testConnectorType, partitions, initialDelays);
     instance3.addConnector(testConnectorType, connector3, new StickyPartitionAssignmentStrategy(Optional.of(4),
-            Optional.of(2), Optional.empty(), zkClient, testCluster), false,
+            Optional.of(2), Optional.empty(), testCluster), false,
         new SourceBasedDeduper(), null);
     instance3.start();
 
@@ -950,21 +950,21 @@ public class TestCoordinator {
     int fullnessFactorPct = 50;
     instance1.addConnector(testConnectorType, connector1, new StickyPartitionAssignmentStrategy(Optional.empty(),
         Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask),
-        Optional.of(fullnessFactorPct), zkClient, testCluster), false, new SourceBasedDeduper(), null);
+        Optional.of(fullnessFactorPct), Optional.of(zkClient), testCluster), false, new SourceBasedDeduper(), null);
     instance1.start();
 
     Coordinator instance2 = createCoordinator(_zkConnectionString, testCluster);
     TestHookConnector connector2 = createConnectorWithPartitionListener("connector2", testConnectorType, partitions, initialDelays);
     instance2.addConnector(testConnectorType, connector2, new StickyPartitionAssignmentStrategy(Optional.empty(),
         Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask),
-        Optional.of(fullnessFactorPct), zkClient, testCluster), false, new SourceBasedDeduper(), null);
+        Optional.of(fullnessFactorPct), Optional.of(zkClient), testCluster), false, new SourceBasedDeduper(), null);
     instance2.start();
 
     Coordinator instance3 = createCoordinator(_zkConnectionString, testCluster);
     TestHookConnector connector3 = createConnectorWithPartitionListener("connector3", testConnectorType, partitions, initialDelays);
     instance3.addConnector(testConnectorType, connector3, new StickyPartitionAssignmentStrategy(Optional.empty(),
             Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask),
-            Optional.of(fullnessFactorPct), zkClient, testCluster), false,
+            Optional.of(fullnessFactorPct), Optional.of(zkClient), testCluster), false,
         new SourceBasedDeduper(), null);
     instance3.start();
 
@@ -1202,7 +1202,7 @@ public class TestCoordinator {
     ZkClient zkClient = new ZkClient(_zkConnectionString);
 
     coordinator.addConnector(connectorType1, connector1, new StickyPartitionAssignmentStrategy(Optional.of(4),
-            Optional.empty(), Optional.empty(), zkClient, testCluster), false,
+            Optional.empty(), Optional.empty(), testCluster), false,
         new SourceBasedDeduper(), null);
     coordinator.addConnector(connectorType2, connector2, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -127,8 +127,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
 
     // STEP 1: keep assignments from previous instances, if possible.
     for (DatastreamGroup dg : datastreams) {
-      int numTasks = constructExpectedNumberOfTasks(dg, instances, Collections.unmodifiableMap(currentAssignmentCopy));
-      setTaskCountForDatastreamGroup(dg.getTaskPrefix(), numTasks);
+      int numTasks = constructExpectedNumberOfTasks(dg, instances);
       Set<DatastreamTask> allAliveTasks = new HashSet<>();
       for (String instance : instances) {
         if (numTasks <= 0) {
@@ -250,9 +249,10 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
     }
   }
 
-  protected int constructExpectedNumberOfTasks(DatastreamGroup dg, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignmentCopy) {
-    return getNumTasks(dg, instances.size());
+  protected int constructExpectedNumberOfTasks(DatastreamGroup dg, List<String> instances) {
+    int numTasks = getNumTasks(dg, instances.size());
+    setTaskCountForDatastreamGroup(dg.getTaskPrefix(), numTasks);
+    return numTasks;
   }
 
   protected int getNumTasks(DatastreamGroup dg, int numInstances) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -557,8 +557,12 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
    * is enabled.
    */
   private void createOrUpdateNumTasksForDatastreamInZK(String stream, int numTasks) {
+    if (_zkClient == null) {
+      LOG.warn("Skip create/update of numTasks in ZK as elastic task assignment is disabled");
+      return;
+    }
+
     Validate.isTrue(_enableElasticTaskAssignment);
-    _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, stream));
     String numTasksPath = KeyBuilder.datastreamNumTasks(_clusterName, stream);
     if (!_zkClient.exists(numTasksPath)) {
       _zkClient.create(numTasksPath, String.valueOf(numTasks), CreateMode.PERSISTENT);
@@ -573,6 +577,11 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
    * Get the numTasks node for a given datastream. This should only be called if elastic task assignment is enabled.
    */
   private int getNumTasksForDatastreamFromZK(String stream) {
+    if (_zkClient == null) {
+      LOG.warn("Trying to get the numTasks from ZK even though elastic task assignment is disabled");
+      return 0;
+    }
+
     Validate.isTrue(_enableElasticTaskAssignment);
     String numTasksPath = KeyBuilder.datastreamNumTasks(_clusterName, stream);
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -19,15 +19,19 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
+import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamGroupPartitionsMetadata;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
+import com.linkedin.datastream.server.zk.KeyBuilder;
 
 import static com.linkedin.datastream.server.assignment.BroadcastStrategyFactory.CFG_MAX_TASKS;
 import static com.linkedin.datastream.server.assignment.StickyPartitionAssignmentStrategyFactory.CFG_PARTITIONS_PER_TASK;
@@ -65,6 +69,8 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
   private final Integer _maxPartitionPerTask;
   private final Integer _partitionsPerTask;
   private final Integer _partitionFullnessFactorPct;
+  private final ZkClient _zkClient;
+  private final String _clusterName;
 
   /**
    * Constructor for StickyPartitionAssignmentStrategy
@@ -88,20 +94,27 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
    * @param partitionFullnessFactorPct If elastic task assignment is enabled, this is used to determine how full to
    *                                   the tasks when fitting partitions into them for the first time. The default
    *                                   is {@value DEFAULT_PARTITION_FULLNESS_FACTOR_PCT}.
+   * @param zkClient The ZkClient to use for interaction with ZooKeeper
+   * @param clusterName The name of the Brooklin cluster
    *
    */
   public StickyPartitionAssignmentStrategy(Optional<Integer> maxTasks, Optional<Integer> imbalanceThreshold,
       Optional<Integer> maxPartitionPerTask, boolean enableElasticTaskAssignment, Optional<Integer> partitionsPerTask,
-      Optional<Integer> partitionFullnessFactorPct) {
+      Optional<Integer> partitionFullnessFactorPct, ZkClient zkClient, String clusterName) {
     super(maxTasks, imbalanceThreshold);
+    Validate.notNull(zkClient);
+    Validate.isTrue(!StringUtils.isBlank(clusterName));
+
     _enableElasticTaskAssignment = enableElasticTaskAssignment;
     _maxPartitionPerTask = maxPartitionPerTask.orElse(Integer.MAX_VALUE);
     _partitionsPerTask = partitionsPerTask.orElse(DEFAULT_PARTITIONS_PER_TASK);
     _partitionFullnessFactorPct = partitionFullnessFactorPct.orElse(DEFAULT_PARTITION_FULLNESS_FACTOR_PCT);
+    _zkClient = zkClient;
+    _clusterName = clusterName;
 
     LOG.info("Elastic task assignment is {}, partitionsPerTask: {}, partitionFullnessFactorPct: {}, "
-            + "maxPartitionPerTask: {}", _enableElasticTaskAssignment ? "enabled" : "disabled", _partitionsPerTask,
-        _partitionFullnessFactorPct, _maxPartitionPerTask);
+            + "maxPartitionPerTask: {}, cluster: {}", _enableElasticTaskAssignment ? "enabled" : "disabled",
+        _partitionsPerTask, _partitionFullnessFactorPct, _maxPartitionPerTask, _clusterName);
   }
 
   /**
@@ -116,11 +129,14 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
    *                           {@value DEFAULT_IMBALANCE_THRESHOLD}.
    * @param maxPartitionPerTask The maximum number of partitions allowed per task. By default it's Integer.MAX (no limit)
    *                            If partitions count in task is larger than this number, Brooklin will throw an exception
+   * @param zkClient The ZkClient to use for interaction with ZooKeeper
+   * @param clusterName The name of the Brooklin cluster
    *
    */
   public StickyPartitionAssignmentStrategy(Optional<Integer> maxTasks, Optional<Integer> imbalanceThreshold,
-      Optional<Integer> maxPartitionPerTask) {
-    this(maxTasks, imbalanceThreshold, maxPartitionPerTask, false, Optional.empty(), Optional.empty());
+      Optional<Integer> maxPartitionPerTask, ZkClient zkClient, String clusterName) {
+    this(maxTasks, imbalanceThreshold, maxPartitionPerTask, false, Optional.empty(), Optional.empty(), zkClient,
+        clusterName);
   }
 
   /**
@@ -417,11 +433,9 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
   }
 
   @Override
-  protected int constructExpectedNumberOfTasks(DatastreamGroup dg, List<String> instances,
-      Map<String, Set<DatastreamTask>> currentAssignment) {
+  protected int constructExpectedNumberOfTasks(DatastreamGroup dg, List<String> instances) {
     boolean enableElasticTaskAssignment = getEnableElasticTaskAssignment(dg);
-    // TODO: Fetch the number of tasks in ZK if needed
-    int numTasks = enableElasticTaskAssignment ? getTaskCountForDatastreamGroup(dg.getTaskPrefix()) :
+    int numTasks = enableElasticTaskAssignment ? getNumTasksFromCacheOrZK(dg.getTaskPrefix()) :
         getNumTasks(dg, instances.size());
 
     // Case 1: If elastic task assignment is disabled set the expected number of tasks to numTasks.
@@ -430,34 +444,26 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
       int minTasks = resolveConfigWithMetadata(dg, CFG_MIN_TASKS, 0);
       if (numTasks > 0) {
         // Case 2: elastic task enabled, numTasks > 0. This indicates that we already know how many tasks we should
-        // have. Return max(numTasks, minTasks) to ensure we have at least minTasks.
+        // have (fetched either from ZK or from the assignment strategy cache). On leader change, numTasks should be
+        // fetched from ZK. Return max(numTasks, minTasks) to ensure we have at least 'minTasks' number of tasks.
         expectedNumberOfTasks = Math.max(numTasks, minTasks);
       } else {
-        // Case 3: elastic task enabled, numTasks == 0. This can occur either on leader change, or if a datastream
-        // is added/restarted. On leadership change, we expect to find existing tasks, whereas for new/restarted
-        // datastreams we will have 0 tasks.
-        //
-        // In the current state, we trust the size of allAliveTasks() if present as the source of truth for the
-        // expected number of tasks. This may not always be correct, and this will be corrected by persisting the
-        // number of tasks to ZK when this value changes.
+        // Case 3: elastic task enabled, numTasks == 0. This can occur if a datastream is added/restarted. On restart,
+        // the ZK numTasks znode is deleted. If a datastream is deleted and recreated with the same name, it will
+        // also appear as a newly added datastream since on datastream delete the numTasks znode will be deleted.
+        // In this situation, the expected number of tasks is set to minTasks.
+        expectedNumberOfTasks = minTasks;
+      }
 
-        // Count the number of tasks present for this datastream
-        Set<DatastreamTask> allAliveTasks = new HashSet<>();
-        for (String instance : instances) {
-          List<DatastreamTask> foundDatastreamTasks =
-              Optional.ofNullable(currentAssignment.get(instance)).map(c ->
-                  c.stream().filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && !allAliveTasks.contains(x))
-                      .collect(Collectors.toList())).orElse(Collections.emptyList());
-          allAliveTasks.addAll(foundDatastreamTasks);
-        }
-        expectedNumberOfTasks = Math.max(allAliveTasks.size(), minTasks);
+      if (expectedNumberOfTasks != numTasks) {
+        createOrUpdateNumTasksForDatastream(dg.getTaskPrefix(), expectedNumberOfTasks);
       }
     }
 
-    LOG.info("Elastic task assignment is {} for datastream group {}, expected number of tasks {}",
-        enableElasticTaskAssignment ? "enabled" : "disabled", dg, expectedNumberOfTasks);
+    LOG.info("Elastic task assignment is {} for datastream group {}, expected number of tasks {}, original numTasks: {}",
+        enableElasticTaskAssignment ? "enabled" : "disabled", dg, expectedNumberOfTasks, numTasks);
 
-    // TODO: Store the number of tasks to ZK if needed
+    setTaskCountForDatastreamGroup(dg.getTaskPrefix(), expectedNumberOfTasks);
     return expectedNumberOfTasks;
   }
 
@@ -488,6 +494,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
       numTasksNeeded = maxTasks;
     }
     if (numTasksNeeded > totalTaskCount) {
+      createOrUpdateNumTasksForDatastream(datastreamPartitions.getDatastreamGroup().getTaskPrefix(), numTasksNeeded);
       setTaskCountForDatastreamGroup(datastreamPartitions.getDatastreamGroup().getTaskPrefix(), numTasksNeeded);
       throw new DatastreamRuntimeException(
           String.format("Not enough tasks. Existing tasks: %d, tasks needed: %d, total partitions: %d",
@@ -501,6 +508,14 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
     // and is greater than 0
     int minTasks = resolveConfigWithMetadata(datastreamGroup, CFG_MIN_TASKS, 0);
     return _enableElasticTaskAssignment && (minTasks > 0);
+  }
+
+  private int getNumTasksFromCacheOrZK(String taskPrefix) {
+    int numTasks = getTaskCountForDatastreamGroup(taskPrefix);
+    if (numTasks <= 0) {
+      numTasks = getNumTasksForDatastream(taskPrefix);
+    }
+    return numTasks;
   }
 
   /**
@@ -532,5 +547,42 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
       LOG.error(errorMsg);
       throw new DatastreamRuntimeException(errorMsg);
     }
+  }
+
+  /**
+   * Check if the numTasks node exists for a given datastream
+   */
+  private boolean checkIfNumTasksExistForDatastream(String stream) {
+    String numTasksPath = KeyBuilder.datastreamNumTasks(_clusterName, stream);
+    return _zkClient.exists(numTasksPath);
+  }
+
+  /**
+   * Create or update the numTasks node for a given datastream
+   */
+  private void createOrUpdateNumTasksForDatastream(String stream, int numTasks) {
+    _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, stream));
+    String numTasksPath = KeyBuilder.datastreamNumTasks(_clusterName, stream);
+    if (!_zkClient.exists(numTasksPath)) {
+      _zkClient.create(numTasksPath, String.valueOf(numTasks), CreateMode.PERSISTENT);
+      LOG.info("Successfully created the numTasks znode for datastream {} with value {}", stream, numTasks);
+      return;
+    }
+    _zkClient.writeData(numTasksPath, String.valueOf(numTasks));
+    LOG.info("Successfully updated the numTasks znode for datastream {} with value {}", stream, numTasks);
+  }
+
+  /**
+   * Get the numTasks node for a given datastream
+   */
+  private int getNumTasksForDatastream(String stream) {
+    String numTasksPath = KeyBuilder.datastreamNumTasks(_clusterName, stream);
+
+    if (!_zkClient.exists(numTasksPath)) {
+      LOG.info("The numTasks znode does not exist for stream {}, returning 0", stream);
+      return 0;
+    }
+
+    return Integer.parseInt(_zkClient.readData(numTasksPath));
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -459,7 +459,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
       }
 
       if (expectedNumberOfTasks != numTasks) {
-        createOrUpdateNumTasksForDatastream(dg.getTaskPrefix(), expectedNumberOfTasks);
+        createOrUpdateNumTasksForDatastreamInZK(dg.getTaskPrefix(), expectedNumberOfTasks);
       }
     }
 
@@ -497,7 +497,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
       numTasksNeeded = maxTasks;
     }
     if (numTasksNeeded > totalTaskCount) {
-      createOrUpdateNumTasksForDatastream(datastreamPartitions.getDatastreamGroup().getTaskPrefix(), numTasksNeeded);
+      createOrUpdateNumTasksForDatastreamInZK(datastreamPartitions.getDatastreamGroup().getTaskPrefix(), numTasksNeeded);
       setTaskCountForDatastreamGroup(datastreamPartitions.getDatastreamGroup().getTaskPrefix(), numTasksNeeded);
       throw new DatastreamRuntimeException(
           String.format("Not enough tasks. Existing tasks: %d, tasks needed: %d, total partitions: %d",
@@ -516,7 +516,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
   private int getNumTasksFromCacheOrZK(String taskPrefix) {
     int numTasks = getTaskCountForDatastreamGroup(taskPrefix);
     if (numTasks <= 0) {
-      numTasks = getNumTasksForDatastream(taskPrefix);
+      numTasks = getNumTasksForDatastreamFromZK(taskPrefix);
     }
     return numTasks;
   }
@@ -556,7 +556,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
    * Create or update the numTasks node for a given datastream. This should only be called if elastic task assignment
    * is enabled.
    */
-  private void createOrUpdateNumTasksForDatastream(String stream, int numTasks) {
+  private void createOrUpdateNumTasksForDatastreamInZK(String stream, int numTasks) {
     Validate.isTrue(_enableElasticTaskAssignment);
     _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, stream));
     String numTasksPath = KeyBuilder.datastreamNumTasks(_clusterName, stream);
@@ -572,7 +572,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy {
   /**
    * Get the numTasks node for a given datastream. This should only be called if elastic task assignment is enabled.
    */
-  private int getNumTasksForDatastream(String stream) {
+  private int getNumTasksForDatastreamFromZK(String stream) {
     Validate.isTrue(_enableElasticTaskAssignment);
     String numTasksPath = KeyBuilder.datastreamNumTasks(_clusterName, stream);
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategyFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategyFactory.java
@@ -9,6 +9,7 @@ import java.util.Optional;
 import java.util.Properties;
 
 import com.linkedin.datastream.common.VerifiableProperties;
+import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.server.api.strategy.AssignmentStrategy;
 import com.linkedin.datastream.server.api.strategy.AssignmentStrategyFactory;
 
@@ -24,6 +25,10 @@ public class StickyPartitionAssignmentStrategyFactory implements AssignmentStrat
   public static final String CFG_PARTITIONS_PER_TASK = "partitionsPerTask";
   public static final String CFG_PARTITION_FULLNESS_THRESHOLD_PCT = "partitionFullnessThresholdPct";
   public static final String CFG_ENABLE_ELASTIC_TASK_ASSIGNMENT = "enableElasticTaskAssignment";
+  public static final String CFG_ZK_ADDRESS = "zkAddress";
+  public static final String CFG_ZK_SESSION_TIMEOUT = "zkSessionTimeout";
+  public static final String CFG_ZK_CONNECTION_TIMEOUT = "zkConnectionTimeout";
+  public static final String CFG_CLUSTER_NAME = "cluster";
 
   public static final boolean DEFAULT_ENABLE_ELASTIC_TASK_ASSIGNMENT = false;
 
@@ -47,7 +52,15 @@ public class StickyPartitionAssignmentStrategyFactory implements AssignmentStrat
         Optional.empty();
     Optional<Integer> partitionFullnessThresholdPct = cfgPartitionFullnessThresholdPct > 0 ?
         Optional.of(cfgPartitionFullnessThresholdPct) : Optional.empty();
+    String cluster = props.getString(CFG_CLUSTER_NAME);
+
+    // Create the ZooKeeper Client
+    String zkAddress = props.getString(CFG_ZK_ADDRESS);
+    int zkSessionTimeout = props.getInt(CFG_ZK_SESSION_TIMEOUT, ZkClient.DEFAULT_SESSION_TIMEOUT);
+    int zkConnectionTimeout = props.getInt(CFG_ZK_CONNECTION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
+    ZkClient zkClient = new ZkClient(zkAddress, zkSessionTimeout, zkConnectionTimeout);
+
     return new StickyPartitionAssignmentStrategy(maxTasks, imbalanceThreshold, maxPartitions,
-        enableElasticTaskAssignment, partitionsPerTask, partitionFullnessThresholdPct);
+        enableElasticTaskAssignment, partitionsPerTask, partitionFullnessThresholdPct, zkClient, cluster);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategyFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategyFactory.java
@@ -52,13 +52,16 @@ public class StickyPartitionAssignmentStrategyFactory implements AssignmentStrat
         Optional.empty();
     Optional<Integer> partitionFullnessThresholdPct = cfgPartitionFullnessThresholdPct > 0 ?
         Optional.of(cfgPartitionFullnessThresholdPct) : Optional.empty();
-    String cluster = props.getString(CFG_CLUSTER_NAME);
+    String cluster = props.getString(CFG_CLUSTER_NAME, null);
 
     // Create the ZooKeeper Client
-    String zkAddress = props.getString(CFG_ZK_ADDRESS);
-    int zkSessionTimeout = props.getInt(CFG_ZK_SESSION_TIMEOUT, ZkClient.DEFAULT_SESSION_TIMEOUT);
-    int zkConnectionTimeout = props.getInt(CFG_ZK_CONNECTION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
-    ZkClient zkClient = new ZkClient(zkAddress, zkSessionTimeout, zkConnectionTimeout);
+    Optional<ZkClient> zkClient = Optional.empty();
+    if (enableElasticTaskAssignment) {
+      String zkAddress = props.getString(CFG_ZK_ADDRESS);
+      int zkSessionTimeout = props.getInt(CFG_ZK_SESSION_TIMEOUT, ZkClient.DEFAULT_SESSION_TIMEOUT);
+      int zkConnectionTimeout = props.getInt(CFG_ZK_CONNECTION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT);
+      zkClient = Optional.of(new ZkClient(zkAddress, zkSessionTimeout, zkConnectionTimeout));
+    }
 
     return new StickyPartitionAssignmentStrategy(maxTasks, imbalanceThreshold, maxPartitions,
         enableElasticTaskAssignment, partitionsPerTask, partitionFullnessThresholdPct, zkClient, cluster);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategyFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategyFactory.java
@@ -8,13 +8,14 @@ package com.linkedin.datastream.server.assignment;
 import java.util.Optional;
 import java.util.Properties;
 
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.server.api.strategy.AssignmentStrategy;
 import com.linkedin.datastream.server.api.strategy.AssignmentStrategyFactory;
-import org.apache.commons.lang3.StringUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import static com.linkedin.datastream.server.assignment.BroadcastStrategyFactory.CFG_MAX_TASKS;
 import static com.linkedin.datastream.server.assignment.StickyMulticastStrategyFactory.CFG_IMBALANCE_THRESHOLD;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -91,6 +91,11 @@ public final class KeyBuilder {
   private static final String TARGET_ASSIGNMENTS = TARGET_ASSIGNMENT_BASE + "/%s";
 
   /**
+   * numTasks information stored for each datastream that uses elastic task assignment
+   */
+  private static final String DATASTREAM_NUMTASKS = DATASTREAM + "/numTasks";
+
+  /**
    * Get the root level ZooKeeper znode of a Brooklin cluster
    * @param clusterName Brooklin cluster name
    */
@@ -193,6 +198,19 @@ public final class KeyBuilder {
   }
 
   /**
+   * Get the ZooKeeeper znode for numTasks of a specific datastream in a Brooklin cluster
+   * This node will only be present for datastreams that use elastic task assignment
+   *
+   * <pre>Example: /{cluster}/dms/{datastreamName}/numTasks</pre>
+   *
+   * @param cluster Brooklin cluster name
+   * @param stream Datastream name
+   */
+  public static String datastreamNumTasks(String cluster, String stream) {
+    return String.format(DATASTREAM_NUMTASKS, cluster, stream);
+  }
+
+  /**
    * Get the ZooKeeper znode for a specific connector enabled in a Brooklin cluster
    * @param cluster Brooklin cluster name
    * @param connectorType Connector
@@ -268,7 +286,6 @@ public final class KeyBuilder {
     // taskId could be empty space, which can result in "//" in the path
     return String.format(DATASTREAM_TASK_STATE_KEY, cluster, connectorType, datastreamTask, key).replaceAll("//", "/");
   }
-
 
   /**
    * Get the ZooKeeper path to store lock

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
@@ -61,7 +61,7 @@ public class TestStickyPartitionAssignment {
   }
 
   @AfterMethod
-  public void teardown() throws IOException {
+  public void teardown() {
     _embeddedZookeeper.shutdown();
   }
 
@@ -72,7 +72,7 @@ public class TestStickyPartitionAssignment {
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy =
           new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(),
-              elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient, _clusterName);
+              elasticAssignmentEnabled, Optional.of(3), Optional.of(90), getZkClient(elasticAssignmentEnabled), _clusterName);
 
       Set<DatastreamTask> taskSet = new HashSet<>();
       List<DatastreamGroup> datastreams;
@@ -104,8 +104,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
-          _clusterName);
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90),
+          getZkClient(elasticAssignmentEnabled), _clusterName);
       Set<DatastreamTask> taskSet = new HashSet<>();
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
@@ -156,8 +156,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
-          _clusterName);
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90),
+          getZkClient(elasticAssignmentEnabled), _clusterName);
       Set<DatastreamTask> taskSet = new HashSet<>();
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
@@ -185,8 +185,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
-          _clusterName);
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90),
+          getZkClient(elasticAssignmentEnabled), _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 1);
@@ -209,8 +209,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
-          _clusterName);
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90),
+          getZkClient(elasticAssignmentEnabled), _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 2);
@@ -234,8 +234,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
-          _clusterName);
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90),
+          getZkClient(elasticAssignmentEnabled), _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 2);
@@ -273,8 +273,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
-          _clusterName);
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90),
+          getZkClient(elasticAssignmentEnabled), _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 2);
@@ -304,8 +304,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
-          _clusterName);
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90),
+          getZkClient(elasticAssignmentEnabled), _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 1, 2);
@@ -347,7 +347,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -378,7 +378,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 4 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -423,7 +423,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 4 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -527,7 +527,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -560,7 +560,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
     datastreams.forEach(datastreamGroup -> datastreamGroup.getDatastreams().get(0).getMetadata()
@@ -612,7 +612,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
     datastreams.forEach(datastreamGroup -> datastreamGroup.getDatastreams().get(0).getMetadata()
@@ -637,6 +637,49 @@ public class TestStickyPartitionAssignment {
     // negative minTasks
     assignment = strategy.assignPartitions(assignment, partitionsMetadata);
     Assert.assertEquals(assignment.get("instance1").size(), maxTasks);
+  }
+
+  @Test
+  public void testZkClientWithElasticTaskEnabledConfigMismatch() {
+    int partitionsPerTask = 2;
+    int fullnessFactorPct = 50;
+
+    // Enable elastic task assignment, and pass an empty ZkClient. This should throw.
+    Assert.assertThrows(IllegalArgumentException.class, () -> new StickyPartitionAssignmentStrategy(Optional.empty(),
+        Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct),
+        Optional.empty(), _clusterName));
+
+    // Disable elastic task assignment, and pass valid ZkClient. This should not throw.
+    new StickyPartitionAssignmentStrategy(Optional.empty(),
+        Optional.empty(), Optional.empty(), false, Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct),
+        Optional.of(_zkClient), _clusterName);
+
+    // Disable elastic task assignment, and pass an empty ZkClient. This should not throw.
+    new StickyPartitionAssignmentStrategy(Optional.empty(),
+        Optional.empty(), Optional.empty(), false, Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct),
+        Optional.empty(), _clusterName);
+  }
+
+  @Test
+  public void testClusterNameWithElasticTaskEnabledConfigMismatch() {
+    int partitionsPerTask = 2;
+    int fullnessFactorPct = 50;
+
+    // Pass null or blank clusterName while elastic task assignment is enabled. This should throw.
+    Assert.assertThrows(IllegalArgumentException.class, () -> new StickyPartitionAssignmentStrategy(Optional.empty(),
+        Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct),
+        Optional.of(_zkClient), null));
+
+    Assert.assertThrows(IllegalArgumentException.class, () -> new StickyPartitionAssignmentStrategy(Optional.empty(),
+        Optional.empty(), Optional.empty(), true, Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct),
+        Optional.of(_zkClient), ""));
+
+    // If elastic task assignment is disabled, it should not matter whether clusterName is null or has a valid value.
+    new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), false,
+        Optional.empty(), Optional.empty(), Optional.empty(), null);
+
+    new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), false,
+        Optional.empty(), Optional.empty(), Optional.empty(), _clusterName);
   }
 
   private void setupTaskLockForAssignment(Map<String, Set<DatastreamTask>> assignment) {
@@ -712,5 +755,9 @@ public class TestStickyPartitionAssignment {
       datastreams.add(new DatastreamGroup(Collections.singletonList(ds)));
     }
     return datastreams;
+  }
+
+  private Optional<ZkClient> getZkClient(boolean enableElasticTaskAssignment) {
+    return enableElasticTaskAssignment ? Optional.of(_zkClient) : Optional.empty();
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.datastream.server.assignment;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -16,6 +17,8 @@ import java.util.Optional;
 import java.util.Set;
 
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableList;
@@ -24,13 +27,16 @@ import com.google.common.collect.ImmutableSet;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
+import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamGroupPartitionsMetadata;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
+import com.linkedin.datastream.server.zk.KeyBuilder;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
+import com.linkedin.datastream.testutil.EmbeddedZookeeper;
 
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -41,6 +47,24 @@ import static org.mockito.Mockito.when;
  * Tests for {@link StickyPartitionAssignmentStrategy}
  */
 public class TestStickyPartitionAssignment {
+  private EmbeddedZookeeper _embeddedZookeeper;
+  private String _clusterName;
+  private ZkClient _zkClient;
+
+  @BeforeMethod
+  public void setup() throws IOException {
+    _clusterName = "testcluster";
+    _embeddedZookeeper = new EmbeddedZookeeper();
+    String zkConnectionString = _embeddedZookeeper.getConnection();
+    _embeddedZookeeper.startup();
+    _zkClient = new ZkClient(zkConnectionString);
+  }
+
+  @AfterMethod
+  public void teardown() throws IOException {
+    _embeddedZookeeper.shutdown();
+  }
+
   @Test
   public void testCreateAssignmentAcrossAllTasks() {
     Set<Boolean> elasticTaskAssignmentEnabledSet = new HashSet<>(Arrays.asList(true, false));
@@ -48,7 +72,7 @@ public class TestStickyPartitionAssignment {
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy =
           new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(),
-          elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+              elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient, _clusterName);
 
       Set<DatastreamTask> taskSet = new HashSet<>();
       List<DatastreamGroup> datastreams;
@@ -80,7 +104,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
+          _clusterName);
       Set<DatastreamTask> taskSet = new HashSet<>();
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
@@ -131,7 +156,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
+          _clusterName);
       Set<DatastreamTask> taskSet = new HashSet<>();
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
@@ -159,7 +185,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
+          _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 1);
@@ -182,7 +209,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
+          _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 2);
@@ -206,7 +234,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
+          _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 2);
@@ -244,7 +273,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
+          _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 2, 2);
@@ -274,7 +304,8 @@ public class TestStickyPartitionAssignment {
 
     elasticTaskAssignmentEnabledSet.forEach(elasticAssignmentEnabled -> {
       StickyPartitionAssignmentStrategy strategy = new StickyPartitionAssignmentStrategy(Optional.empty(),
-          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90));
+          Optional.empty(), Optional.empty(), elasticAssignmentEnabled, Optional.of(3), Optional.of(90), _zkClient,
+          _clusterName);
       List<DatastreamGroup> datastreams;
       if (elasticAssignmentEnabled) {
         datastreams = generateDatastreams("ds", 1, 2);
@@ -316,7 +347,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct));
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -347,7 +378,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 4 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct));
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -392,7 +423,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 4 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct));
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -451,6 +482,8 @@ public class TestStickyPartitionAssignment {
     // Pass an empty assignment to simulate a datastream restart which wipes out the tasks. The number of tasks needed
     // should be reassessed on the next assignment when we add the datastream back.
     assignment = Collections.emptyMap();
+    // Delete the ZK node for numTasks for this datastream to simulate deletion of this node on datastream stop.
+    _zkClient.delete(KeyBuilder.datastreamNumTasks(_clusterName, datastreams.get(0).getTaskPrefix()));
     // Pass an empty datastream list, since on datastream stop, we expect the stopped datastream to be filtered out
     // from the list of valid datastreams passed to the assign() call.
     assignment = strategy.assign(Collections.emptyList(), instances, assignment);
@@ -494,7 +527,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct));
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
 
@@ -527,7 +560,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct));
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
     datastreams.forEach(datastreamGroup -> datastreamGroup.getDatastreams().get(0).getMetadata()
@@ -579,7 +612,7 @@ public class TestStickyPartitionAssignment {
     // Create a strategy with partitionsPerTask = 2 and fullnessFactorPct as 50%
     StickyPartitionAssignmentStrategy strategy =
         new StickyPartitionAssignmentStrategy(Optional.empty(), Optional.empty(), Optional.empty(), true,
-            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct));
+            Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), _zkClient, _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
     datastreams.forEach(datastreamGroup -> datastreamGroup.getDatastreams().get(0).getMetadata()

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
@@ -350,6 +350,7 @@ public class TestStickyPartitionAssignment {
             Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
+    datastreams.forEach(dg -> _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, dg.getTaskPrefix())));
 
     Map<String, Set<DatastreamTask>> assignment = Collections.emptyMap();
     List<String> instances = new ArrayList<>();
@@ -381,6 +382,7 @@ public class TestStickyPartitionAssignment {
             Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
+    datastreams.forEach(dg -> _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, dg.getTaskPrefix())));
 
     Map<String, Set<DatastreamTask>> assignment = Collections.emptyMap();
     List<String> instances = new ArrayList<>();
@@ -426,6 +428,7 @@ public class TestStickyPartitionAssignment {
             Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
+    datastreams.forEach(dg -> _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, dg.getTaskPrefix())));
 
     Map<String, Set<DatastreamTask>> assignment = Collections.emptyMap();
     List<String> instances = new ArrayList<>();
@@ -530,6 +533,7 @@ public class TestStickyPartitionAssignment {
             Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
+    datastreams.forEach(dg -> _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, dg.getTaskPrefix())));
 
     Map<String, Set<DatastreamTask>> assignment = Collections.emptyMap();
     List<String> instances = new ArrayList<>();
@@ -563,8 +567,11 @@ public class TestStickyPartitionAssignment {
             Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
-    datastreams.forEach(datastreamGroup -> datastreamGroup.getDatastreams().get(0).getMetadata()
-        .put(BroadcastStrategyFactory.CFG_MAX_TASKS, String.valueOf(maxTasks)));
+    datastreams.forEach(datastreamGroup -> {
+      datastreamGroup.getDatastreams().get(0).getMetadata()
+          .put(BroadcastStrategyFactory.CFG_MAX_TASKS, String.valueOf(maxTasks));
+      _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, datastreamGroup.getTaskPrefix()));
+    });
 
     Map<String, Set<DatastreamTask>> assignment = Collections.emptyMap();
     List<String> instances = new ArrayList<>();
@@ -615,8 +622,11 @@ public class TestStickyPartitionAssignment {
             Optional.of(partitionsPerTask), Optional.of(fullnessFactorPct), Optional.of(_zkClient), _clusterName);
 
     List<DatastreamGroup> datastreams = generateDatastreams("ds", 1, minTasks);
-    datastreams.forEach(datastreamGroup -> datastreamGroup.getDatastreams().get(0).getMetadata()
-        .put(BroadcastStrategyFactory.CFG_MAX_TASKS, String.valueOf(maxTasks)));
+    datastreams.forEach(datastreamGroup -> {
+      datastreamGroup.getDatastreams().get(0).getMetadata()
+          .put(BroadcastStrategyFactory.CFG_MAX_TASKS, String.valueOf(maxTasks));
+      _zkClient.ensurePath(KeyBuilder.datastream(_clusterName, datastreamGroup.getTaskPrefix()));
+    });
 
     Map<String, Set<DatastreamTask>> assignment = Collections.emptyMap();
     List<String> instances = new ArrayList<>();

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -188,4 +188,19 @@ public class DatastreamTestUtils {
       dsStore.updateDatastream(datastream.getName(), datastream, true);
     }
   }
+
+  /**
+   * Deletes the datastreams' numTasks znode from ZooKeeper if present.
+   * @param zkClient ZooKeeper client
+   * @param cluster name of the datastream cluster
+   * @param datastreams list of datastreams
+   */
+  public static void deleteDatastreamsNumTasks(ZkClient zkClient, String cluster, String... datastreams) {
+    for (String datastreamName : datastreams) {
+      zkClient.ensurePath(KeyBuilder.datastreams(cluster));
+      CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, cluster);
+      ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, cluster);
+      dsStore.deleteDatastreamNumTasks(datastreamName);
+    }
+  }
 }


### PR DESCRIPTION
Elastic task assignment elastically figures out the number of tasks needed for supporting a limited number of partitions per task. This PR stores this information in ZooKeeper for persistence across leader changes and across assignments.

The assignment strategy creates a ZkClient to get and create/update the numTasks ZK Node.

The ZK node is created under: /dms//numTasks, where matches the datastream's TASK_PREFIX.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
