### PR TITLE
Datastream stop transition redesign

### DIFF
--- a/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
+++ b/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
@@ -100,7 +100,7 @@
           "name" : "force",
           "type" : "boolean",
           "default" : "false",
-          "doc" : "whether or not to resume all datastreams within the given datastream's group"
+          "doc" : "whether or not to stop all datastreams within the given datastream's group"
         } ]
       } ]
     }

--- a/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdl
+++ b/datastream-common/src/main/pegasus/com/linkedin/datastream/common/Datastream.pdl
@@ -53,6 +53,7 @@ record Datastream {
     PAUSED
     DELETING
     STOPPED
+    STOPPING
   }
 
   /**

--- a/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
+++ b/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
@@ -38,7 +38,7 @@
       "type" : {
         "type" : "enum",
         "name" : "DatastreamStatus",
-        "symbols" : [ "INITIALIZING", "READY", "PAUSED", "DELETING", "STOPPED" ]
+        "symbols" : [ "INITIALIZING", "READY", "PAUSED", "DELETING", "STOPPED", "STOPPING" ]
       },
       "doc" : "Status of the datastream",
       "symbolDocs" : {
@@ -187,7 +187,7 @@
             "name" : "force",
             "type" : "boolean",
             "default" : "false",
-            "doc" : "whether or not to resume all datastreams within the given datastream's group"
+            "doc" : "whether or not to stop all datastreams within the given datastream's group"
           } ]
         } ]
       }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java
@@ -94,6 +94,7 @@ public class DatastreamServer {
   private final Map<String, String> _bootstrapConnectors;
 
   private Coordinator _coordinator;
+  private Properties _properties;
   private DatastreamStore _datastreamStore;
   private DatastreamJettyStandaloneLauncher _jettyLauncher;
   private JmxReporter _jmxReporter;
@@ -130,7 +131,8 @@ public class DatastreamServer {
   public DatastreamServer(Properties properties) throws DatastreamException {
     LOG.info("Start to initialize DatastreamServer. Properties: " + properties);
     LOG.info("Creating coordinator.");
-    VerifiableProperties verifiableProperties = new VerifiableProperties(properties);
+    _properties = properties;
+    VerifiableProperties verifiableProperties = new VerifiableProperties(_properties);
 
     HashSet<String> connectorTypes = new HashSet<>(verifiableProperties.getStringList(CONFIG_CONNECTOR_NAMES,
         Collections.emptyList()));
@@ -148,7 +150,7 @@ public class DatastreamServer {
       throw new DatastreamRuntimeException(errorMessage);
     }
 
-    CoordinatorConfig coordinatorConfig = new CoordinatorConfig(properties);
+    CoordinatorConfig coordinatorConfig = new CoordinatorConfig(_properties);
 
     LOG.info("Setting up DMS endpoint server.");
     ZkClient zkClient = new ZkClient(coordinatorConfig.getZkAddress(), coordinatorConfig.getZkSessionTimeout(),
@@ -224,6 +226,10 @@ public class DatastreamServer {
 
   public DatastreamStore getDatastreamStore() {
     return _datastreamStore;
+  }
+
+  public Properties getProperties() {
+    return _properties;
   }
 
   public int getHttpPort() {


### PR DESCRIPTION
Introducing a new intermediate STOPPING state in the lifecycle of a datastream, which represents a transitioning state for the leader to calculate and generate a new reassignment when a stop request is issued. This blocking transitioning state would make sure that any updates made to the datastream are applied successfully if datastream is restarted with a stop and resume call with a 60-second timeout in between. 

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
