### PR TITLE
Implemented metrics for LoadBasedPartitionAssignmentStrategy

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
@@ -6,7 +6,6 @@
 package com.linkedin.datastream.server.assignment;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -41,8 +40,8 @@ import com.linkedin.datastream.server.PartitionThroughputInfo;
  * Performs partition assignment based on partition throughput information
  */
 public class LoadBasedPartitionAssigner implements MetricsAware {
-  private static final Logger LOG = LoggerFactory.getLogger(LoadBasedPartitionAssignmentStrategy.class.getName());
-  private static final String CLASS_NAME = LoadBasedPartitionAssignmentStrategy.class.getSimpleName();
+  private static final Logger LOG = LoggerFactory.getLogger(LoadBasedPartitionAssigner.class.getName());
+  private static final String CLASS_NAME = LoadBasedPartitionAssigner.class.getSimpleName();
   private static final DynamicMetricsManager DYNAMIC_METRICS_MANAGER = DynamicMetricsManager.getInstance();
   private static final String MIN_PARTITIONS_ACROSS_TASKS = "minPartitionsAcrossTasks";
   private static final String MAX_PARTITIONS_ACROSS_TASKS = "maxPartitionsAcrossTasks";
@@ -228,9 +227,13 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
    */
   @Override
   public List<BrooklinMetricInfo> getMetricInfos() {
+    List<BrooklinMetricInfo> metricInfos = new ArrayList<>();
     String prefix = CLASS_NAME + MetricsAware.KEY_REGEX;
-    return Arrays.asList(new BrooklinGaugeInfo(prefix + MIN_PARTITIONS_ACROSS_TASKS),
-        new BrooklinGaugeInfo(prefix + MAX_PARTITIONS_ACROSS_TASKS));
+
+    metricInfos.add(new BrooklinGaugeInfo(prefix + MIN_PARTITIONS_ACROSS_TASKS));
+    metricInfos.add(new BrooklinGaugeInfo(prefix + MAX_PARTITIONS_ACROSS_TASKS));
+
+    return Collections.unmodifiableList(metricInfos);
   }
 
   void cleanupMetrics() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -12,7 +12,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
@@ -24,12 +26,19 @@ import com.google.common.annotations.VisibleForTesting;
 import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.common.RetriesExhaustedException;
 import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
+import com.linkedin.datastream.metrics.BrooklinMeterInfo;
+import com.linkedin.datastream.metrics.BrooklinMetricInfo;
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.metrics.MetricsAware;
 import com.linkedin.datastream.server.ClusterThroughputInfo;
 import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamGroupPartitionsMetadata;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.Pair;
 import com.linkedin.datastream.server.providers.PartitionThroughputProvider;
+
+import static com.linkedin.datastream.server.assignment.LoadBasedPartitionAssigner.PartitionAssignmentStats;
 
 
 /**
@@ -38,12 +47,19 @@ import com.linkedin.datastream.server.providers.PartitionThroughputProvider;
  */
 public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignmentStrategy {
   private static final Logger LOG = LoggerFactory.getLogger(LoadBasedPartitionAssignmentStrategy.class.getName());
+  private static final String CLASS_NAME = LoadBasedPartitionAssignmentStrategy.class.getSimpleName();
+  private static final DynamicMetricsManager DYNAMIC_METRICS_MANAGER = DynamicMetricsManager.getInstance();
+  private static final String MIN_PARTITIONS_ACROSS_TASKS = "minPartitionsAcrossTasks";
+  private static final String MAX_PARTITIONS_ACROSS_TASKS = "maxPartitionsAcrossTasks";
+  private static final String THROUGHPUT_INFO_FETCH_RATE = "throughputInfoFetchRate";
 
   private final PartitionThroughputProvider _throughputProvider;
   private final int _taskCapacityMBps;
   private final int _taskCapacityUtilizationPct;
   private final int _throughputInfoFetchTimeoutMs;
   private final int _throughputInfoFetchRetryPeriodMs;
+  private final LoadBasedPartitionAssigner _assigner;
+  private final Map<String, LoadBasedPartitionAssigner.PartitionAssignmentStats> _partitionAssignmentStatsMap;
 
   // TODO Make these configurable
   private final boolean _enableThroughputBasedPartitionAssignment = true;
@@ -63,6 +79,8 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     _taskCapacityUtilizationPct = taskCapacityUtilizationPct;
     _throughputInfoFetchTimeoutMs = throughputInfoFetchTimeoutMs;
     _throughputInfoFetchRetryPeriodMs = throughputInfoFetchRetryPeriodMs;
+    _assigner = new LoadBasedPartitionAssigner();
+    _partitionAssignmentStatsMap = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -127,7 +145,6 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
       }
     }
 
