### PR TITLE
Adding hostname in zk connector path task nodes

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -635,6 +635,12 @@ public class ZkAdapter {
     // connector will receive onAssignmentChange() with the new task. If it tries
     // to acquire the task before the connector task node is created, this will
     // fail with NoNodeException since lock node hangs off of connector task node.
+    String taskPath =
+        KeyBuilder.connectorTask(_cluster, task.getConnectorType(), task.getDatastreamTaskName());
+    _zkclient.ensurePath(taskPath);
+    // For debugging partition assignment issues, adding hostnames to zk task nodes.
+    _zkclient.writeData(taskPath, instance);
+
     String taskConfigPath =
         KeyBuilder.datastreamTaskConfig(_cluster, task.getConnectorType(), task.getDatastreamTaskName());
     _zkclient.ensurePath(taskConfigPath);


### PR DESCRIPTION
For debugging of partition assignment issues, adding hostname in the zookeeper connector path's task nodes
