### PR TITLE
Migrating from AdminUtils with AdminClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,7 @@ project(':datastream-client') {
 project(':datastream-server') {
 
   dependencies {
-    compile "com.101tec:zkclient:$zkclientVersion"
+    compile "org.apache.helix:zookeeper-api:$helixZkclientVersion"
     compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
 

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnector.java
@@ -69,9 +69,8 @@ public class TestKafkaConnector extends BaseKafkaZkTest {
   @Test
   public void testConnectorWithStartPosition() throws UnsupportedEncodingException, DatastreamValidationException {
     String topicName = "testConnectorWithStartPosition";
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName, 0, 100);
-    long ts = System.currentTimeMillis();
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName, 100, 100);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName, 0, 100);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName, 100, 100);
     Datastream ds = createDatastream("testConnectorPopulatesPartitions", topicName);
     Map<Integer, Long> offsets = Collections.singletonMap(0, 100L);
     KafkaConnector connector =
@@ -92,8 +91,8 @@ public class TestKafkaConnector extends BaseKafkaZkTest {
   @Test
   public void testPopulatingDefaultSerde() throws Exception {
     String topicName = "testPopulatingDefaultSerde";
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName, 0, 100);
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName, 100, 100);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName, 0, 100);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName, 100, 100);
     Datastream ds = createDatastream("testPopulatingDefaultSerde", topicName);
     KafkaConnector connector =
         new KafkaConnector("test", getDefaultConfig(null), "testCluster");
@@ -107,7 +106,7 @@ public class TestKafkaConnector extends BaseKafkaZkTest {
   @Test
   public void testConnectorPopulatesPartitions() throws UnsupportedEncodingException, DatastreamValidationException {
     String topicName = "testConnectorPopulatesPartitions";
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName, 0, 10);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName, 0, 10);
 
     Datastream ds = createDatastream("testConnectorPopulatesPartitions", topicName);
     KafkaConnector connector =