-    // TODO Implement metrics
     // Doing assignment
     Map<String, Set<DatastreamTask>> newAssignment = doAssignment(clusterThroughputInfo, currentAssignment,
         unassignedPartitions, datastreamPartitions);
@@ -139,10 +156,15 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
   Map<String, Set<DatastreamTask>> doAssignment(ClusterThroughputInfo clusterThroughputInfo,
       Map<String, Set<DatastreamTask>> currentAssignment, List<String> unassignedPartitions,
       DatastreamGroupPartitionsMetadata datastreamPartitions) {
-    LoadBasedPartitionAssigner partitionAssigner = new LoadBasedPartitionAssigner();
-    Map<String, Set<DatastreamTask>> assignment = partitionAssigner.assignPartitions(clusterThroughputInfo,
-        currentAssignment, unassignedPartitions, datastreamPartitions, _maxPartitionPerTask);
-    LOG.info("new assignment info, assignment: {}", assignment);
+    Pair<Map<String, Set<DatastreamTask>>, PartitionAssignmentStats> assignmentResult = _assigner.assignPartitions(
+        clusterThroughputInfo, currentAssignment, unassignedPartitions, datastreamPartitions, _maxPartitionPerTask);
+    Map<String, Set<DatastreamTask>> assignment = assignmentResult.getKey();
+    LOG.info("New assignment info, assignment: {}", assignment);
+    PartitionAssignmentStats stats = assignmentResult.getValue();
+    String taskPrefix = datastreamPartitions.getDatastreamGroup().getTaskPrefix();
+    LOG.info("Assignment stats for {}. Min partitions across tasks: {}, max partitions across tasks: {}", taskPrefix,
+        stats.getMinPartitionsAcrossTasks(), stats.getMaxPartitionsAcrossTasks());
+    updateMetricsForDatastream(taskPrefix, stats);
     return assignment;
   }
 
@@ -150,6 +172,7 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     AtomicInteger attemptNum = new AtomicInteger(0);
     return PollUtils.poll(() -> {
       try {
+        DYNAMIC_METRICS_MANAGER.createOrUpdateMeter(CLASS_NAME, THROUGHPUT_INFO_FETCH_RATE, 1);
         return _throughputProvider.getThroughputInfo(datastreamGroup);
       } catch (Exception ex) {
         attemptNum.set(attemptNum.get() + 1);
@@ -158,5 +181,49 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
       }
     }, Objects::nonNull, _throughputInfoFetchRetryPeriodMs, _throughputInfoFetchTimeoutMs)
         .orElseThrow(RetriesExhaustedException::new);
