### PR TITLE
fix rebalancing-tasks bug and added tests

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -205,7 +205,8 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
       int minTasksPerInstance = tasksTotal / instances.size();
 
       // some rebalance to increase the task count in instances below the minTasksPerInstance
-      while (newAssignment.get(instancesBySize.get(0)).size() < minTasksPerInstance) {
+      while (newAssignment.get(instancesBySize.get(0)).size() + _imbalanceThreshold < newAssignment.get(
+          instancesBySize.get(instancesBySize.size() - 1)).size()) {
         String smallInstance = instancesBySize.get(0);
         String largeInstance = instancesBySize.get(instancesBySize.size() - 1);
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyMulticastStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyMulticastStrategy.java
@@ -515,6 +515,24 @@ public class TestStickyMulticastStrategy {
     reBalancingTasksWithThresholdHelper(instances, new int[]{5, 5, 5}, 1);
     reBalancingTasksWithThresholdHelper(instances, new int[]{5, 5, 5}, 2);
     reBalancingTasksWithThresholdHelper(instances, new int[]{5, 5, 5}, 3);
+
+    instances = new String[]{"instance1", "instance2"};
+    reBalancingTasksWithThresholdHelper(instances, new int[]{9, 13}, 1);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{9, 13}, 2);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{9, 13}, 3);
+
+    reBalancingTasksWithThresholdHelper(instances, new int[]{1, 10}, 1);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{1, 10}, 2);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{1, 10}, 3);
+
+    reBalancingTasksWithThresholdHelper(instances, new int[]{5, 5}, 1);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{5, 5}, 2);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{5, 5}, 3);
+
+    instances = new String[]{"instance1"};
+    reBalancingTasksWithThresholdHelper(instances, new int[]{9}, 1);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{9}, 2);
+    reBalancingTasksWithThresholdHelper(instances, new int[]{9}, 3);
   }
 
   // this helper function tests the rebalancing of tasks with an imbalance threshold across the instances


### PR DESCRIPTION
### Problem: 
Both the LoadBasedPartition and StickyPartition Strategy follow the StickyMulticastStrategy to assign the datastream tasks across the available instances. 

In the StickyMulticastStrategy, the last step of the process is to rebalance the tasks across instances such that the number of tasks across the instances adheres to the `imbalance threshold` value.  

> _Basically, the difference between the max #tasks assigned to any instance and the min #tasks assigned to any other instance should not exceed the imbalance threshold_. 


In the current implementation, there was a minor bug, which in some cases failed to achieve that proper rebalance. That issue causes validation failures and thus availability misses on the mirror-making service. 
____
**Failure Scenario:** Observed in production service with 6 instances connected to ZK and has 538 tasks in total.

We saw from the production logs that the tasks were distributed across the instances with counts: _89, 89, 89, 89, 93, 89_ 

And given that we enforce the imbalance threshold of 1, the actual distribution should have been something like 
_89, 89, 90, 90, 90, 90_

In the below pasted rebalance code, 

_tasksTotal = 538_
_minTasksPerInstance = 538 / 6 = 89_ 
And since the minimum number of tasks assigned == minTasksPerInstance, it won't go in the while loop to rebalance.

```
// STEP 3: Trigger rebalance if the number of different tasks more than the configured threshold

if (newAssignment.get(instancesBySize.get(instancesBySize.size() - 1)).size() - newAssignment.get(instancesBySize.get(0)).size() > _imbalanceThreshold) {
 int tasksTotal = newAssignment.values().stream().mapToInt(Set::size).sum();
 int minTasksPerInstance = tasksTotal / instances.size();

 // some rebalance to increase the task count in instances below the minTasksPerInstance
 while (newAssignment.get(instancesBySize.get(0)).size() < minTasksPerInstance) {
   ...
 }
}
```
____
### Solution:
Update the rebalancing code condition to only terminate when the **min #tasks assigned + the imbalance threshold is less than the max #tasks assigned**.

_____
Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
