### PR TITLE
Dedupe tasks on LeaderDoAssignment

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -88,8 +88,8 @@ public class BroadcastStrategy implements AssignmentStrategy {
     Map<String, List<DatastreamTask>> reuseTaskMap =
         tasksAvailableToReuse.stream().collect(Collectors.groupingBy(DatastreamTask::getTaskPrefix));
     int instancePos = 0;
-    Set<String> uniqueDatastreamTaskNamesSet = new HashSet<>();
     for (DatastreamGroup dg : datastreams) {
+      Set<String> uniqueDatastreamTaskNamesSet = new HashSet<>();
       List<DatastreamTask> reuseTasksPerDg = reuseTaskMap.getOrDefault(dg.getTaskPrefix(), Collections.emptyList());
 
       int numTasks = getNumTasks(dg, instances.size());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -88,7 +88,7 @@ public class BroadcastStrategy implements AssignmentStrategy {
     Map<String, List<DatastreamTask>> reuseTaskMap =
         tasksAvailableToReuse.stream().collect(Collectors.groupingBy(DatastreamTask::getTaskPrefix));
     int instancePos = 0;
-    Set<String> uniqueDatastreamTaskNames = new HashSet<>();
+    Set<String> uniqueDatastreamTaskNamesSet = new HashSet<>();
     for (DatastreamGroup dg : datastreams) {
       List<DatastreamTask> reuseTasksPerDg = reuseTaskMap.getOrDefault(dg.getTaskPrefix(), Collections.emptyList());
 
@@ -106,7 +106,7 @@ public class BroadcastStrategy implements AssignmentStrategy {
         currentAssignmentCopy.get(instance).remove(foundDatastreamTask);
 
         // Prevent duplicate datastream task names
-        if (!uniqueDatastreamTaskNames.add(foundDatastreamTask.getDatastreamTaskName())) {
+        if (!uniqueDatastreamTaskNamesSet.add(foundDatastreamTask.getDatastreamTaskName())) {
           continue;
         }
         newAssignment.get(instance).add(foundDatastreamTask);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -101,16 +101,16 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
     List<DatastreamTask> currentlyAssignedDatastreamTasks = new ArrayList<>();
     currentAssignment.values().forEach(currentlyAssignedDatastreamTasks::addAll);
 
-    Set<String> uniqueDatastreamTaskNames = new HashSet<>();
+    Set<String> uniqueDatastreamTaskNamesSet = new HashSet<>();
     for (DatastreamGroup dg : datastreams) {
       Set<DatastreamTask> tasksForDatastreamGroup = currentlyAssignedDatastreamTasks.stream()
-          .filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && uniqueDatastreamTaskNames.add(x.getDatastreamTaskName()))
+          .filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && uniqueDatastreamTaskNamesSet.add(x.getDatastreamTaskName()))
           .collect(Collectors.toSet());
 
       // If there are no datastream tasks that are currently assigned for this datastream.
       if (tasksForDatastreamGroup.isEmpty()) {
         tasksForDatastreamGroup = createTasksForDatastream(dg, maxTasksPerDatastream);
-        uniqueDatastreamTaskNames.addAll(tasksForDatastreamGroup
+        uniqueDatastreamTaskNamesSet.addAll(tasksForDatastreamGroup
             .stream()
             .map(DatastreamTask::getDatastreamTaskName)
             .collect(Collectors.toSet()));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -101,8 +101,8 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
     List<DatastreamTask> currentlyAssignedDatastreamTasks = new ArrayList<>();
     currentAssignment.values().forEach(currentlyAssignedDatastreamTasks::addAll);
 
-    Set<String> uniqueDatastreamTaskNamesSet = new HashSet<>();
     for (DatastreamGroup dg : datastreams) {
+      Set<String> uniqueDatastreamTaskNamesSet = new HashSet<>();
       Set<DatastreamTask> tasksForDatastreamGroup = currentlyAssignedDatastreamTasks.stream()
           .filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && uniqueDatastreamTaskNamesSet.add(x.getDatastreamTaskName()))
           .collect(Collectors.toSet());
@@ -110,10 +110,6 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
       // If there are no datastream tasks that are currently assigned for this datastream.
       if (tasksForDatastreamGroup.isEmpty()) {
         tasksForDatastreamGroup = createTasksForDatastream(dg, maxTasksPerDatastream);
-        uniqueDatastreamTaskNamesSet.addAll(tasksForDatastreamGroup
-            .stream()
-            .map(DatastreamTask::getDatastreamTaskName)
-            .collect(Collectors.toSet()));
       } else {
         Datastream datastream = dg.getDatastreams().get(0);
         if (datastream.hasSource() && datastream.getSource().hasPartitions()) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadbalancingStrategy.java
@@ -101,14 +101,19 @@ public class LoadbalancingStrategy implements AssignmentStrategy {
     List<DatastreamTask> currentlyAssignedDatastreamTasks = new ArrayList<>();
     currentAssignment.values().forEach(currentlyAssignedDatastreamTasks::addAll);
 
+    Set<String> uniqueDatastreamTaskNames = new HashSet<>();
     for (DatastreamGroup dg : datastreams) {
       Set<DatastreamTask> tasksForDatastreamGroup = currentlyAssignedDatastreamTasks.stream()
-          .filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()))
+          .filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && uniqueDatastreamTaskNames.add(x.getDatastreamTaskName()))
           .collect(Collectors.toSet());
 
       // If there are no datastream tasks that are currently assigned for this datastream.
       if (tasksForDatastreamGroup.isEmpty()) {
         tasksForDatastreamGroup = createTasksForDatastream(dg, maxTasksPerDatastream);
+        uniqueDatastreamTaskNames.addAll(tasksForDatastreamGroup
+            .stream()
+            .map(DatastreamTask::getDatastreamTaskName)
+            .collect(Collectors.toSet()));
       } else {
         Datastream datastream = dg.getDatastreams().get(0);
         if (datastream.hasSource() && datastream.getSource().hasPartitions()) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -135,6 +135,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
     // STEP 1: keep assignments from previous instances, if possible.
     for (DatastreamGroup dg : datastreams) {
       int numTasks = constructExpectedNumberOfTasks(dg, instances.size());
+      Set<String> uniqueDatastreamTaskNames = new HashSet<>();
       Set<DatastreamTask> allAliveTasks = new HashSet<>();
       for (String instance : instances) {
         if (numTasks <= 0) {
@@ -142,7 +143,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
         }
         List<DatastreamTask> foundDatastreamTasks =
             Optional.ofNullable(currentAssignmentCopy.get(instance)).map(c ->
-                c.stream().filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && !allAliveTasks.contains(x))
+                c.stream().filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && uniqueDatastreamTaskNames.add(x.getDatastreamTaskName()))
                     .collect(Collectors.toList())).orElse(Collections.emptyList());
 
         allAliveTasks.addAll(foundDatastreamTasks);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -135,7 +135,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
     // STEP 1: keep assignments from previous instances, if possible.
     for (DatastreamGroup dg : datastreams) {
       int numTasks = constructExpectedNumberOfTasks(dg, instances.size());
-      Set<String> uniqueDatastreamTaskNames = new HashSet<>();
+      Set<String> uniqueDatastreamTaskNamesSet = new HashSet<>();
       Set<DatastreamTask> allAliveTasks = new HashSet<>();
       for (String instance : instances) {
         if (numTasks <= 0) {
@@ -143,7 +143,7 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
         }
         List<DatastreamTask> foundDatastreamTasks =
             Optional.ofNullable(currentAssignmentCopy.get(instance)).map(c ->
-                c.stream().filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && uniqueDatastreamTaskNames.add(x.getDatastreamTaskName()))
+                c.stream().filter(x -> x.getTaskPrefix().equals(dg.getTaskPrefix()) && uniqueDatastreamTaskNamesSet.add(x.getDatastreamTaskName()))
                     .collect(Collectors.toList())).orElse(Collections.emptyList());
 
         allAliveTasks.addAll(foundDatastreamTasks);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestBroadcastStrategy.java
@@ -162,6 +162,14 @@ public class TestBroadcastStrategy {
     // which is possible when the previous leader gets interrupted while updating the assignment.
     assignment.get("instance1").addAll(assignment.get("instance2"));
 
+    // Create a new task with the same name but different partitions, should dedupe out
+    Optional<DatastreamTask> oldTask = assignment.get("instance1")
+        .stream()
+        .findFirst();
+    Assert.assertTrue(oldTask.isPresent());
+    DatastreamTaskImpl newTask = new DatastreamTaskImpl(oldTask.get().getDatastreams(), oldTask.get().getId(), Arrays.asList(0, 1, 2));
+    assignment.get("instance1").add(newTask);
+
     Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, instances, assignment);
     Set<DatastreamTask> newAssignmentTasks = newAssignment.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
     List<DatastreamTask> newAssignmentTasksList = newAssignment.values().stream().flatMap(Set::stream).collect(Collectors.toList());

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadbalancingStrategy.java
@@ -11,6 +11,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Properties;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -237,6 +238,14 @@ public class TestLoadbalancingStrategy {
     // Copying the assignment to simulate the scenario where two instances have the same task,
     // which is possible when the previous leader gets interrupted while updating the assignment.
     assignment.get("instance1").addAll(assignment.get("instance2"));
+
+    // Create a new task with the same name but different partitions, should dedupe out
+    Optional<DatastreamTask> oldTask = assignment.get("instance1")
+        .stream()
+        .findFirst();
+    Assert.assertTrue(oldTask.isPresent());
+    DatastreamTaskImpl newTask = new DatastreamTaskImpl(oldTask.get().getDatastreams(), oldTask.get().getId(), Arrays.asList(0, 1, 2));
+    assignment.get("instance1").add(newTask);
 
     Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, instances, assignment);
     Set<DatastreamTask> newAssignmentTasks = newAssignment.values().stream().flatMap(Set::stream).collect(Collectors.toSet());

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyMulticastStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyMulticastStrategy.java
@@ -296,6 +296,14 @@ public class TestStickyMulticastStrategy {
     // which is possible when the previous leader gets interrupted while updating the assignment.
     assignment.get("instance1").addAll(assignment.get("instance2"));
 
+    // Create a new task with the same name but different partitions, should dedupe out
+    Optional<DatastreamTask> oldTask = assignment.get("instance1")
+        .stream()
+        .findFirst();
+    Assert.assertTrue(oldTask.isPresent());
+    DatastreamTaskImpl newTask = new DatastreamTaskImpl(oldTask.get().getDatastreams(), oldTask.get().getId(), Arrays.asList(0, 1, 2));
+    assignment.get("instance1").add(newTask);
+
     Map<String, Set<DatastreamTask>> newAssignment = strategy.assign(datastreams, Arrays.asList(instances), assignment);
     Set<DatastreamTask> newAssignmentTasks = newAssignment.values().stream().flatMap(Set::stream).collect(Collectors.toSet());
     List<DatastreamTask> newAssignmentTasksList = newAssignment.values().stream().flatMap(Set::stream).collect(Collectors.toList());


### PR DESCRIPTION
Fixes crashing during `LeaderDoAssignment` by deduplicating tasks that contain the same task name.
This can happen if a leader change happens while saving an existing assignment change is already in progress.
If we reach this case, select one of the tasks as valid and remove the others.