@@ -147,9 +146,9 @@ public class TestKafkaConnector extends BaseKafkaZkTest {
     String topicName2 = "topic2";
     String topicName3 = "topic3";
 
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName1, 0, 100);
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName2, 0, 100);
-    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _zkUtils, topicName3, 0, 100);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName1, 0, 100);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName2, 0, 100);
+    TestKafkaConnectorTask.produceEvents(_kafkaCluster, _adminClient, topicName3, 0, 100);
 
     Properties properties = getDefaultConfig(null);
     properties.put(AbstractKafkaConnector.IS_GROUP_ID_HASHING_ENABLED, Boolean.toString(isGroupIdHashingEnabled));

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaConsumerOffsets.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaConsumerOffsets.java
@@ -46,7 +46,7 @@ public class TestKafkaConsumerOffsets extends BaseKafkaZkTest {
     // create topics
     List<String> topics = new ArrayList<>();
     IntStream.range(0, TOPIC_COUNT).forEach(i -> topics.add("topic" + i));
-    topics.forEach(topic -> createTopic(_zkUtils, topic, PARTITION_COUNT));
+    topics.forEach(topic -> createTopic(_adminClient, topic, PARTITION_COUNT));
 
     // setup datastream and connector
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("topicStream", _broker, "topic\\d+");

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnector.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
-import kafka.admin.AdminUtils;
 
 import com.linkedin.data.template.StringMap;
 import com.linkedin.datastream.common.Datastream;
@@ -221,9 +220,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     coordinator.initializeDatastream(datastream);
 
     // create topic
-    if (!AdminUtils.topicExists(_zkUtils, topic)) {
-      AdminUtils.createTopic(_zkUtils, topic, 2, 1, new Properties(), null);
-    }
+    createTopic(_adminClient, topic, 2);
 
     // Make sure "*" is converted to a list of partitions
     pausedPartitions.put(topic, new HashSet<>(Collections.singletonList("*")));
@@ -274,9 +271,9 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     String saltyTopic = "SaltyPizza";
     String saladTopic = "HealthySalad";
 
-    createTopic(_zkUtils, saladTopic);
-    createTopic(_zkUtils, yummyTopic);
-    createTopic(_zkUtils, saltyTopic);
+    createTopic(_adminClient, saladTopic);
+    createTopic(_adminClient, yummyTopic);
+    createTopic(_adminClient, saltyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -378,7 +375,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     String yummyTopic = "YummyPizza";
     String saltyTopic = "SaltyPizza";
 
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -409,7 +406,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
         "Expected record from YummyPizza topic but got record from " + record.getDestination().get());
 
     // create a new topic ending in "Pizza" and produce an event to it
-    createTopic(_zkUtils, saltyTopic);
+    createTopic(_adminClient, saltyTopic);
     KafkaMirrorMakerConnectorTestUtils.produceEvents(saltyTopic, 1, _kafkaCluster);
 
     if (!PollUtils.poll(() -> datastreamProducer.getEvents().size() == 2, POLL_PERIOD_MS, POLL_TIMEOUT_MS)) {
@@ -429,8 +426,8 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     String yummyTopic = "YummyPizza";
     String saltyTopic = "SaltyPizza";
 
-    createTopic(_zkUtils, yummyTopic);
-    createTopic(_zkUtils, saltyTopic);
+    createTopic(_adminClient, yummyTopic);
+    createTopic(_adminClient, saltyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -460,7 +457,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
     datastreamProducer.getEvents().clear();
 
     // delete the topic
-    deleteTopic(_zkUtils, yummyTopic);
+    deleteTopic(_adminClient, yummyTopic);
 
     // produce another event to SaltyPizza
     KafkaMirrorMakerConnectorTestUtils.produceEvents(saltyTopic, 1, _kafkaCluster);
@@ -611,7 +608,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
 
     String yummyTopic = "YummyPizza";
 
-    createTopic(_zkUtils, yummyTopic, 1);
+    createTopic(_adminClient, yummyTopic, 1);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -637,7 +634,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
         ImmutableSet.of(yummyTopic + "-0"));
 
     String saltyTopic = "SaltyPizza";
-    createTopic(_zkUtils, saltyTopic, 2);
+    createTopic(_adminClient, saltyTopic, 2);
 
     Assert.assertTrue(PollUtils.poll(() -> partitionChangeCalls.get() == 2, POLL_PERIOD_MS, POLL_TIMEOUT_MS));
     partitionInfo = connector.getDatastreamPartitions();
@@ -716,7 +713,7 @@ public class TestKafkaMirrorMakerConnector extends BaseKafkaZkTest {
   @Test
   public void testGetStateForMultipleTasks() throws Exception {
     List<String> topics = Arrays.asList("YummyPizza", "SaltyPizza", "HealthySalad");
-    topics.forEach(t -> createTopic(_zkUtils, t));
+    topics.forEach(t -> createTopic(_adminClient, t));
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -102,9 +102,9 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     String saltyTopic = "SaltyPizza";
     String saladTopic = "HealthySalad";
 
-    createTopic(_zkUtils, saladTopic);
-    createTopic(_zkUtils, yummyTopic);
-    createTopic(_zkUtils, saltyTopic);
+    createTopic(_adminClient, saladTopic);
+    createTopic(_adminClient, yummyTopic);
+    createTopic(_adminClient, saltyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -161,9 +161,9 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
 
     String destinationTopicPrefixOverride = "newPrefix";
 
-    createTopic(_zkUtils, saladTopic);
-    createTopic(_zkUtils, yummyTopic);
-    createTopic(_zkUtils, saltyTopic);
+    createTopic(_adminClient, saladTopic);
+    createTopic(_adminClient, yummyTopic);
+    createTopic(_adminClient, saltyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -209,7 +209,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     String yummyTopic = "YummyPizza";
 
     int partitionCount = 10;
-    createTopic(_zkUtils, yummyTopic, partitionCount);
+    createTopic(_adminClient, yummyTopic, partitionCount);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -254,7 +254,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   @Test
   public void testFlushAndCommitDuringGracefulStop() throws Exception {
     String yummyTopic = "YummyPizza";
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -561,7 +561,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   @Test
   public void testAutoOffsetResetConfigOverride() throws Exception {
     String yummyTopic = "YummyPizza";
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create 2 datastreams to consume from topics ending in "Pizza", each with different offset reset strategy
     Datastream datastreamLatest =
@@ -628,9 +628,9 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     String saltyTopic = "SaltyPizza";
     String spicyTopic = "SpicyPizza";
 
-    createTopic(_zkUtils, spicyTopic);
-    createTopic(_zkUtils, yummyTopic);
-    createTopic(_zkUtils, saltyTopic);
+    createTopic(_adminClient, spicyTopic);
+    createTopic(_adminClient, yummyTopic);
+    createTopic(_adminClient, saltyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -790,7 +790,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   @SuppressWarnings("unchecked")
   public void testAutoPauseOnSendFailure() throws Exception {
     String yummyTopic = "YummyPizza";
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -873,7 +873,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   @Test
   public void testAutoPauseAndResumeOnSendFailure() throws Exception {
     String yummyTopic = "YummyPizza";
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -947,7 +947,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
 
   private void testValidateTaskDiesOnRewindFailure(boolean failOnGetLastCheckpointToSeekTo, boolean flushlessMode) throws InterruptedException {
     String yummyTopic = "YummyPizza";
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -1012,8 +1012,8 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     String yummyTopic = "YummyPizza";
     String saltyTopic = "SaltyPizza";
 
-    createTopic(_zkUtils, yummyTopic);
-    createTopic(_zkUtils, saltyTopic);
+    createTopic(_adminClient, yummyTopic);
+    createTopic(_adminClient, saltyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -1049,7 +1049,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     KafkaMirrorMakerConnectorTestUtils.produceEvents(saltyTopic, 1, _kafkaCluster);
 
     // delete YummyPizza topic
-    deleteTopic(_zkUtils, yummyTopic);
+    deleteTopic(_adminClient, yummyTopic);
 
     // verify the task is no longer subscribed to the deleted topic YummyPizza
     boolean partitionRevoked = PollUtils.poll(() -> {
@@ -1121,7 +1121,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   @SuppressWarnings("unchecked")
   public void testAutoPauseAndResume() throws Exception {
     String yummyTopic = "YummyPizza";
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -1174,7 +1174,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   @Test
   public void testFlowControlDisabled() throws Exception {
     String yummyTopic = "YummyPizza";
-    createTopic(_zkUtils, yummyTopic);
+    createTopic(_adminClient, yummyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");
@@ -1219,7 +1219,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     };
 
     for (String topic : cookieTopics) {
-      createTopic(_zkUtils, topic);
+      createTopic(_adminClient, topic);
     }
 
     // create a datastream to consume from topics ending in "Cookie"
@@ -1254,9 +1254,9 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
     String yummyTopic = "YummyPizza";
     String saltyTopic = "SaltyPizza";
     String spicyTopic = "SpicyPizza";
-    createTopic(_zkUtils, yummyTopic);
-    createTopic(_zkUtils, saltyTopic);
-    createTopic(_zkUtils, spicyTopic);
+    createTopic(_adminClient, yummyTopic);
+    createTopic(_adminClient, saltyTopic);
+    createTopic(_adminClient, spicyTopic);
 
     // create a datastream to consume from topics ending in "Pizza"
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("pizzaStream", _broker, "\\w+Pizza");

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaTopicPartitionStats.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaTopicPartitionStats.java
@@ -42,7 +42,7 @@ public class TestKafkaTopicPartitionStats extends BaseKafkaZkTest {
   @Test
   public void testProcessTopicPartitionStats() {
     List<String> topics = Arrays.asList("topic1", "topic2");
-    topics.forEach(topic -> createTopic(_zkUtils, topic, PARTITION_COUNT));
+    topics.forEach(topic -> createTopic(_adminClient, topic, PARTITION_COUNT));
 
     Datastream datastream = KafkaMirrorMakerConnectorTestUtils.createDatastream("topicStream", _broker, "topic\\d+");
 
@@ -72,7 +72,7 @@ public class TestKafkaTopicPartitionStats extends BaseKafkaZkTest {
     }
 
     // Delete the topic to revoke partitions from topic2
-    deleteTopic(_zkUtils, topics.get(0));
+    deleteTopic(_adminClient, topics.get(0));
     expected.remove(topics.get(0));
 
     // Wait until the partitions from the deleted topic are revoked

--- a/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaTransportProvider.java
+++ b/datastream-kafka/src/test/java/com/linkedin/datastream/kafka/TestKafkaTransportProvider.java
@@ -220,9 +220,7 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
 
     DatastreamTask task = new DatastreamTaskImpl(Collections.singletonList(ds));
     TransportProvider transportProvider = provider.assignTransportProvider(task);
-    provider.createTopic(destinationUri, 1, new Properties());
-
-    KafkaTestUtils.waitForTopicCreation(_zkUtils, topicName, _kafkaCluster.getBrokers());
+    provider.createTopic(destinationUri, 1, new Properties(), ds);
 
     LOG.info(String.format("Topic %s created with %d partitions and topic properties %s", topicName, 1,
         new Properties()));
@@ -296,9 +294,9 @@ public class TestKafkaTransportProvider extends BaseKafkaZkTest {
 
     DatastreamTask task = new DatastreamTaskImpl(Collections.singletonList(ds));
     TransportProvider transportProvider = provider.assignTransportProvider(task);
-    provider.createTopic(destinationUri, numberOfPartitions, new Properties());
+    provider.createTopic(destinationUri, numberOfPartitions, new Properties(), ds);
 
-    KafkaTestUtils.waitForTopicCreation(_zkUtils, topicName, _kafkaCluster.getBrokers());
+    //KafkaTestUtils.waitForTopicCreation(_adminClient, topicName, _kafkaCluster.getBrokers());
 
     LOG.info(String.format("Topic %s created with %d partitions and topic properties %s", topicName, numberOfPartitions,
         new Properties()));

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2334,6 +2334,13 @@ public class TestCoordinator {
   }
 
   private void validateRetention(Datastream stream, DatastreamResources resource, Duration expectedRetention) {
+    // Adding a sleep to simulate time required for topic metadata to be synced across all brokers of destination
+    // kafka cluster.
+    try {
+      Thread.sleep(2000);
+    } catch (Exception e) {
+    }
+
     Datastream queryStream = resource.get(stream.getName());
     Assert.assertNotNull(queryStream.getDestination());
     StringMap metadata = queryStream.getMetadata();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.I0Itec.zkclient.exception.ZkNoNodeException;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -176,6 +176,10 @@ public class EmbeddedDatastreamCluster {
     return domainConnectorProperties;
   }
 
+  public String getBrokers() {
+    return _kafkaCluster.getBrokers();
+  }
+
   public KafkaCluster getKafkaCluster() {
     return _kafkaCluster;
   }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -21,4 +21,5 @@ ext {
     testngVersion = "7.1.0"
     zkclientVersion = "0.11"
     zookeeperVersion = "3.4.13"
+    helixZkclientVersion = "1.0.1"
 }


### PR DESCRIPTION
Replace kafka.admin.AdminUtils usage with kafka.client.AdminClient because AdminUtils is deprecated.
Also in a following effort 101tec ZkClient will be replaced by helix ZkClient and this is required for that.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
