### PR TITLE
Revert "Update pegasus version (#805)"

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -15,7 +15,7 @@ ext {
     metricsCoreVersion = "4.1.0"
     mockitoVersion = "1.10.19"
     parseqVersion = "2.6.31"
-    pegasusVersion = "29.14.0"
+    pegasusVersion = "29.2.3"
     scalaVersion = "2.11"
     slf4jVersion = "1.7.5"
     testngVersion = "7.1.0"


### PR DESCRIPTION
Change is causing failure in brooklin-li-common tests. Reverting so that
release can proceed until we debug the issue.

This reverts commit 239c4318e7adf6c7f1ed5a4eae2ab2885778d873.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
