### PR TITLE
Update the DatabaseChunkedReader to take the Connection as input rather than the DataSource

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/databases/dbreader/DatabaseChunkedReader.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/databases/dbreader/DatabaseChunkedReader.java
@@ -16,7 +16,6 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import javax.sql.DataSource;
 
 import org.apache.avro.Schema;
 import org.apache.commons.lang.StringUtils;
@@ -99,7 +98,7 @@ public class DatabaseChunkedReader implements Closeable {
   /**
    * Create a DatabaseChunkedReader instance
    * @param props Configuration
-   * @param source JDBC DataSource object to use for connecting
+   * @param connection JDBC DataSource Connection object
    * @param sourceQuery Query to execute on the source in chunked mode. The query cannot be any SQL query and
    *                    needs to follow specific rules. The query should only involve one table, as specified
    *                    by the 'table' parameter, should query all unique key columns and in the order specified
@@ -111,7 +110,7 @@ public class DatabaseChunkedReader implements Closeable {
    * @param databaseSource DatabaseSource implementation to query table metadata needed for constructing the chunk query
    * @param id Name to identify the reader instance in logs
    */
-  public DatabaseChunkedReader(Properties props, DataSource source, String sourceQuery, String db, String table,
+  public DatabaseChunkedReader(Properties props, Connection connection, String sourceQuery, String db, String table,
       DatabaseSource databaseSource, String id) throws SQLException {
     _databaseChunkedReaderConfig = new DatabaseChunkedReaderConfig(props);
     _sourceQuery = sourceQuery;
@@ -121,8 +120,7 @@ public class DatabaseChunkedReader implements Closeable {
     _fetchSize = _databaseChunkedReaderConfig.getFetchSize();
     _queryTimeoutSecs = _databaseChunkedReaderConfig.getQueryTimeout();
     _rowCountLimit = _databaseChunkedReaderConfig.getRowCountLimit();
-    _connection = source.getConnection();
-    Validate.notNull(_connection, "getConnection returned null for source" + source);
+    _connection = connection;
     _chunkedQueryManager = _databaseChunkedReaderConfig.getChunkedQueryManager();
     _skipBadMessagesEnabled = _databaseChunkedReaderConfig.getShouldSkipBadMessage();
 

--- a/datastream-common/src/test/java/com/linkedin/datastream/common/databases/dbreader/TestDatabaseChunkedReader.java
+++ b/datastream-common/src/test/java/com/linkedin/datastream/common/databases/dbreader/TestDatabaseChunkedReader.java
@@ -233,7 +233,7 @@ public class TestDatabaseChunkedReader {
 
     for (int i = 0; i < numPartitions; i++) {
       try (DatabaseChunkedReader reader =
-          new DatabaseChunkedReader(props, mockSources.get(i), "TEST_DB", TEST_SOURCE_QUERY,
+          new DatabaseChunkedReader(props, mockSources.get(i).getConnection(), "TEST_DB", TEST_SOURCE_QUERY,
               TEST_COMPOSITE_KEY_TABLE, mockDBSource, "testRowCount_" + i)) {
         reader.subscribe(Collections.singletonList(0), null);
         for (DatabaseRow row = reader.poll(); row != null; row = reader.poll()) {
@@ -286,7 +286,7 @@ public class TestDatabaseChunkedReader {
 
     int count = 0;
     DatabaseChunkedReader reader =
-        new DatabaseChunkedReader(props, mockDs, TEST_SIMPLE_QUERY, "TEST_DB", TEST_SIMPLE_KEY_TABLE, mockDBSource, readerId);
+        new DatabaseChunkedReader(props, mockDs.getConnection(), TEST_SIMPLE_QUERY, "TEST_DB", TEST_SIMPLE_KEY_TABLE, mockDBSource, readerId);
     reader.subscribe(Collections.singletonList(0), null);
     for (DatabaseRow row = reader.poll(); row != null; row = reader.poll()) {
       Assert.assertEquals(row, new DatabaseRow(Collections.singletonList(field)));
@@ -323,7 +323,7 @@ public class TestDatabaseChunkedReader {
     Mockito.when(mockRs.next()).thenReturn(false); //No results for the query. Test to ensure the first query is a chunked query
     Mockito.when(mockStmt.executeQuery()).thenReturn(mockRs);
     DatabaseChunkedReader reader =
-        new DatabaseChunkedReader(props, mockDs, TEST_SIMPLE_QUERY, "TEST_DB", TEST_SIMPLE_KEY_TABLE, mockDBSource,
+        new DatabaseChunkedReader(props, mockDs.getConnection(), TEST_SIMPLE_QUERY, "TEST_DB", TEST_SIMPLE_KEY_TABLE, mockDBSource,
             "TEST_CHECKPOINT");
     Map<String, Object> checkpoint = new HashMap<>();
     checkpoint.put("key1", 99);

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "1.2.0"
+  version = "2.0.0"
 }
 
 subprojects {


### PR DESCRIPTION
Currently the `DatabaseChunkedReader` takes a `DataSource` as input and calls its `getConnection()` function to obtain a connection to the DB. In the release resources code path, it does not clean up this `Connection` object, and this is potentially a leak and should be closed. The way we use the `DatabaseChunkedReader` in Oracle bootstrap is that we reuse the same `DataSource` for seeding multiple tables. Thus we can potentially expect the Oracle bootstrap task to know when it no longer needs the `Connection` object and close it. This would require passing the `Connection` object to the `DatabaseChunkedReader` instead of the `DataSource`.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
