### PR TITLE
Publishing artifacts to JFrog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 }
 
 allprojects {
-  group = "com.github.datastream"
+  group = "com.linkedin.datastream"
 
   apply plugin: 'eclipse'
   apply plugin: 'idea'

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -59,7 +59,7 @@ subprojects {
 
             licenses {
               license {
-                name = 'Copyright 2021 Linkedin, All Rights Reserved'
+                name = 'Copyright 2019 Linkedin, All Rights Reserved'
                 url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
               }
             }
@@ -95,7 +95,7 @@ subprojects {
 
           licenses {
             license {
-              name = 'Copyright 2021 Linkedin, All Rights Reserved'
+              name = 'Copyright 2019 Linkedin, All Rights Reserved'
               url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }
@@ -130,7 +130,7 @@ subprojects {
 
           licenses {
             license {
-              name = 'Copyright 2021 Linkedin, All Rights Reserved'
+              name = 'Copyright 2019 Linkedin, All Rights Reserved'
               url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }
@@ -152,7 +152,7 @@ subprojects {
 
           licenses {
             license {
-              name = 'Copyright 2021 Linkedin, All Rights Reserved'
+              name = 'Copyright 2019 Linkedin, All Rights Reserved'
               url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "1.0.3-SNAPSHOT"
+  version = "1.2.0"
 }
 
 subprojects {
@@ -33,7 +33,8 @@ subprojects {
     classifier = "tests"
   }
 
-  def allPublications = ['mavenJava', 'dataTemplateJava']
+  def allPublications = ['mavenJava', 'dataTemplateJava', 'testDataTemplateJava']
+
   if (project.tasks.findByName("mainRestClientJar")) {
 
     task restClientSourceJar(type: Jar) {
@@ -50,6 +51,19 @@ subprojects {
           artifact javadocJar
 
           version project.version
+
+          pom {
+            name = 'Brooklin'
+            description = 'An extensible distributed system for reliable nearline data streaming at scale'
+            url = 'https://github.com/linkedin/brooklin'
+
+            licenses {
+              license {
+                name = 'Copyright 2019 Linkedin, All Rights Reserved'
+                url = 'https://github.com/linkedin/brooklin/blob/master/LICENSE'
+              }
+            }
+          }
         }
       }
     }
@@ -59,7 +73,7 @@ subprojects {
 
   publishing {
     publications {
-      mavenJava(MavenPublication) {
+      maven(MavenPublication) {
         from components.java
 
         artifact sourcesJar
@@ -108,6 +122,19 @@ subprojects {
         artifact javadocJar
 
         version project.version
+
+        pom {
+          name = 'Brooklin'
+          description = 'An extensible distributed system for reliable nearline data streaming at scale'
+          url = 'https://github.com/linkedin/brooklin'
+
+          licenses {
+            license {
+              name = 'Copyright 2019 Linkedin, All Rights Reserved'
+              url = 'https://github.com/linkedin/brooklin/blob/master/LICENSE'
+            }
+          }
+        }
       }
 
       testDataTemplateJava(MavenPublication) {
@@ -117,6 +144,19 @@ subprojects {
         artifact javadocJar
 
         version project.version
+
+        pom {
+          name = 'Brooklin'
+          description = 'An extensible distributed system for reliable nearline data streaming at scale'
+          url = 'https://github.com/linkedin/brooklin'
+
+          licenses {
+            license {
+              name = 'Copyright 2019 Linkedin, All Rights Reserved'
+              url = 'https://github.com/linkedin/brooklin/blob/master/LICENSE'
+            }
+          }
+        }
       }
     }
   }
@@ -134,7 +174,9 @@ subprojects {
       }
 
       defaults {
-        publications('maven')
+        allPublications.each {
+          publication -> publications(publication)
+        }
       }
     }
   }
@@ -143,7 +185,7 @@ subprojects {
     skip = project.hasProperty('artifactory.dryRun')
 
     doFirst {
-      println "Publishing $jar.baseName to Artifactory (dryRun: $dryRun, repo: $repoName, publish: $publish)"
+      println "Publishing $jar.baseName to Artifactory (dryRun: $skip), publish: $publish)"
     }
   }
 

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -55,12 +55,12 @@ subprojects {
           pom {
             name = 'Brooklin'
             description = 'An extensible distributed system for reliable nearline data streaming at scale'
-            url = 'https://github.com/linkedin/brooklin'
+            url = 'https://www.github.com/linkedin/brooklin'
 
             licenses {
               license {
                 name = 'Copyright 2019 Linkedin, All Rights Reserved'
-                url = 'https://github.com/linkedin/brooklin/blob/master/LICENSE'
+                url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
               }
             }
           }
@@ -86,7 +86,7 @@ subprojects {
         pom {
           name = 'Brooklin'
           description = 'An extensible distributed system for reliable nearline data streaming at scale'
-          url = 'https://github.com/linkedin/brooklin'
+          url = 'https://www.github.com/linkedin/brooklin'
 
           // Default packaging is jar, so only specify otherwise for non-jars
           if (project.pluginManager.hasPlugin('war')) {
@@ -96,7 +96,7 @@ subprojects {
           licenses {
             license {
               name = 'Copyright 2019 Linkedin, All Rights Reserved'
-              url = 'https://github.com/linkedin/brooklin/blob/master/LICENSE'
+              url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }
           developers {
@@ -110,7 +110,7 @@ subprojects {
           scm {
             connection = 'scm:git:git://github.com:linkedin/brooklin.git'
             developerConnection = 'scm:git:ssh://github.com:linkedin/brooklin.git'
-            url = 'https://github.com/linkedin/brooklin'
+            url = 'https://www.github.com/linkedin/brooklin'
           }
         }
       }
@@ -126,12 +126,12 @@ subprojects {
         pom {
           name = 'Brooklin'
           description = 'An extensible distributed system for reliable nearline data streaming at scale'
-          url = 'https://github.com/linkedin/brooklin'
+          url = 'https://www.github.com/linkedin/brooklin'
 
           licenses {
             license {
               name = 'Copyright 2019 Linkedin, All Rights Reserved'
-              url = 'https://github.com/linkedin/brooklin/blob/master/LICENSE'
+              url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }
         }
@@ -148,12 +148,12 @@ subprojects {
         pom {
           name = 'Brooklin'
           description = 'An extensible distributed system for reliable nearline data streaming at scale'
-          url = 'https://github.com/linkedin/brooklin'
+          url = 'https://www.github.com/linkedin/brooklin'
 
           licenses {
             license {
               name = 'Copyright 2019 Linkedin, All Rights Reserved'
-              url = 'https://github.com/linkedin/brooklin/blob/master/LICENSE'
+              url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }
         }
@@ -198,7 +198,7 @@ subprojects {
       name = 'brooklin'
       userOrg = 'linkedin'
       licenses = ['BSD 2-Clause']
-      vcsUrl = 'https://github.com/linkedin/brooklin'
+      vcsUrl = 'https://www.github.com/linkedin/brooklin'
       publicDownloadNumbers = true
       version {
         name = project.version

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -73,7 +73,7 @@ subprojects {
 
   publishing {
     publications {
-      maven(MavenPublication) {
+      mavenJava(MavenPublication) {
         from components.java
 
         artifact sourcesJar

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -59,7 +59,7 @@ subprojects {
 
             licenses {
               license {
-                name = 'Copyright 2019 Linkedin, All Rights Reserved'
+                name = 'Copyright 2021 Linkedin, All Rights Reserved'
                 url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
               }
             }
@@ -95,7 +95,7 @@ subprojects {
 
           licenses {
             license {
-              name = 'Copyright 2019 Linkedin, All Rights Reserved'
+              name = 'Copyright 2021 Linkedin, All Rights Reserved'
               url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }
@@ -130,7 +130,7 @@ subprojects {
 
           licenses {
             license {
-              name = 'Copyright 2019 Linkedin, All Rights Reserved'
+              name = 'Copyright 2021 Linkedin, All Rights Reserved'
               url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }
@@ -152,7 +152,7 @@ subprojects {
 
           licenses {
             license {
-              name = 'Copyright 2019 Linkedin, All Rights Reserved'
+              name = 'Copyright 2021 Linkedin, All Rights Reserved'
               url = 'https://www.github.com/linkedin/brooklin/blob/master/LICENSE'
             }
           }


### PR DESCRIPTION
As bintray is deprecated, adding support for pushing Brooklin artifacts to JFrog simultaneously with bintray. 

Running and Testing steps:
1. Publish artifacts to JFrog. (To be able to publish artifacts to JFrog, you need to create an account at JFrog and use your LinkedIn username and API key for pushing artifacts)
2. ELR (External Library Request) the necessary artifacts to the internal LinkedIn DDS repo from the private Brooklin repo at https://go/elr
3. Update the respective MP to pull the artifacts from the DDS external repo, for example (https://rb.corp.linkedin.com/r/2645764/diff/4/)
4. run mint validate && mint build on that MP to ensure it fetches all those libraries and passes all the tests.

FAQs:

a) Command to publish artifacts
`./gradlew artifactoryPublish`

b) How to find the artifacts? Any webpage which has all the artifacts
All the published artifacts can be found in the JFrog Brooklin repo at https://linkedin.jfrog.io/ui/repos/tree/General/brooklin

c) How does the versioning work for these artifacts?
We usually follow Semantic Versioning which is explained here, https://github.com/linkedin/brooklin/wiki/Developer-Guide. But along with that, we have to make sure that the newer version doesn't already exist in JFrog artifactory.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
