### PR TITLE
Add metrics for elastic task assignment

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/strategy/AssignmentStrategy.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/strategy/AssignmentStrategy.java
@@ -102,4 +102,10 @@ public interface AssignmentStrategy {
       Map<String, Set<DatastreamTask>> currentAssignment) {
     return Collections.emptyMap();
   }
+
+  /**
+   * Perform any strategy specific cleanup if required.
+   */
+  default void cleanupStrategy() {
+  }
 }

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2887,8 +2887,9 @@ public class TestCoordinator {
         new DummyTransportProviderAdminFactory().createTransportProviderAdmin(
             DummyTransportProviderAdminFactory.PROVIDER_NAME, new Properties()));
 
+    BroadcastStrategy mockStrategy = Mockito.spy(new BroadcastStrategy(Optional.empty()));
     TestHookConnector connector1 = new TestHookConnector("connector1", testConnectorType);
-    instance1.addConnector(testConnectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
+    instance1.addConnector(testConnectorType, connector1, mockStrategy, false,
         new SourceBasedDeduper(), null);
     instance1.start();
 
@@ -2905,6 +2906,7 @@ public class TestCoordinator {
     Thread t = instance1.getEventThread();
     Assert.assertFalse(t != null && t.isAlive());
     Assert.assertTrue(PollUtils.poll(instance1::isZkSessionExpired, 100, 30000));
+    verify(mockStrategy, times(1)).cleanupStrategy();
     instance1.stop();
     instance1.getDatastreamCache().getZkclient().close();
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1901,6 +1901,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       _dynamicMetricsManager.registerGauge(connectorName, NUM_DATASTREAM_TASKS,
           () -> connectorInfo.getConnector().getNumDatastreamTasks());
       _metricInfos.add(new BrooklinGaugeInfo(MetricRegistry.name(connectorName, NUM_DATASTREAM_TASKS)));
+
+      AssignmentStrategy strategy = connectorInfo.getAssignmentStrategy();
+      if (strategy instanceof MetricsAware) {
+        addMetricInfos((MetricsAware) strategy);
+      }
     }
 
     public List<BrooklinMetricInfo> getMetricInfos() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -337,7 +337,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     // Stopping all the connectors so that they stop producing.
     for (String connectorType : _connectors.keySet()) {
       try {
-        _connectors.get(connectorType).getConnector().stop();
+        ConnectorInfo connectorInfo = _connectors.get(connectorType);
+        connectorInfo.getConnector().stop();
+        connectorInfo.getAssignmentStrategy().cleanupStrategy();
       } catch (Exception ex) {
         _log.warn(String.format(
             "Connector stop threw an exception for connectorType %s, " + "Swallowing it and continuing shutdown.",
@@ -490,6 +492,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         .collect(Collectors.toList());
 
     onDatastreamChange(new ArrayList<>());
+
+    // Perform AssignmentStrategy cleanup for all the connectors
+    _connectors.values().forEach(connectorInfo -> {
+      connectorInfo.getAssignmentStrategy().cleanupStrategy();
+    });
+
     // Shutdown the event producer to stop any further production of records.
     // Event producer shutdown sequence does not need to wait for onAssignmentChange to complete.
     // This will ensure that even if any task thread does not respond to thread interruption, it will

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -281,4 +281,8 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
   protected int getTaskCountForDatastreamGroup(String taskPrefix) {
     return _taskCountPerDatastreamGroup.getOrDefault(taskPrefix, 0);
   }
+
+  protected void clearAllDatastreamGroupTaskCounts() {
+    _taskCountPerDatastreamGroup.clear();
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -502,8 +502,8 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
   private void updateOrRegisterElasticTaskAssignmentMetrics(DatastreamGroupPartitionsMetadata datastreamPartitions,
       int totalTaskCount) {
     int totalPartitions = datastreamPartitions.getPartitions().size();
-    int actualPartitionsPerTask = (totalTaskCount / totalPartitions)
-        + (((totalTaskCount % totalPartitions) == 0) ? 0 : 1);
+    int actualPartitionsPerTask = (totalPartitions / totalTaskCount)
+        + (((totalPartitions % totalTaskCount) == 0) ? 0 : 1);
 
     int partitionsPerTask = resolveConfigWithMetadata(datastreamPartitions.getDatastreamGroup(),
         CFG_PARTITIONS_PER_TASK, _partitionsPerTask);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -164,8 +164,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
         .collect(Collectors.toSet());
     _elasticTaskAssignmentInfoHashMap.keySet().forEach(datastreamTaskPrefix -> {
       if (!datastreamTaskPrefixes.contains(datastreamTaskPrefix)) {
-        DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, ACTUAL_PARTITIONS_PER_TASK);
-        DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, PARTITIONS_PER_TASK_NEEDS_ADJUSTMENT);
+        unregisterMetrics(datastreamTaskPrefix);
         _elasticTaskAssignmentInfoHashMap.remove(datastreamTaskPrefix);
       }
     });
@@ -471,10 +470,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
   @Override
   public void cleanupStrategy() {
     // Clear the maintained state and unregister the metrics
-    _elasticTaskAssignmentInfoHashMap.keySet().forEach(datastreamTaskPrefix -> {
-      DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, ACTUAL_PARTITIONS_PER_TASK);
-      DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, PARTITIONS_PER_TASK_NEEDS_ADJUSTMENT);
-    });
+    _elasticTaskAssignmentInfoHashMap.keySet().forEach(this::unregisterMetrics);
     _elasticTaskAssignmentInfoHashMap.clear();
     clearAllDatastreamGroupTaskCounts();
   }
@@ -684,6 +680,14 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
             && _elasticTaskAssignmentInfoHashMap.get(taskPrefix).getNeedsAdjustment()) ? 1.0 : 0.0;
     DYNAMIC_METRICS_MANAGER.registerGauge(CLASS_NAME, taskPrefix, PARTITIONS_PER_TASK_NEEDS_ADJUSTMENT,
         needsAdjustmentSupplier);
+  }
+
+  /**
+   * Unregister metrics for a given datastream group
+   */
+  private void unregisterMetrics(String datastreamTaskPrefix) {
+    DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, ACTUAL_PARTITIONS_PER_TASK);
+    DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, PARTITIONS_PER_TASK_NEEDS_ADJUSTMENT);
   }
 
   /**

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -197,7 +197,6 @@ public class DatastreamTestUtils {
    */
   public static void deleteDatastreamsNumTasks(ZkClient zkClient, String cluster, String... datastreams) {
     for (String datastreamName : datastreams) {
-      zkClient.ensurePath(KeyBuilder.datastreams(cluster));
       CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, cluster);
       ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, cluster);
       dsStore.deleteDatastreamNumTasks(datastreamName);


### PR DESCRIPTION
This PR adds metrics for elastic task assignment. The metrics track a) actual number of partitions/task, b) whether the actual partitions/task is above the configured partitionsPerTask.

It does this by having the StickyPartitionAssignmentStrategy implement the MetricsAware interface and pulling these into the Coordinator metrics.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
