### PR TITLE
Bump up LiKafkaVersion to pull in a version without the Kafka message format bump changes, fix build issue

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -102,6 +102,7 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     // TODO Get task count estimate based on throughput and pick a winner
     LoadBasedTaskCountEstimator estimator = new LoadBasedTaskCountEstimator(_taskCapacityMBps, _taskCapacityUtilizationPct);
     int maxTaskCount = estimator.getTaskCount(clusterThroughputInfo, Collections.emptyList(), Collections.emptyList());
+    LOG.info("Max task count obtained from estimator: {}", maxTaskCount);
 
     // TODO Get unassigned partitions
     // Calculating unassigned partitions

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -1,5 +1,5 @@
 ext {
-    LIKafkaVersion = "1.0.61"
+    LIKafkaVersion = "1.0.65"
     apacheHttpClientVersion = "4.5.3"
     avroVersion = "1.7.7"
     commonsCliVersion = "1.2"


### PR DESCRIPTION
This PR bumps up the LiKafkaVersion to 1.0.65 which reverts the changes made by Kafka team for the passthrough message format bump. This also fixes a findbugs build issue.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
