### PR TITLE
Fixed bug with incorrect partitionsPerTask config assignment for elastic task feature

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/PartitionAssignmentStrategyConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/PartitionAssignmentStrategyConfig.java
@@ -51,17 +51,17 @@ public final class PartitionAssignmentStrategyConfig {
     VerifiableProperties props = new VerifiableProperties(config);
     int cfgMaxTasks = props.getInt(CFG_MAX_TASKS, 0);
     int cfgImbalanceThreshold = props.getInt(CFG_IMBALANCE_THRESHOLD, 0);
-    int cfgMaxParitionsPerTask = props.getInt(CFG_MAX_PARTITION_PER_TASK, 0);
+    int cfgMaxPartitionsPerTask = props.getInt(CFG_MAX_PARTITION_PER_TASK, 0);
     int cfgPartitionsPerTask = props.getInt(CFG_PARTITIONS_PER_TASK, 0);
     int cfgPartitionFullnessThresholdPct = props.getIntInRange(CFG_PARTITION_FULLNESS_THRESHOLD_PCT, 0, 0, 100);
 
     // Set to Optional.empty() if the value is 0
     _maxTasks = cfgMaxTasks > 0 ? Optional.of(cfgMaxTasks) : Optional.empty();
     _imbalanceThreshold = cfgImbalanceThreshold > 0 ? Optional.of(cfgImbalanceThreshold) : Optional.empty();
-    _maxPartitions = cfgMaxParitionsPerTask > 0 ? Optional.of(cfgMaxParitionsPerTask) : Optional.empty();
+    _maxPartitions = cfgMaxPartitionsPerTask > 0 ? Optional.of(cfgMaxPartitionsPerTask) : Optional.empty();
     _enableElasticTaskAssignment = props.getBoolean(CFG_ENABLE_ELASTIC_TASK_ASSIGNMENT,
         DEFAULT_ENABLE_ELASTIC_TASK_ASSIGNMENT);
-    _partitionsPerTask = cfgPartitionsPerTask > 0 ? Optional.of(cfgMaxParitionsPerTask) :
+    _partitionsPerTask = cfgPartitionsPerTask > 0 ? Optional.of(cfgPartitionsPerTask) :
         Optional.empty();
     _partitionFullnessThresholdPct = cfgPartitionFullnessThresholdPct > 0 ?
         Optional.of(cfgPartitionFullnessThresholdPct) : Optional.empty();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestPartitionAssignmentStrategyConfig.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestPartitionAssignmentStrategyConfig.java
@@ -1,0 +1,90 @@
+/**
+ *  Copyright 2021 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server.assignment;
+
+import java.util.Optional;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static com.linkedin.datastream.server.assignment.BroadcastStrategyFactory.CFG_MAX_TASKS;
+import static com.linkedin.datastream.server.assignment.StickyMulticastStrategyFactory.CFG_IMBALANCE_THRESHOLD;
+
+
+/**
+ * Tests for {@link PartitionAssignmentStrategyConfig}
+ */
+public class TestPartitionAssignmentStrategyConfig {
+
+  private static final String CFG_MAX_PARTITION_PER_TASK_VALUE = "10";
+  private static final String CFG_IMBALANCE_THRESHOLD_VALUE = "90";
+  private static final String CFG_MAX_TASKS_VALUE = "20";
+  private static final String CFG_PARTITIONS_PER_TASK_VALUE = "15";
+  private static final String CFG_PARTITIONS_FULLNESS_THRESHOLD_PCT_VALUE = "75";
+  private static final String CFG_ENABLE_ELASTIC_TASK_ASSIGNMENT_VALUE = "true";
+  private static final String CFG_ZK_ADDRESS_VALUE = "dummyZk";
+  private static final String CFG_ZK_SESSION_TIMEOUT_VALUE = "1000";
+  private static final String CFG_ZK_CONNECTION_TIMEOUT_VALUE = "2000";
+  private static final String CFG_CLUSTER_NAME_VALUE = "dummyCluster";
+  private static final String INVALID_INTEGER_VALUE = "-1";
+
+
+  @Test
+  public void configValuesCorrectlyAssignedTest() {
+    Properties props = new Properties();
+    props.setProperty(CFG_MAX_TASKS, CFG_MAX_TASKS_VALUE);
+    props.setProperty(CFG_IMBALANCE_THRESHOLD, CFG_IMBALANCE_THRESHOLD_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_MAX_PARTITION_PER_TASK, CFG_MAX_PARTITION_PER_TASK_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_PARTITIONS_PER_TASK, CFG_PARTITIONS_PER_TASK_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_PARTITION_FULLNESS_THRESHOLD_PCT,
+        CFG_PARTITIONS_FULLNESS_THRESHOLD_PCT_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_ENABLE_ELASTIC_TASK_ASSIGNMENT,
+        CFG_ENABLE_ELASTIC_TASK_ASSIGNMENT_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_ZK_ADDRESS, CFG_ZK_ADDRESS_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_ZK_SESSION_TIMEOUT, CFG_ZK_SESSION_TIMEOUT_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_ZK_CONNECTION_TIMEOUT, CFG_ZK_CONNECTION_TIMEOUT_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_CLUSTER_NAME, CFG_CLUSTER_NAME_VALUE);
+
+    PartitionAssignmentStrategyConfig config = new PartitionAssignmentStrategyConfig(props);
+    Assert.assertEquals(config.getMaxTasks(), Optional.of(Integer.parseInt(CFG_MAX_TASKS_VALUE)));
+    Assert.assertEquals(config.getImbalanceThreshold(), Optional.of(Integer.parseInt(CFG_IMBALANCE_THRESHOLD_VALUE)));
+    Assert.assertEquals(config.getPartitionsPerTask(), Optional.of(Integer.parseInt(CFG_PARTITIONS_PER_TASK_VALUE)));
+    Assert.assertEquals(config.getMaxPartitions(), Optional.of(Integer.parseInt(CFG_MAX_PARTITION_PER_TASK_VALUE)));
+    Assert.assertEquals(config.getPartitionFullnessThresholdPct(),
+        Optional.of(Integer.parseInt(CFG_PARTITIONS_FULLNESS_THRESHOLD_PCT_VALUE)));
+    Assert.assertEquals(config.isElasticTaskAssignmentEnabled(),
+        Boolean.parseBoolean(CFG_ENABLE_ELASTIC_TASK_ASSIGNMENT_VALUE));
+    Assert.assertEquals(config.getZkAddress(), CFG_ZK_ADDRESS_VALUE);
+    Assert.assertEquals(config.getZkSessionTimeout(), Integer.parseInt(CFG_ZK_SESSION_TIMEOUT_VALUE));
+    Assert.assertEquals(config.getZkConnectionTimeout(), Integer.parseInt(CFG_ZK_CONNECTION_TIMEOUT_VALUE));
+    Assert.assertEquals(config.getCluster(), CFG_CLUSTER_NAME_VALUE);
+  }
+
+  @Test
+  public void configValuesRevertedToEmptyWhenInvalidTest() {
+    Properties props = new Properties();
+    props.setProperty(CFG_MAX_TASKS, INVALID_INTEGER_VALUE);
+    props.setProperty(CFG_IMBALANCE_THRESHOLD, INVALID_INTEGER_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_MAX_PARTITION_PER_TASK, INVALID_INTEGER_VALUE);
+    props.setProperty(PartitionAssignmentStrategyConfig.CFG_PARTITIONS_PER_TASK, INVALID_INTEGER_VALUE);
+
+    PartitionAssignmentStrategyConfig config = new PartitionAssignmentStrategyConfig(props);
+    Assert.assertEquals(config.getMaxTasks(), Optional.empty());
+    Assert.assertEquals(config.getImbalanceThreshold(), Optional.empty());
+    Assert.assertEquals(config.getMaxPartitions(), Optional.empty());
+    Assert.assertEquals(config.getPartitionsPerTask(), Optional.empty());
+  }
+
+  @Test
+  public void configValuesSetToDefaultWhenNotProvidedTest() {
+    PartitionAssignmentStrategyConfig config = new PartitionAssignmentStrategyConfig(new Properties());
+    Assert.assertEquals(config.getMaxTasks(), Optional.empty());
+    Assert.assertEquals(config.getImbalanceThreshold(), Optional.empty());
+    Assert.assertEquals(config.getMaxPartitions(), Optional.empty());
+    Assert.assertEquals(config.getPartitionsPerTask(), Optional.empty());
+  }
+}


### PR DESCRIPTION
- Fixed bug with incorrect partitionsPerTask config assignment for elastic task feature.
- Added tests for `PartitionAssignmentStrategeyConfig` file.
- Fixed typo in `maxPartitionsPerTask`.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
