### PR TITLE
Added new datastream metadata field to include allowlist regex

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -130,4 +130,9 @@ public class DatastreamMetadataConstants {
    * Datastream metadata that represents number of tasks
    */
   public static final String NUM_TASKS = "numTasks";
+
+  /**
+   * Datastream metadata that represents the source allowlist
+   */
+  public static final String REGEX_SOURCE_ALLOWLIST = "system.source.allowlist";
 }


### PR DESCRIPTION
Added allow-listing config in datastream metadata for easy access and configuration in BMM based operations. Until now the allow-listing value was appended into the connection string for the Kafka pub-sub system, but to use it for any other pub-sub systems differently, I wanted to expose that as separate metadata instead of doing string manipulations in the server code.

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
