### PR TITLE
skipping onPartitionsRevoked during consumer.close() call

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -259,7 +259,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   /**
    * Exposing the flag for overridden classes
    */
-  protected Boolean getSkipOnPartitionsRevoked() {
+  protected boolean getSkipOnPartitionsRevoked() {
     return _skipOnPartitionsRevoked;
   }
 
@@ -774,7 +774,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   @Override
   public void onPartitionsRevoked(Collection<TopicPartition> topicPartitions) {
     if (_skipOnPartitionsRevoked) {
-      _logger.info("Skipping commit in onPartitionsRevoked during consumer.close().");
+      _logger.info("Skipping commit in onPartitionsRevoked during consumer.close()");
       return;
     }
     _logger.info("Partition ownership revoked for {}, checkpointing.", topicPartitions);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -774,7 +774,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   @Override
   public void onPartitionsRevoked(Collection<TopicPartition> topicPartitions) {
     if (_skipOnPartitionsRevoked) {
-      _logger.warn("Skipping commit in onPartitionsRevoked due to an exception.");
+      _logger.info("Skipping commit in onPartitionsRevoked during consumer.close().");
       return;
     }
     _logger.info("Partition ownership revoked for {}, checkpointing.", topicPartitions);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -371,7 +371,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   @Override
   public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
     if (getSkipOnPartitionsRevoked()) {
-      _logger.warn("Skipping commit in onPartitionsRevoked due to exception.");
+      _logger.info("Skipping commit in onPartitionsRevoked during consumer.close().");
       return;
     }
     super.onPartitionsRevoked(partitions);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -370,6 +370,10 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
 
   @Override
   public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
+    if (getSkipOnPartitionsRevoked()) {
+      _logger.warn("Skipping commit in onPartitionsRevoked due to exception.");
+      return;
+    }
     super.onPartitionsRevoked(partitions);
     _topicManager.onPartitionsRevoked(partitions);
   }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -371,7 +371,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
   @Override
   public void onPartitionsRevoked(Collection<TopicPartition> partitions) {
     if (getSkipOnPartitionsRevoked()) {
-      _logger.info("Skipping commit in onPartitionsRevoked during consumer.close().");
+      _logger.info("Skipping commit in onPartitionsRevoked during consumer.close()");
       return;
     }
     super.onPartitionsRevoked(partitions);

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "2.0.0"
+  version = "3.0.0-SNAPSHOT"
 }
 
 subprojects {

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "3.0.0-SNAPSHOT"
+  version = "3.0.0"
 }
 
 subprojects {


### PR DESCRIPTION
Adding functionality to skip onPartitionsRevoked call during consumer.close(). Else it would lead to duplicate calls to onPartitionsRevoked().
More details about this in comments in the PR https://github.com/linkedin/brooklin/pull/881
