### PR TITLE
Fixing test OnAssignmentChangeMultipleReassignments

### DIFF
--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestAbstractKafkaConnector.java
@@ -149,7 +149,7 @@ public class TestAbstractKafkaConnector {
     props.setProperty("daemonThreadIntervalInSeconds", "2");
     // With failStopTaskOnce set to true the AbstractKafkaBasedConnectorTask.stop is configured
     // to fail the first time with InterruptedException and pass the second time.
-    TestKafkaConnector connector = new TestKafkaConnector(false, props, true);
+    TestKafkaConnector connector = new TestKafkaConnector(false, props, true, false);
 
     // first task assignment assigns task 1
     List<DatastreamTask> firstTaskAssignment = getTaskListInRange(1, 2);
@@ -268,7 +268,7 @@ public class TestAbstractKafkaConnector {
     private boolean _failStopTaskOnce;
     private int _createTaskCalled = 0;
     private int _stopTaskCalled = 0;
-    private boolean _taskThreadDead = true;
+    private boolean _taskThreadDead;
 
     /**
      * Constructor for TestKafkaConnector


### PR DESCRIPTION
This PR fixes the test OnAssignmentChangeMultipleReassignments by using the taskThreadDead parameter. After merging #877, we added a check to see if the task thread was dead before attempting to stop any task. We needed a respective fix in this test.

This test was added in a parallel running PR, hence it was missed when PR #877 fixed other similar tests. 

**************************

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
