### PR TITLE
Revert "Revert "Update pegasus version"" -- Keep the update to pegaus version 29.14.0

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -15,7 +15,7 @@ ext {
     metricsCoreVersion = "4.1.0"
     mockitoVersion = "1.10.19"
     parseqVersion = "2.6.31"
-    pegasusVersion = "29.2.3"
+    pegasusVersion = "29.14.0"
     scalaVersion = "2.11"
     slf4jVersion = "1.7.5"
     testngVersion = "7.1.0"


### PR DESCRIPTION
Reverts linkedin/brooklin#808
Incompatibility with avro on velocity module has been worked around.