### PR TITLE
Skip dependency check during lock acquire if there are no partitionV2 in dependency task

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -162,9 +162,14 @@ public class DatastreamTaskImpl implements DatastreamTask {
    * @param partitionsV2 new partitions for this task
    */
   public DatastreamTaskImpl(DatastreamTaskImpl predecessor, Collection<String> partitionsV2) {
+    _dependencies = new ArrayList<>();
     if (!predecessor.isLocked()) {
-      throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, "
-          + "the previous assignment has not been picked up");
+      if (!predecessor._partitionsV2.isEmpty()) {
+        throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, " +
+            "the previous assignment has not been picked up");
+      }
+    } else {
+      _dependencies.add(predecessor.getDatastreamTaskName());
     }
 
     _datastreams = predecessor._datastreams;
@@ -181,8 +186,6 @@ public class DatastreamTaskImpl implements DatastreamTask {
     _transportProviderName = predecessor._transportProviderName;
     _destinationSerDes = predecessor._destinationSerDes;
 
-    _dependencies = new ArrayList<>();
-    _dependencies.add(predecessor.getDatastreamTaskName());
     computeHashCode();
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -163,10 +163,11 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public DatastreamTaskImpl(DatastreamTaskImpl predecessor, Collection<String> partitionsV2) {
     _dependencies = new ArrayList<>();
-    if (!predecessor.isLocked() && !predecessor._partitionsV2.isEmpty()) {
-      throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, " +
-          "the previous assignment has not been picked up");
-    } else {
+    if (!predecessor._partitionsV2.isEmpty()) {
+      if (!predecessor.isLocked()) {
+        throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, " +
+            "the previous assignment has not been picked up");
+      }
       _dependencies.add(predecessor.getDatastreamTaskName());
     }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -163,11 +163,9 @@ public class DatastreamTaskImpl implements DatastreamTask {
    */
   public DatastreamTaskImpl(DatastreamTaskImpl predecessor, Collection<String> partitionsV2) {
     _dependencies = new ArrayList<>();
-    if (!predecessor.isLocked()) {
-      if (!predecessor._partitionsV2.isEmpty()) {
-        throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, " +
-            "the previous assignment has not been picked up");
-      }
+    if (!predecessor.isLocked() && !predecessor._partitionsV2.isEmpty()) {
+      throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, " +
+          "the previous assignment has not been picked up");
     } else {
       _dependencies.add(predecessor.getDatastreamTaskName());
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -256,7 +256,13 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
             throw new DatastreamRuntimeException(errorMessage);
           }
           if (partitionChanged) {
-            return new DatastreamTaskImpl((DatastreamTaskImpl) task, newPartitions);
+            try {
+              return new DatastreamTaskImpl((DatastreamTaskImpl) task, newPartitions);
+            } catch (Exception e) {
+              LOG.error("Hit exception while creating a new task from existing task: {} assigned to instance: {}",
+                  task.getDatastreamTaskName(), instance, e);
+              throw e;
+            }
           } else {
             return task;
           }
@@ -409,9 +415,15 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
         }
 
         if (partitionChanged) {
-          DatastreamTaskImpl newTask = new DatastreamTaskImpl((DatastreamTaskImpl) task, newPartitions);
-          extraDependencies.forEach(newTask::addDependency);
-          return newTask;
+          try {
+            DatastreamTaskImpl newTask = new DatastreamTaskImpl((DatastreamTaskImpl) task, newPartitions);
+            extraDependencies.forEach(newTask::addDependency);
+            return newTask;
+          } catch (Exception e) {
+            LOG.error("Hit exception while creating a new task from existing task: {} assigned to instance: {}",
+                task.getDatastreamTaskName(), instance, e);
+            throw e;
+          }
         } else {
           return task;
         }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -57,13 +57,16 @@ public class TestDatastreamTask {
     stream.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(stream));
 
     DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(stream));
-    task.setPartitionsV2(ImmutableList.of("partition1"));
 
     ZkAdapter mockZkAdapter = mock(ZkAdapter.class);
     task.setZkAdapter(mockZkAdapter);
-
-    task.addDependency(createDependencyTask(stream, true));
     when(mockZkAdapter.checkIsTaskLocked(anyString(), anyString(), anyString())).thenReturn(false);
+
+    DatastreamTaskImpl task2 = new DatastreamTaskImpl(task, new ArrayList<>());
+    Assert.assertEquals(new HashSet<>(task2.getDependencies()), Collections.emptySet());
+
+    task.setPartitionsV2(ImmutableList.of("partition1"));
+    task.addDependency(createDependencyTask(stream, true));
     Assert.assertThrows(DatastreamTransientException.class, () -> new DatastreamTaskImpl(task, new ArrayList<>()));
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestDatastreamTask.java
@@ -76,6 +76,7 @@ public class TestDatastreamTask {
     stream.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, DatastreamTaskImpl.getTaskPrefix(stream));
 
     DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(stream));
+    task.setPartitionsV2(ImmutableList.of("partition1"));
 
     ZkAdapter mockZkAdapter = mock(ZkAdapter.class);
     task.setZkAdapter(mockZkAdapter);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignment.java
@@ -187,8 +187,13 @@ public class TestStickyPartitionAssignment {
       DatastreamGroupPartitionsMetadata partitionsMetadata =
           new DatastreamGroupPartitionsMetadata(datastreams.get(0), partitions);
 
+      Map<String, Set<DatastreamTask>> assignment2 = strategy.assignPartitions(assignment, partitionsMetadata);
+      assignment2.put("instance2", taskSet);
+      partitions = ImmutableList.of("t-0", "t-1", "t1-0", "t2-0");
+      DatastreamGroupPartitionsMetadata partitionsMetadata2 =
+          new DatastreamGroupPartitionsMetadata(datastreams.get(0), partitions);
       Assert.assertThrows(DatastreamRuntimeException.class,
-          () -> strategy.assignPartitions(assignment, partitionsMetadata));
+          () -> strategy.assignPartitions(assignment2, partitionsMetadata2));
     });
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -679,6 +679,7 @@ public class TestZkAdapter {
     task1.setId("3");
     task1.setConnectorType(connectorType);
     task1.setZkAdapter(adapter1);
+    task1.setPartitionsV2(ImmutableList.of("partition1"));
 
     List<DatastreamTask> tasks = new ArrayList<>();
     tasks.add(task1);


### PR DESCRIPTION
Currently, in `StickyPartitionAssignmentStrategy` while creation of new task during partition assignment from existing task checks for the dependency task to be in running state. It validates the running state by checking if the lock is acquired by this task. In case of slow/bad host, this lock will not be acquired, resulting in partition assignment failure. To avoid the scenario where the dependency is the one with no partition, ideally the new task does not need to set dependency on it. Dependency is set to ensure that no two tasks process the same partition at the same time. If the dependency does not have partition, then there is no need to set dependency.
