### PR TITLE
Fix Stopping Logic and Maintain Stopping Latch Counter

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -93,7 +93,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected volatile long _lastPolledTimeMillis = System.currentTimeMillis();
   protected volatile long _lastPollCompletedTimeMillis = 0;
   protected final CountDownLatch _startedLatch = new CountDownLatch(1);
-  protected final CountDownLatch _stoppedLatch = new CountDownLatch(1);
+  private final CountDownLatch _stoppedLatch = new CountDownLatch(1);
   private final AtomicBoolean _metricDeregistered = new AtomicBoolean(false);
 
   // config
@@ -438,9 +438,13 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
         }
       }
       postShutdownHook();
-      _stoppedLatch.countDown();
+      countDownStoppedLatch();
       _logger.info("{} stopped", _taskName);
     }
+  }
+
+  protected void countDownStoppedLatch() {
+    _stoppedLatch.countDown();
   }
 
   /**
@@ -1098,5 +1102,10 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   @VisibleForTesting
   public String getConsumerAutoOffsetResetConfig() {
     return _consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "");
+  }
+
+  @VisibleForTesting
+  public long getStoppedLatchCount() {
+    return _stoppedLatch.getCount();
   }
 }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -259,22 +259,17 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
         if (isConnectorTaskDead(connectorTaskEntry)) {
           _logger.warn("Detected that the kafka connector task is not running for datastream task {}. Restarting it",
               datastreamTask.getDatastreamTaskName());
-          if (isTaskThreadDead(connectorTaskEntry)) {
-            _logger.warn("Task thread for datastream task {} has died. No need to attempt to stop the task",
-                datastreamTask.getDatastreamTaskName());
+          // If stoppedTask is null it means that attempting to stop the task failed and that it will be retired again
+          // (in the next restartDeadTasks iteration).
+          // If we dont successfully stop the task before creating another connector task we can potentially end up with
+          // two connector tasks instances running in parallel. This is possible because the acquire method acts as a
+          // re-entrant lock if the same host calls the acquire method for the same task multiple times.
+          DatastreamTask stoppedTask = stopTask(datastreamTask, connectorTaskEntry);
+          if (stoppedTask != null) {
             deadDatastreamTasks.add(datastreamTask);
           } else {
-            // If stoppedTask is null it means that attempting to stop the task failed and that it will be retired again
-            // (in the next restartDeadTasks iteration).
-            // If we dont successfully stop the task before creating another connector task we can potentially end up with
-            // two connector tasks instances running in parallel. This is possible because the acquire method acts as a
-            // re-entrant lock if the same host calls the acquire method for the same task multiple times.
-            DatastreamTask stoppedTask = stopTask(datastreamTask, connectorTaskEntry);
-            if (stoppedTask != null) {
-              deadDatastreamTasks.add(datastreamTask);
-            } else {
-              _logger.error("Connector task for datastream task {} could not be stopped.", datastreamTask.getDatastreamTaskName());
-            }
+            _logger.error("Connector task for datastream task {} could not be stopped.",
+                datastreamTask.getDatastreamTaskName());
           }
         } else {
           _logger.info("Connector task for datastream task {} is healthy", datastreamTask.getDatastreamTaskName());
@@ -362,6 +357,11 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
    */
   private DatastreamTask stopTask(DatastreamTask datastreamTask, ConnectorTaskEntry connectorTaskEntry) {
     try {
+      if (isTaskThreadDead(connectorTaskEntry)) {
+        _logger.warn("Task thread for datastream task {} has died. No need to attempt to stop the task",
+            datastreamTask.getDatastreamTaskName());
+        return datastreamTask;
+      }
       connectorTaskEntry.setPendingStop();
       AbstractKafkaBasedConnectorTask connectorTask = connectorTaskEntry.getConnectorTask();
       connectorTask.stop();

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -352,6 +352,9 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
         LOG.info("Trying to acquire the lock on datastreamTask: {}", _datastreamTask);
         _datastreamTask.acquire(LOCK_ACQUIRE_TIMEOUT);
       } catch (DatastreamRuntimeException ex) {
+        // setting _stoppedLatch count to 0 since the lock couldn't be acquired,
+        // as a non-zero stoppedLatch value won't let the task to be stopped.
+        countDownStoppedLatch();
         LOG.error(String.format("Failed to acquire lock for datastreamTask %s", _datastreamTask), ex);
         _dynamicMetricsManager.createOrUpdateMeter(generateMetricsPrefix(_connectorName, CLASS_NAME), _datastreamName,
             TASK_LOCK_ACQUIRE_ERROR_RATE, 1);

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -84,7 +84,7 @@ public class TestAbstractKafkaConnector {
     props.setProperty("daemonThreadIntervalInSeconds", "2");
     // With failStopTaskOnce set to true the AbstractKafkaBasedConnectorTask.stop is configured
     // to fail the first time with InterruptedException and pass the second time.
-    TestKafkaConnector connector = new TestKafkaConnector(false, props, true);
+    TestKafkaConnector connector = new TestKafkaConnector(false, props, true, false);
     DatastreamTaskImpl datastreamTask1 = new DatastreamTaskImpl();
     datastreamTask1.setTaskPrefix("testtask1");
     connector.onAssignmentChange(Collections.singletonList(datastreamTask1));
@@ -114,7 +114,7 @@ public class TestAbstractKafkaConnector {
     props.setProperty("daemonThreadIntervalInSeconds", "2");
     // With failStopTaskOnce set to true the AbstractKafkaBasedConnectorTask.stop is configured
     // to fail the first time with InterruptedException and pass the second time.
-    TestKafkaConnector connector = new TestKafkaConnector(false, props, true);
+    TestKafkaConnector connector = new TestKafkaConnector(false, props, true, false);
     DatastreamTaskImpl datastreamTask = new DatastreamTaskImpl();
     datastreamTask.setTaskPrefix("testtask1");
     connector.onAssignmentChange(Collections.singletonList(datastreamTask));
@@ -199,19 +199,34 @@ public class TestAbstractKafkaConnector {
     private boolean _failStopTaskOnce;
     private int _createTaskCalled = 0;
     private int _stopTaskCalled = 0;
+    private boolean _taskThreadDead = true;
 
     /**
      * Constructor for TestKafkaConnector
      * @param restartThrows Indicates whether calling {@link #restartDeadTasks()}
      *                      for the first time should throw a {@link RuntimeException}
      * @param props Configuration properties to use
+     * @param failStopTaskOnce Fails Stopping task once
+     * @param taskThreadDead Mocks if the task thread is dead or alive
      */
-    public TestKafkaConnector(boolean restartThrows, Properties props, boolean failStopTaskOnce) {
+    public TestKafkaConnector(boolean restartThrows, Properties props, boolean failStopTaskOnce, boolean taskThreadDead) {
       super("test", props, new KafkaGroupIdConstructor(
           Boolean.parseBoolean(props.getProperty(IS_GROUP_ID_HASHING_ENABLED, Boolean.FALSE.toString())),
           "TestkafkaConnectorCluster"), "TestkafkaConnectorCluster", LOG);
       _restartThrows = restartThrows;
       _failStopTaskOnce = failStopTaskOnce;
+      _taskThreadDead = taskThreadDead;
+    }
+
+    /**
+     * Constructor for TestKafkaConnector
+     * @param restartThrows Indicates whether calling {@link #restartDeadTasks()}
+     *                      for the first time should throw a {@link RuntimeException}
+     * @param props Configuration properties to use
+     * @param failStopTaskOnce Fails Stopping task once
+     */
+    public TestKafkaConnector(boolean restartThrows, Properties props, boolean failStopTaskOnce) {
+      this(restartThrows, props, failStopTaskOnce, true);
     }
 
     @Override
@@ -241,7 +256,7 @@ public class TestAbstractKafkaConnector {
 
     @Override
     protected boolean isTaskThreadDead(ConnectorTaskEntry connectorTaskEntry) {
-      return true;
+      return _taskThreadDead;
     }
 
     @Override


### PR DESCRIPTION
Fixed stop logic by preventing to stop dead-thread tasks and also maintaining stopping latch counter irrespective of success or failure in acquiring task lock.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