+  }
+
+  @Override
+  public List<BrooklinMetricInfo> getMetricInfos() {
+    List<BrooklinMetricInfo> metricInfos = new ArrayList<>();
+    String prefix = CLASS_NAME + MetricsAware.KEY_REGEX;
+
+    metricInfos.add(new BrooklinGaugeInfo(prefix + MIN_PARTITIONS_ACROSS_TASKS));
+    metricInfos.add(new BrooklinGaugeInfo(prefix + MAX_PARTITIONS_ACROSS_TASKS));
+    metricInfos.add(new BrooklinMeterInfo(CLASS_NAME + "." + THROUGHPUT_INFO_FETCH_RATE));
+
+    return Collections.unmodifiableList(metricInfos);
+  }
+
+  @Override
+  public void cleanupStrategy() {
+    _partitionAssignmentStatsMap.keySet().forEach(this::unregisterMetrics);
+    _partitionAssignmentStatsMap.clear();
+    super.cleanupStrategy();
+  }
+
+  private void updateMetricsForDatastream(String datastream, PartitionAssignmentStats stats) {
+    if (!_partitionAssignmentStatsMap.containsKey(datastream)) {
+      registerLoadBasedPartitionAssignmentMetrics(datastream);
+    }
+    _partitionAssignmentStatsMap.put(datastream, stats);
+  }
+
+  private void registerLoadBasedPartitionAssignmentMetrics(String datastream) {
+    Supplier<Integer> minPartitionsAcrossTasksSupplier = () -> _partitionAssignmentStatsMap
+        .getOrDefault(datastream, PartitionAssignmentStats.DEFAULT).getMinPartitionsAcrossTasks();
+    DYNAMIC_METRICS_MANAGER.registerGauge(CLASS_NAME, datastream, MIN_PARTITIONS_ACROSS_TASKS,
+        minPartitionsAcrossTasksSupplier);
+
+    Supplier<Integer> maxPartitionsAcrossTasksSupplier = () -> _partitionAssignmentStatsMap
+        .getOrDefault(datastream, PartitionAssignmentStats.DEFAULT).getMaxPartitionsAcrossTasks();
+    DYNAMIC_METRICS_MANAGER.registerGauge(CLASS_NAME, datastream, MAX_PARTITIONS_ACROSS_TASKS,
+        maxPartitionsAcrossTasksSupplier);
+  }
+
+  @Override
+  protected void unregisterMetrics(String datastream) {
+    DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastream, MIN_PARTITIONS_ACROSS_TASKS);
+    DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastream, MAX_PARTITIONS_ACROSS_TASKS);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -722,7 +722,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
   /**
    * Unregister metrics for a given datastream group
    */
-  private void unregisterMetrics(String datastreamTaskPrefix) {
+  protected void unregisterMetrics(String datastreamTaskPrefix) {
     DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, ACTUAL_PARTITIONS_PER_TASK);
     DYNAMIC_METRICS_MANAGER.unregisterMetric(CLASS_NAME, datastreamTaskPrefix, PARTITIONS_PER_TASK_NEEDS_ADJUSTMENT);
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssigner.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssigner.java
@@ -27,10 +27,12 @@ import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamGroupPartitionsMetadata;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
+import com.linkedin.datastream.server.Pair;
 import com.linkedin.datastream.server.PartitionThroughputInfo;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
 
+import static com.linkedin.datastream.server.assignment.LoadBasedPartitionAssigner.PartitionAssignmentStats;
 import static org.mockito.Matchers.anyString;
 
 
@@ -55,8 +57,10 @@ public class TestLoadBasedPartitionAssigner {
         Collections.singletonList(ds1)), Arrays.asList("P1", "P2", "P3"));
 
     LoadBasedPartitionAssigner assigner = new LoadBasedPartitionAssigner();
-    Map<String, Set<DatastreamTask>> newAssignment =
+    Pair<Map<String, Set<DatastreamTask>>, PartitionAssignmentStats> assignmentResults =
         assigner.assignPartitions(throughputInfo, currentAssignment, unassignedPartitions, metadata, Integer.MAX_VALUE);
+    Map<String, Set<DatastreamTask>> newAssignment = assignmentResults.getKey();
+    PartitionAssignmentStats stats = assignmentResults.getValue();
 
     DatastreamTask task1 = (DatastreamTask) newAssignment.get("instance1").toArray()[0];
     DatastreamTask task2 = (DatastreamTask) newAssignment.get("instance2").toArray()[0];
@@ -66,6 +70,10 @@ public class TestLoadBasedPartitionAssigner {
     Assert.assertEquals(task1.getPartitionsV2().size(), 1);
     Assert.assertEquals(task2.getPartitionsV2().size(), 1);
     Assert.assertEquals(task3.getPartitionsV2().size(), 1);
+
+    // verify stats
+    Assert.assertEquals(stats.getMinPartitionsAcrossTasks(), 1);
+    Assert.assertEquals(stats.getMaxPartitionsAcrossTasks(), 1);
 
     // verify that all partitions got assigned
     Set<String> assignedPartitions = new HashSet<>();
@@ -104,8 +112,9 @@ public class TestLoadBasedPartitionAssigner {
         Collections.singletonList(ds2)), Arrays.asList("P3"));
 
     LoadBasedPartitionAssigner assigner = new LoadBasedPartitionAssigner();
