### PR TITLE
tests for min/max partitions per task metrics and minor code quality improvements

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -129,6 +129,7 @@ public class DynamicMetricsManager {
    */
   @SuppressWarnings("unchecked")
   private <T extends Metric> T getMetric(String name, Class<T> clazz) {
+    Validate.notNull(clazz, "metric class argument is null.");
     if (clazz.equals(Counter.class)) {
       return (T) _metricRegistry.counter(name);
     } else if (clazz.equals(Meter.class)) {
@@ -136,53 +137,23 @@ public class DynamicMetricsManager {
     } else if (clazz.equals(Histogram.class)) {
       return (T) _metricRegistry.histogram(name);
     } else if (clazz.equals(Gauge.class)) {
-      return (T) new ResettableGauge<>();
+      throw new IllegalArgumentException("This method doesn't work with Gauges.");
     } else if (clazz.equals(Timer.class)) {
-      return (T) new Timer();
+      return (T) _metricRegistry.timer(name);
     } else {
       throw new IllegalArgumentException("Invalid metric type: " + clazz);
     }
   }
 
-  /**
-   * Internal method to create and register a metric with the registry. If the metric with the same
-   * name has already been registered before, it will be returned instead of creating a new one as
-   * metric registry forbids duplicate registrations. For an existing Gauge metric, we replace its
-   * value supplier with the new supplier passed in.
-   * @param simpleName namespace of the metric
-   * @param key optional key for the metric (eg. source name)
-   * @param metricName actual name of the metric
-   * @param metricClass class of the metric type
-   * @param supplier optional supplier for Gauge metric (not used for non-Gauge metrics)
-   * @param <T> metric type
-   * @param <V> value type for the supplier
-   */
-  @SuppressWarnings("unchecked")
-  private <T extends Metric, V> T doRegisterMetric(String simpleName, String key, String metricName,
-      Class<T> metricClass, Supplier<V> supplier) {
-    validateArguments(simpleName, metricName);
-    Validate.notNull(metricClass, "metric class argument is null.");
-
-    String fullMetricName = MetricRegistry.name(simpleName, key, metricName);
-
-    Metric metric = getMetric(fullMetricName, metricClass);
+  private void countReference(String fullMetricName) {
     _registeredMetricRefCount.compute(fullMetricName, (localKey, val) -> (val == null) ? 1 : val + 1);
-    if (metric instanceof ResettableGauge) {
-      Validate.notNull(supplier, "null supplier to Gauge");
-      ((ResettableGauge) metric).setSupplier(supplier);
-
-      try {
-        // Gauge needs explicit registration
-        _metricRegistry.register(fullMetricName, metric);
-      } catch (IllegalArgumentException e) {
-        // This can happen with parallel unit tests
-      }
-    }
-
     // _indexedMetrics update is left to the createOrUpdate APIs which is only needed
     // if the same metrics are accessed through both registerMetric and createOrUpdate.
+  }
 
-    return (T) metric;
+  private String formatName(String simpleName, String key, String metricName) {
+    validateArguments(simpleName, metricName);
+    return MetricRegistry.name(simpleName, key, metricName);
   }
 
   /**
@@ -196,8 +167,12 @@ public class DynamicMetricsManager {
    */
   @SuppressWarnings("unchecked")
   public <T extends Metric> T registerMetric(String simpleName, String key, String metricName, Class<T> metricClass) {
-    Validate.isTrue(!metricClass.equals(Gauge.class), "please call registerGauge() to register a Gauge metric.");
-    return doRegisterMetric(simpleName, key, metricName, metricClass, null);
+    if (Gauge.class.isAssignableFrom(metricClass)) {
+      throw new IllegalArgumentException("Cannot register Gauges; use registerGauge");
+    }
+    String name = formatName(simpleName, key, metricName);
+    countReference(name);
+    return getMetric(name, metricClass);
   }
 
   /**
@@ -221,7 +196,9 @@ public class DynamicMetricsManager {
    */
   @SuppressWarnings("unchecked")
   public <T> Gauge<T> registerGauge(String simpleName, String key, String metricName, Supplier<T> supplier) {
-    return doRegisterMetric(simpleName, key, metricName, Gauge.class, supplier);
+    String name = formatName(simpleName, key, metricName);
+    countReference(name);
+    return _metricRegistry.gauge(name, () -> new ResettableGauge<T>(supplier));
   }
 
   /**
@@ -231,9 +208,8 @@ public class DynamicMetricsManager {
    * @param supplier value supplier for the Gauge
    * @return the metric just registered or previously registered one
    */
-  @SuppressWarnings("unchecked")
   public <T> Gauge<T> registerGauge(String simpleName, String metricName, Supplier<T> supplier) {
-    return doRegisterMetric(simpleName, null, metricName, Gauge.class, supplier);
+    return registerGauge(simpleName, null, metricName, supplier);
   }
 
   /**

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -330,37 +330,6 @@ public class DynamicMetricsManager {
   }
 
   /**
-   * Updates the Gauge (or creates it if it does not exist) for the specified key/metricName pair to the given value.
-   * A Gauge used in this way should not have an explicit supplier.
-   * @param classSimpleName the simple name of the underlying class
-   * @param key the key (i.e. topic or partition) for the metric
-   * @param metricName the metric name
-   * @param value the new value
-   */
-  @SuppressWarnings("unchecked")
-  public <T> void createOrUpdateGauge(String classSimpleName, String key, String metricName, T value) {
-    validateArguments(classSimpleName, metricName);
-    // create and register the metric if it does not exist
-    ResettableGauge<T> gauge = (ResettableGauge<T>) checkCache(classSimpleName, key, metricName).orElseGet(() -> {
-      ResettableGauge<T> newGauge = (ResettableGauge<T>) _metricRegistry.gauge(
-        MetricRegistry.name(classSimpleName, key, metricName), () -> new ResettableGauge<>(() -> value));
-      updateCache(classSimpleName, key, metricName, newGauge);
-      return newGauge;
-    });
-    gauge.setSupplier(() -> value);
-  }
-
-  /**
-   * Updates the Gauge (or creates it if it does not exist) for the specified metricName to the given value.
-   * @param classSimpleName the simple name of the underlying class
-   * @param metricName the metric name
-   * @param value the new value
-   */
-  public <T> void createOrUpdateGauge(String classSimpleName, String metricName, T value) {
-    createOrUpdateGauge(classSimpleName, null, metricName, value);
-  }
-
-  /**
    * Update the histogram (or creates it if it does not exist) for the specified key/metricName pair by the given value.
    * If the histogram does not exist, create one using {@link SlidingTimeWindowArrayReservoir} with the specified window
    * time in ms. This can be useful for certain metrics that don't want to use the

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -213,6 +213,14 @@ public class DynamicMetricsManager {
   }
 
   /**
+   * Explicitly set the Supplier for a Gauge.
+   */
+  public <T> void setGauge(Gauge<T> gauge, Supplier<T> supplier) {
+    Validate.isTrue(gauge instanceof ResettableGauge, "Unsupported Gauge impl.");
+    ((ResettableGauge<T>) gauge).setSupplier(supplier);
+  }
+
+  /**
    * Unregister the metric for the specified key/metricName pair by the given value; if it has
    * never been registered, do nothing
    * @param simpleName the simple name of the underlying class

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -346,12 +346,12 @@ public class DynamicMetricsManager {
   }
 
   /**
-   * Set the Gauge (or creates it if it does not exist) for the specified key/metricName pair to the given value.
+   * Updates the Gauge (or creates it if it does not exist) for the specified key/metricName pair to the given value.
    * A Gauge used in this way should not have an explicit supplier.
    * @param classSimpleName the simple name of the underlying class
    * @param key the key (i.e. topic or partition) for the metric
    * @param metricName the metric name
-   * @param value amount to increment the counter by (use negative value to decrement)
+   * @param value the new value
    */
   @SuppressWarnings("unchecked")
   public <T> void createOrUpdateGauge(String classSimpleName, String key, String metricName, T value) {
@@ -367,10 +367,10 @@ public class DynamicMetricsManager {
   }
 
   /**
-   * Update the counter (or creates it if it does not exist) for the specified metricName.
+   * Updates the Gauge (or creates it if it does not exist) for the specified metricName to the given value.
    * @param classSimpleName the simple name of the underlying class
    * @param metricName the metric name
-   * @param value amount to increment the counter by (use negative value to decrement)
+   * @param value the new value
    */
   public <T> void createOrUpdateGauge(String classSimpleName, String metricName, T value) {
     createOrUpdateGauge(classSimpleName, null, metricName, value);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
@@ -192,6 +192,7 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
 
     IntSummaryStatistics stats = newAssignments.values().stream()
       .flatMap(x -> x.stream()) // flatten
+      .filter(x -> x.getTaskPrefix().equals(datastreamGroupName))
       .collect(Collectors.summarizingInt(x -> x.getPartitionsV2().size()));
 
     // update metrics

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -233,7 +233,6 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
    */
   @Override
   public void cleanupStrategy() {
-    _assigner.cleanupMetrics();
     super.cleanupStrategy();
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -233,6 +233,7 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
    */
   @Override
   public void cleanupStrategy() {
+    _assigner.cleanupMetrics();
     super.cleanupStrategy();
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssigner.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssigner.java
@@ -13,12 +13,15 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Metric;
 import com.codahale.metrics.MetricRegistry;
 
 import com.linkedin.datastream.common.Datastream;
@@ -34,6 +37,7 @@ import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.server.PartitionThroughputInfo;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 import com.linkedin.datastream.testutil.DatastreamTestUtils;
+import com.linkedin.datastream.testutil.MetricsTestUtils;
 
 import static org.mockito.Matchers.anyString;
 
@@ -94,6 +98,11 @@ public class TestLoadBasedPartitionAssigner {
     Assert.assertEquals(statObj.getTotalPartitions(), 1);
     Assert.assertEquals(statObj.getPartitionsWithUnknownThroughput(), 0);
     Assert.assertEquals(statObj.getThroughputRateInKBps(), 5);
+
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.minPartitionsAcrossTasks", 1);
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.maxPartitionsAcrossTasks", 1);
+
+    MetricsTestUtils.verifyMetrics(assigner, DynamicMetricsManager.getInstance());
   }
 
   @Test
@@ -148,6 +157,13 @@ public class TestLoadBasedPartitionAssigner {
     Assert.assertEquals(statObj.getTotalPartitions(), 1);
     Assert.assertEquals(statObj.getPartitionsWithUnknownThroughput(), 0);
     Assert.assertEquals(statObj.getThroughputRateInKBps(), 5);
+
+    assertMetric("LoadBasedPartitionAssigner.ds1.minPartitionsAcrossTasks", (Integer x) -> x > 0);
+    assertMetric("LoadBasedPartitionAssigner.ds1.maxPartitionsAcrossTasks", (Integer x) -> x <= 3);
+    assertMetric("LoadBasedPartitionAssigner.ds2.minPartitionsAcrossTasks", (Integer x) -> x > 0);
+    assertMetric("LoadBasedPartitionAssigner.ds2.maxPartitionsAcrossTasks", (Integer x) -> x <= 3);
+
+    MetricsTestUtils.verifyMetrics(assigner, DynamicMetricsManager.getInstance());
   }
 
   @Test
@@ -183,6 +199,11 @@ public class TestLoadBasedPartitionAssigner {
     Assert.assertEquals(statObj.getTotalPartitions(), 2);
     Assert.assertEquals(statObj.getPartitionsWithUnknownThroughput(), 2);
     Assert.assertEquals(statObj.getThroughputRateInKBps(), 0);
+
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.minPartitionsAcrossTasks", 2);
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.maxPartitionsAcrossTasks", 2);
+
+    MetricsTestUtils.verifyMetrics(assigner, DynamicMetricsManager.getInstance());
   }
 
   @Test
@@ -216,6 +237,11 @@ public class TestLoadBasedPartitionAssigner {
     // verify that task in instance1 got the new partition
     Assert.assertEquals(task3.getPartitionsV2().size(), 3);
     Assert.assertTrue(task3.getPartitionsV2().contains("P4"));
+
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.minPartitionsAcrossTasks", 1);
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.maxPartitionsAcrossTasks", 3);
+
+    MetricsTestUtils.verifyMetrics(assigner, DynamicMetricsManager.getInstance());
   }
 
   @Test
@@ -255,7 +281,10 @@ public class TestLoadBasedPartitionAssigner {
     // verify that task in instance1 got the new partition
     Assert.assertEquals(task4.getPartitionsV2().size(), 2);
     Assert.assertTrue(task4.getPartitionsV2().contains("P-2"));
+
+    MetricsTestUtils.verifyMetrics(assigner, DynamicMetricsManager.getInstance());
   }
+
 
   @Test
   public void throwsExceptionWhenNotEnoughRoomForAllPartitionsTest() {
@@ -313,6 +342,11 @@ public class TestLoadBasedPartitionAssigner {
     // verify that task in instance2 got the new partition
     Assert.assertEquals(task3.getPartitionsV2().size(), 2);
     Assert.assertTrue(task3.getPartitionsV2().contains("P4"));
+
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.minPartitionsAcrossTasks", 2);
+    assertMetricEquals("LoadBasedPartitionAssigner.ds1.maxPartitionsAcrossTasks", 2);
+
+    MetricsTestUtils.verifyMetrics(assigner, DynamicMetricsManager.getInstance());
   }
 
   @Test
@@ -342,6 +376,8 @@ public class TestLoadBasedPartitionAssigner {
     partitionsMap2.get("T3").add("P2");
     index2 = assigner.findTaskWithRoomForAPartition(tasks2, partitionsMap2, 1, 1);
     Assert.assertEquals(index2, 0);
+
+    MetricsTestUtils.verifyMetrics(assigner, DynamicMetricsManager.getInstance());
   }
 
   private DatastreamTask createTaskForDatastream(Datastream datastream) {
@@ -366,5 +402,21 @@ public class TestLoadBasedPartitionAssigner {
           new PartitionThroughputInfo(bytesInRate, messagesInRate, partitionName));
     }
     return new ClusterThroughputInfo("dummy", partitionThroughputMap);
+  }
+
+  @SuppressWarnings("unchecked")
+  private <T> void assertMetric(String name, Predicate<T> predicate) {
+   Metric metric = DynamicMetricsManager.getInstance().getMetric(name);
+    Assert.assertNotNull(metric);
+    if (metric instanceof Gauge) {
+      T value = ((Gauge<T>) metric).getValue();
+      Assert.assertTrue(predicate.test(value), "(value " + value.toString() + ")");
+    } else {
+      Assert.fail("unexpected metric type " + metric.getClass().getSimpleName());
+    }
+  }
+
+  private <T> void assertMetricEquals(String name, T value) {
+    assertMetric(name, Predicate.isEqual(value));
   }
 }


### PR DESCRIPTION
Fixed bug where min/max partitions per task was being reported incorrectly. Previously, the min/max were the same across all datastreams.

New setGauge method in DynamicMetricsManager enables explicitly setting a gauge value. This reduces some lifecycle management complexity in LoadBalancedPartitionAssigner.

Incidental code quality improvements.

Tests added to verify affected metrics (min/maxPartitionsPerTask).

Fixed bug related to registration of Gauges and Timers (they weren't actually registered before).

Dropped (accidentally?) exported class that was holding min/max stats per task.