### PR TITLE
Adding comments for kafka 2.4 functionality changes

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -769,6 +769,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   public void onPartitionsRevoked(Collection<TopicPartition> topicPartitions) {
     _logger.info("Partition ownership revoked for {}, checkpointing.", topicPartitions);
     _kafkaTopicPartitionTracker.onPartitionsRevoked(topicPartitions);
+    //_failure flag is used to address 2.4 kafka version behavior changes for onPartitionRevoked calls.
+    //Prior to this version, consumer close was not calling onPartitionsRevoked.
     if (!_shutdown && !topicPartitions.isEmpty() && !_failure) { // there is a commit at the end of the run method, skip extra commit in shouldDie mode.
       try {
         maybeCommitOffsets(_consumer, true); // happens inline as part of poll

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -370,6 +370,8 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
 
   @Override
   public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+    //Do not remove super.onPartitionsRevoked call or refactor the code to take care of the kafka 2.4 changes.
+    //Prior to this version, consumer close was not calling onPartitionsRevoked.
     super.onPartitionsRevoked(partitions);
     _topicManager.onPartitionsRevoked(partitions);
   }


### PR DESCRIPTION
Adding explicit comments for prevent loss of functionality in the over ridden API onPartitionsRevoked in [KafkaMirrorMakerConnectorTask]
Mode details about this in comments in the PR https://github.com/linkedin/brooklin/pull/881