### PR TITLE
Removing partial Helix ZkClient dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -319,7 +319,7 @@ project(':datastream-client') {
 project(':datastream-server') {
 
   dependencies {
-    compile "org.apache.helix:zookeeper-api:$helixZkclientVersion"
+    compile "com.101tec:zkclient:$zkclientVersion"
     compile "org.codehaus.jackson:jackson-core-asl:$jacksonVersion"
     compile "org.codehaus.jackson:jackson-mapper-asl:$jacksonVersion"
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
+import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
In a previous patch to replace AdminUtils with AdminClient partial Helix ZkClient dependency was
introduced in datastream-server. This fix is to undo had dependency and revert back to 101tech
ZkClient for now.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
