### PR TITLE
Catch interrupt signal in the connector task runnable

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -388,7 +388,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
       consumerSubscribe();
 
       ConsumerRecords<?, ?> records;
-      while (!_shutdown) {
+      while (!_shutdown && !Thread.currentThread().isInterrupted()) {
         // perform any pre-computations before poll()
         preConsumerPollHook();
 


### PR DESCRIPTION
In the stopTasks logic, the thread might not get interrupted sometimes and thus could land up running forever. This change tries to catch the interrupt status in the runnable to eventually stop the task instead of recurring forever. 

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
