### PR TITLE
Migrate from bintray to jfrog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -22,7 +22,7 @@ allprojects {
   repositories {
     mavenCentral()
     maven {
-      url  "https://linkedin.bintray.com/maven"
+      url  "https://linkedin.jfrog.io/artifactory/open-source"
     }
     mavenLocal()
   }

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -6,7 +6,7 @@ repositories {
         }
         // For Rest.li's (pegasus) gradle plugin
         maven {
-            url "https://linkedin.bintray.com/maven"
+            url "https://linkedin.jfrog.io/artifactory/open-source"
         }
     }
 }
@@ -14,5 +14,7 @@ repositories {
 dependencies {
     classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
     classpath 'com.linkedin.pegasus:gradle-plugins:29.2.3'
+    // TODO Remove this dependency
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
 }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -5,6 +5,7 @@ allprojects {
 subprojects {
   apply plugin: 'maven-publish'
   apply plugin: 'com.jfrog.bintray'
+  apply plugin: 'com.jfrog.artifactory'
   apply plugin: 'pegasus'
 
   task sourcesJar(type: Jar) {
@@ -117,6 +118,32 @@ subprojects {
 
         version project.version
       }
+    }
+  }
+
+  // Artifactory publishing
+  artifactory {
+    //docs: https://www.jfrog.com/confluence/display/rtf/gradle+artifactory+plugin
+    contextUrl = 'https://linkedin.jfrog.io/artifactory'
+    publish {
+      repository {
+        repoKey = 'brooklin'
+        username = System.getenv('ARTIFACTORY_USER')
+        password = System.getenv('ARTIFACTORY_API_KEY')
+        maven = true
+      }
+
+      defaults {
+        publications('maven')
+      }
+    }
+  }
+
+  artifactoryPublish {
+    skip = project.hasProperty('artifactory.dryRun')
+
+    doFirst {
+      println "Publishing $jar.baseName to Artifactory (dryRun: $dryRun, repo: $repoName, publish: $publish)"
     }
   }
 


### PR DESCRIPTION
Bintray is getting deprecated from May 1st. So, moving from bintray to jfrog. Will publish another PR for artifactory.
