### PR TITLE
Stop the tasks in parallel in AbstractKafkaConnector

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -83,7 +83,6 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
   private static final Duration CANCEL_TASK_TIMEOUT = Duration.ofSeconds(75);
   private static final Duration POST_CANCEL_TASK_TIMEOUT = Duration.ofSeconds(15);
   private static final Duration SHUTDOWN_EXECUTOR_SHUTDOWN_TIMEOUT = CANCEL_TASK_TIMEOUT.plus(POST_CANCEL_TASK_TIMEOUT);
-  //Duration.ofSeconds(30);
   static final Duration MIN_DAEMON_THREAD_STARTUP_DELAY = Duration.ofMinutes(2);
 
   private static final String NUM_TASK_RESTARTS = "numTaskRestarts";


### PR DESCRIPTION
Currently during container shutdown, the tasks are shutdown sequentially in `AbstractKafkaConnector`. The shutdown code waits for the task threads to be killed for 60+ sec. This increases the overall stop time, if the kafka producers have a lot pending to flush in scale environment. Ideally all the tasks can be stopped in parallel, similar to when the task assignment changes.

Using the shutdown executor service to stop the tasks. When the executor is stopped, it will force kill the ongoing operations. So, I'm changing the shutdown executor time to be same as the time it waits to stop a task which is currently 75 + 15 = 90 sec.