### PR TITLE
Print count of orphaned tasks and orphaned task locks in the log message

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -1075,7 +1075,7 @@ public class ZkAdapter {
       connectorTaskList.remove(KeyBuilder.DATASTREAM_TASK_LOCK_ROOT_NAME);
 
       if (connectorTaskList.size() > 0) {
-        LOG.warn("Found orphan tasks: {} in connector: {}", connectorTaskList, connector);
+        LOG.warn("Found {} orphan tasks: {} in connector: {}", connectorTaskList.size(), connectorTaskList, connector);
         if (cleanUpOrphanTasksInConnector) {
           connectorTaskList.forEach(t -> deleteConnectorTask(connector, t));
         }
@@ -1151,7 +1151,7 @@ public class ZkAdapter {
       });
 
       if (orphanLockList.size() > 0) {
-        LOG.warn("Found orphan task locks: {} in connector: {}", orphanLockList, connector);
+        LOG.warn("Found {} orphan task locks: {} in connector: {}", orphanLockList.size(), orphanLockList, connector);
         if (cleanUpOrphanTaskLocksInConnector) {
           _finalOrphanLockList.addAll(orphanLockList);
         }


### PR DESCRIPTION
Print count of orphaned tasks and task logs in addition to printing the actual tasks, task locks and connector info in ZkAdapter while cleaning up orphan tasks.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
