### PR TITLE
Fixing flaky test testCreateDatastreamHappyPathDefaultRetention

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2337,7 +2337,7 @@ public class TestCoordinator {
     // Adding a sleep to simulate time required for topic metadata to be synced across all brokers of destination
     // kafka cluster.
     try {
-      Thread.sleep(2000);
+      Thread.sleep(5000);
     } catch (Exception e) {
     }
 


### PR DESCRIPTION
Increasing the timeout before validating retention time.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