-    Map<String, Set<DatastreamTask>> newAssignment =
+    Pair<Map<String, Set<DatastreamTask>>, PartitionAssignmentStats> assignmentResult =
         assigner.assignPartitions(throughputInfo, currentAssignment, unassignedPartitions, metadata, Integer.MAX_VALUE);
+    Map<String, Set<DatastreamTask>> newAssignment = assignmentResult.getKey();
 
     Set<DatastreamTask> allTasks = new HashSet<>();
     allTasks.add((DatastreamTask) newAssignment.get("instance1").toArray()[0]);
@@ -141,8 +150,9 @@ public class TestLoadBasedPartitionAssigner {
         Collections.singletonList(ds1)), Arrays.asList("P1", "P2", "P3", "P4"));
 
     LoadBasedPartitionAssigner assigner = new LoadBasedPartitionAssigner();
-    Map<String, Set<DatastreamTask>> newAssignment =
+    Pair<Map<String, Set<DatastreamTask>>, PartitionAssignmentStats> assignmentResult =
         assigner.assignPartitions(throughputInfo, currentAssignment, unassignedPartitions, metadata, Integer.MAX_VALUE);
+    Map<String, Set<DatastreamTask>> newAssignment = assignmentResult.getKey();
 
     DatastreamTask task1 = (DatastreamTask) newAssignment.get("instance1").toArray()[0];
     DatastreamTask task2 = (DatastreamTask) newAssignment.get("instance2").toArray()[0];
@@ -175,8 +185,9 @@ public class TestLoadBasedPartitionAssigner {
         Collections.singletonList(ds1)), Arrays.asList("P1", "P2", "P3", "P4"));
 
     LoadBasedPartitionAssigner assigner = new LoadBasedPartitionAssigner();
-    Map<String, Set<DatastreamTask>> newAssignment =
+    Pair<Map<String, Set<DatastreamTask>>, PartitionAssignmentStats> assignmentResult =
         assigner.assignPartitions(throughputInfo, currentAssignment, unassignedPartitions, metadata, Integer.MAX_VALUE);
+    Map<String, Set<DatastreamTask>> newAssignment = assignmentResult.getKey();
 
     DatastreamTask task3 = (DatastreamTask) newAssignment.get("instance1").toArray()[0];
 
@@ -233,9 +244,10 @@ public class TestLoadBasedPartitionAssigner {
 
     LoadBasedPartitionAssigner assigner = new LoadBasedPartitionAssigner();
     int maxPartitionsPerTask = 2;
-    Map<String, Set<DatastreamTask>> newAssignment =
+    Pair<Map<String, Set<DatastreamTask>>, PartitionAssignmentStats> assignmentResult =
         assigner.assignPartitions(throughputInfo, currentAssignment, unassignedPartitions, metadata,
             maxPartitionsPerTask);
+    Map<String, Set<DatastreamTask>> newAssignment = assignmentResult.getKey();
 
     DatastreamTask task3 = (DatastreamTask) newAssignment.get("instance2").toArray()[0];
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssignmentStrategy.java
@@ -5,7 +5,6 @@
  */
 package com.linkedin.datastream.server.assignment;
 
-import com.linkedin.datastream.testutil.MetricsTestUtils;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
@@ -41,6 +40,7 @@ import com.linkedin.datastream.server.zk.KeyBuilder;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
 import com.linkedin.datastream.testutil.EmbeddedZookeeper;
+import com.linkedin.datastream.testutil.MetricsTestUtils;
 
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyInt;


### PR DESCRIPTION
Implemented the following metrics for `LoadBasedPartitionAssignmentStrategy`:

- Minimum partitions across tasks (per datastream)
- Maximum partitions across tasks (per datastream)
- Throughput information fetch rate

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
