### PR TITLE
Make PartitionThroughputProvider metricsAware

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/providers/PartitionThroughputProvider.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/providers/PartitionThroughputProvider.java
@@ -7,6 +7,7 @@ package com.linkedin.datastream.server.providers;
 
 import java.util.Map;
 
+import com.linkedin.datastream.metrics.MetricsAware;
 import com.linkedin.datastream.server.ClusterThroughputInfo;
 import com.linkedin.datastream.server.DatastreamGroup;
 
@@ -15,7 +16,7 @@ import com.linkedin.datastream.server.DatastreamGroup;
  * Abstraction that provides topic partition throughput information. Used by load-based assignment strategies to do
  * partition assignment based on throughput
  */
-public interface PartitionThroughputProvider {
+public interface PartitionThroughputProvider extends MetricsAware {
 
   /**
    * Retrieves per-partition throughput information for the given cluster

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -191,6 +191,7 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     List<BrooklinMetricInfo> metricInfos = new ArrayList<>();
     metricInfos.add(new BrooklinMeterInfo(CLASS_NAME + "." + THROUGHPUT_INFO_FETCH_RATE));
     metricInfos.addAll(_assigner.getMetricInfos());
+    metricInfos.addAll(_throughputProvider.getMetricInfos());
     return Collections.unmodifiableList(metricInfos);
   }
 


### PR DESCRIPTION
Make PartitionThroughputProvider metricsAware so that the implementer classes can emit metrics.