### PR TITLE
Remove Scala Dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -161,8 +161,8 @@ project(':datastream-utils') {
     compile project(':datastream-common')
     compile "com.101tec:zkclient:$zkclientVersion"
     compile "com.google.guava:guava:$guavaVersion"
-    testCompile project(":datastream-kafka_$scalaSuffix")
-    testCompile project(":datastream-testcommon_$scalaSuffix")
+    testCompile project(":datastream-kafka")
+    testCompile project(":datastream-testcommon")
   }
 }
 
@@ -172,7 +172,7 @@ project(':datastream-file-connector') {
     compile project(':datastream-common')
     compile project(':datastream-utils')
     testCompile project(':datastream-server')
-    testCompile project(":datastream-testcommon_$scalaSuffix")
+    testCompile project(":datastream-testcommon")
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 }
@@ -188,7 +188,7 @@ project(':datastream-directory') {
   }
 }
 
-project(":datastream-kafka_$scalaSuffix") {
+project(":datastream-kafka") {
   dependencies {
     compile "com.linkedin.kafka:kafka_$scalaSuffix:$kafkaVersion"
     compile "commons-httpclient:commons-httpclient:$commonsHttpClientVersion"
@@ -197,7 +197,7 @@ project(":datastream-kafka_$scalaSuffix") {
     compile project(':datastream-server-api')
     compile project(':datastream-utils')
 
-    testCompile project(":datastream-testcommon_$scalaSuffix")
+    testCompile project(":datastream-testcommon")
     testCompile "org.mockito:mockito-core:$mockitoVersion"
 
     tasks.create(name: "copyDependentLibs", type: Copy) {
@@ -216,7 +216,7 @@ project(':datastream-kafka-factory-impl') {
   dependencies {
     compile project(':datastream-kafka-connector')
 
-    testCompile project(":datastream-kafka_$scalaSuffix")
+    testCompile project(":datastream-kafka")
   }
 }
 
@@ -224,23 +224,23 @@ project(':datastream-kafka-connector') {
   dependencies {
     compile project(':datastream-server-api')
     compile project(':datastream-common')
-    compile project(":datastream-kafka_$scalaSuffix")
+    compile project(":datastream-kafka")
     compile "org.apache.httpcomponents:httpclient:$apacheHttpClientVersion"
     compile "commons-validator:commons-validator:$commonsValidatorVersion"
     compile "org.apache.commons:commons-lang3:$commonslang3Version"
     compile "javax.xml.bind:jaxb-api:2.3.1"
 
-    testCompile project(":datastream-kafka_$scalaSuffix")
-    testCompile project(":datastream-testcommon_$scalaSuffix")
+    testCompile project(":datastream-kafka")
+    testCompile project(":datastream-testcommon")
     testCompile project(':datastream-kafka-factory-impl')
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 }
 
-project(":datastream-testcommon_$scalaSuffix") {
+project(":datastream-testcommon") {
   dependencies {
     compile project(':datastream-server-api')
-    compile project(":datastream-kafka_$scalaSuffix")
+    compile project(":datastream-kafka")
     compile project(':datastream-common')
     compile project(':datastream-utils')
     compile project(':datastream-server')
@@ -261,7 +261,7 @@ project(':datastream-tools') {
     compile project(':datastream-common')
     compile project(':datastream-client')
     compile project(':datastream-server')
-    compile project(":datastream-testcommon_$scalaSuffix")
+    compile project(":datastream-testcommon")
     compile "commons-cli:commons-cli:$commonsCliVersion"
   }
 
@@ -284,12 +284,12 @@ project(':datastream-tools') {
     from(project(':datastream-file-connector').configurations.runtime) { into("libs/") }
     from(project(':datastream-directory').jar) { into("libs/") }
     from(project(':datastream-directory').configurations.runtime) { into("libs/") }
-    from(project(":datastream-testcommon_$scalaSuffix").jar) { into("libs/") }
-    from(project(":datastream-testcommon_$scalaSuffix").configurations.runtime) { into("libs/") }
+    from(project(":datastream-testcommon").jar) { into("libs/") }
+    from(project(":datastream-testcommon").configurations.runtime) { into("libs/") }
     from(project(':datastream-common').jar) { into("libs/") }
     from(project(':datastream-common').configurations.runtime) { into("libs/") }
-    from(project(":datastream-kafka_$scalaSuffix").jar) { into("libs/") }
-    from(project(":datastream-kafka_$scalaSuffix").configurations.runtime) { into("libs/") }
+    from(project(":datastream-kafka").jar) { into("libs/") }
+    from(project(":datastream-kafka").configurations.runtime) { into("libs/") }
     from(project(':datastream-kafka-connector').jar) { into("libs/") }
     from(project(':datastream-kafka-connector').configurations.runtime) { into("libs/") }
     duplicatesStrategy 'exclude'
@@ -308,8 +308,8 @@ project(':datastream-client') {
     compile project(':datastream-common')
     compile project(':datastream-utils')
 
-    testCompile project(":datastream-testcommon_$scalaSuffix")
-    testCompile project(":datastream-kafka_$scalaSuffix")
+    testCompile project(":datastream-testcommon")
+    testCompile project(":datastream-kafka")
     testCompile project(':datastream-server')
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
@@ -328,10 +328,10 @@ project(':datastream-server') {
     compile project(':datastream-utils')
     compile project(':datastream-client')
 
-    testCompile project(":datastream-kafka_$scalaSuffix")
+    testCompile project(":datastream-kafka")
     testCompile "com.linkedin.kafka:kafka_$scalaSuffix:$kafkaVersion"
     testCompile project(':datastream-client')
-    testCompile project(":datastream-testcommon_$scalaSuffix")
+    testCompile project(":datastream-testcommon")
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 
@@ -364,11 +364,11 @@ project(':datastream-server-restli') {
     compile project(':datastream-server')
     compile project(':datastream-common')
 
-    testCompile project(":datastream-kafka_$scalaSuffix")
+    testCompile project(":datastream-kafka")
     testCompile "com.linkedin.kafka:kafka_$scalaSuffix:$kafkaVersion"
     testCompile project(':datastream-client')
     testCompile project(':datastream-file-connector')
-    testCompile project(":datastream-testcommon_$scalaSuffix")
+    testCompile project(":datastream-testcommon")
     testCompile "org.mockito:mockito-core:$mockitoVersion"
   }
 

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedKafkaCluster.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/EmbeddedKafkaCluster.java
@@ -17,7 +17,7 @@ import org.apache.kafka.common.utils.SystemTime;
 import org.apache.kafka.common.utils.Time;
 
 import kafka.server.KafkaConfig;
-import kafka.server.KafkaServer;
+import kafka.server.KafkaServerStartable;
 
 import com.linkedin.datastream.common.FileUtils;
 import com.linkedin.datastream.common.NetworkUtils;
@@ -33,7 +33,7 @@ public class EmbeddedKafkaCluster {
 
   private final String _brokers;
 
-  private final List<KafkaServer> _brokerList;
+  private final List<KafkaServerStartable> _brokerList;
   private final List<File> _logDirs;
 
   /**
@@ -115,16 +115,15 @@ public class EmbeddedKafkaCluster {
       properties.setProperty("log.cleaner.enable", Boolean.FALSE.toString()); //to save memory
       properties.setProperty("offsets.topic.num.partitions", "1");
 
-      KafkaServer broker = startBroker(properties);
+      KafkaServerStartable broker = startBroker(properties);
 
       _brokerList.add(broker);
       _logDirs.add(logDir);
     }
   }
 
-  private KafkaServer startBroker(Properties props) {
-    KafkaServer server = new KafkaServer(KafkaConfig.fromProps(props), new EmbeddedSystemTime(),
-        scala.Option.apply(""), scala.collection.JavaConversions.asScalaBuffer(Collections.emptyList()));
+  private KafkaServerStartable startBroker(Properties props) {
+    KafkaServerStartable server = new KafkaServerStartable(KafkaConfig.fromProps(props));
     server.startup();
     return server;
   }
@@ -156,7 +155,7 @@ public class EmbeddedKafkaCluster {
    * Shut down the Kafka cluster
    */
   public void shutdown() {
-    for (KafkaServer broker : _brokerList) {
+    for (KafkaServerStartable broker : _brokerList) {
       try {
         broker.shutdown();
       } catch (Exception e) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -11,18 +11,5 @@ include 'datastream-server-api'
 include 'datastream-server-restli'
 include 'datastream-tools'
 include 'datastream-utils'
-
-def scalaModules = [
-    'datastream-kafka',
-    'datastream-testcommon'
-] as HashSet
-
-scalaModules.each {
-  include it
-}
-
-rootProject.children.each {
-  if (scalaModules.contains(it.name)) {
-    it.name = it.name + "_" + scalaSuffix
-  }
-}
+include 'datastream-testcommon'
+include 'datastream-kafka'


### PR DESCRIPTION
Remove minimally used Scala Dependencies from Brooklin code to avoid cross-scala versions builds.

______ 

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
