### PR TITLE
Handle leaking TP exception in handleAssignmentChange

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -30,6 +30,9 @@ public final class CoordinatorConfig {
   public static final String CONFIG_MAX_DATASTREAM_TASKS_PER_INSTANCE = PREFIX + "maxDatastreamTasksPerInstance";
   public static final String CONFIG_PERFORM_PRE_ASSIGNMENT_CLEANUP = PREFIX + "performPreAssignmentCleanup";
   public static final String CONFIG_REINIT_ON_NEW_ZK_SESSION = PREFIX + "reinitOnNewZKSession";
+  public static final String CONFIG_MAX_ASSIGNMENT_RETRY_COUNT = PREFIX + "maxAssignmentRetryCount";
+
+  public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
 
   private final String _cluster;
   private final String _zkAddress;
@@ -46,11 +49,14 @@ public final class CoordinatorConfig {
   private final int _maxDatastreamTasksPerInstance;
   private final boolean _performPreAssignmentCleanup;
   private final boolean _reinitOnNewZkSession;
+  private final int _maxAssignmentRetryCount;
 
   /**
    * Construct an instance of CoordinatorConfig
    * @param config configuration properties to load
    * @throws IllegalArgumentException if any required config property is missing
+   *
+   * TODO : Add unit tests for all coordinator config properties
    */
   public CoordinatorConfig(Properties config) {
     _config = config;
@@ -68,6 +74,7 @@ public final class CoordinatorConfig {
     _maxDatastreamTasksPerInstance = _properties.getInt(CONFIG_MAX_DATASTREAM_TASKS_PER_INSTANCE, 0);
     _performPreAssignmentCleanup = _properties.getBoolean(CONFIG_PERFORM_PRE_ASSIGNMENT_CLEANUP, false);
     _reinitOnNewZkSession = _properties.getBoolean(CONFIG_REINIT_ON_NEW_ZK_SESSION, false);
+    _maxAssignmentRetryCount = _properties.getInt(CONFIG_MAX_ASSIGNMENT_RETRY_COUNT, DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT);
   }
 
   public Properties getConfigProperties() {
@@ -124,5 +131,9 @@ public final class CoordinatorConfig {
 
   public boolean getReinitOnNewZkSession() {
     return _reinitOnNewZkSession;
+  }
+
+  public int getMaxAssignmentRetryCount() {
+    return _maxAssignmentRetryCount;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderAdminFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DummyTransportProviderAdminFactory.java
@@ -28,6 +28,8 @@ public class DummyTransportProviderAdminFactory implements TransportProviderAdmi
   public static final String PROVIDER_NAME = "default";
 
   private final boolean _throwOnSend;
+  private boolean _failTransportProviderOnce;
+  private boolean _failTransportProvider;
 
   int _createDestinationCount = 0;
   int _dropDestinationCount = 0;
@@ -36,19 +38,29 @@ public class DummyTransportProviderAdminFactory implements TransportProviderAdmi
    * Constructor for DummyTransportProviderAdminFactory
    */
   public DummyTransportProviderAdminFactory() {
-    this(false);
+    this(false, false, false);
   }
 
   /**
    * Constructor for DummyTransportProviderAdminFactory which can optionally throw exception on every send call
    * @param throwOnSend whether or not to throw an exception on send calls
+   * @param failTransportProviderOnce whether to fail TransportProvider creation once
+   * @param failTransportProvider whether to fail TransportProvider creation always
    */
-  public DummyTransportProviderAdminFactory(boolean throwOnSend) {
+  public DummyTransportProviderAdminFactory(boolean throwOnSend, boolean failTransportProviderOnce,
+      boolean failTransportProvider) {
+    _failTransportProviderOnce = failTransportProviderOnce;
+    _failTransportProvider = failTransportProvider;
     _throwOnSend = throwOnSend;
   }
 
   @Override
   public TransportProvider assignTransportProvider(DatastreamTask task) {
+    if (_failTransportProviderOnce || _failTransportProvider) {
+      _failTransportProviderOnce = false;
+      throw new RuntimeException("Failed to initialize TransportProvider");
+    }
+
     return new TransportProvider() {
 
       @Override

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
@@ -1,0 +1,52 @@
+/**
+ *  Copyright 2019 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+/**
+ * Test for {@link com.linkedin.datastream.server.CoordinatorConfig}
+ */
+@Test
+public class TestCoordinatorConfig {
+  private static final String CLUSTER = "brooklin";
+  private static final String ZK_ADDRESS = "localhost:9999";
+
+  private CoordinatorConfig createCoordinatorConfig(Properties props) {
+    props.put(CoordinatorConfig.CONFIG_CLUSTER, CLUSTER);
+    props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, ZK_ADDRESS);
+    CoordinatorConfig config = new CoordinatorConfig(props);
+    return config;
+  }
+
+  @BeforeMethod
+  public void setup() {
+  }
+
+  @AfterMethod
+  public void teardown() {
+  }
+
+  @Test
+  public void testCoordinatorMaxAssignmentRetryCountFromConfig() throws Exception {
+    Properties props = new Properties();
+    props.put(CoordinatorConfig.CONFIG_MAX_ASSIGNMENT_RETRY_COUNT, "10");
+    CoordinatorConfig config = createCoordinatorConfig(props);
+    Assert.assertEquals(10, config.getMaxAssignmentRetryCount());
+  }
+
+  @Test
+  public void testCoordinatorMaxAssignmentRetryCountDefault() throws Exception {
+    Properties props = new Properties();
+    CoordinatorConfig config = createCoordinatorConfig(props);
+    Assert.assertEquals(CoordinatorConfig.DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT, config.getMaxAssignmentRetryCount());
+  }
+}


### PR DESCRIPTION
During handleAssignmentChange, while initializing task we were leaking a possible
exception while creating TransportProvider object. This patch fixes it by issuing
a retry on failure.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
