### PR TITLE
Use 2.4.1.57 kafka version

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -9,7 +9,7 @@ ext {
     guavaVersion = "25.0-jre"
     intellijAnnotationsVersion = "12.0"
     jacksonVersion = "2.10.0"
-    kafkaVersion = "2.4.1.42"
+    kafkaVersion = "2.4.1.57"
     log4jVersion = "1.2.17"
     metricsCoreVersion = "4.1.0"
     mockitoVersion = "1.10.19"


### PR DESCRIPTION
2.4.1.42 version was causing build failures due to a mismatch of java versions used to compile and run. 2.4.1.57 fixes it.  

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
