### PR TITLE
Replace 101tec ZkClient with Helix ZkClient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ project(':datastream-server-api') {
 project(':datastream-utils') {
   dependencies {
     compile project(':datastream-common')
-    compile "com.101tec:zkclient:$zkclientVersion"
+    compile "org.apache.helix:zookeeper-api:$helixZkclientVersion"
     compile "com.google.guava:guava:$guavaVersion"
     testCompile project(":datastream-kafka")
     testCompile project(":datastream-testcommon")
@@ -318,7 +318,6 @@ project(':datastream-client') {
 project(':datastream-server') {
 
   dependencies {
-    compile "com.101tec:zkclient:$zkclientVersion"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
     compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
@@ -355,7 +354,6 @@ project(':datastream-server-restli') {
     compile "com.linkedin.pegasus:restli-netty-standalone:$pegasusVersion"
     compile "com.linkedin.pegasus:r2-jetty:$pegasusVersion"
     compile "com.linkedin.parseq:parseq:$parseqVersion"
-    compile "com.101tec:zkclient:$zkclientVersion"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
     compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -19,8 +19,8 @@ import java.util.Set;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
-import org.I0Itec.zkclient.exception.ZkInterruptedException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.zookeeper.zkclient.exception.ZkInterruptedException;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CachedDatastreamReader.java
@@ -15,7 +15,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Collectors;
 
-import org.I0Itec.zkclient.exception.ZkNoNodeException;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -28,12 +28,12 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import org.I0Itec.zkclient.IZkChildListener;
-import org.I0Itec.zkclient.IZkDataListener;
-import org.I0Itec.zkclient.IZkStateListener;
-import org.I0Itec.zkclient.exception.ZkException;
-import org.I0Itec.zkclient.exception.ZkNoNodeException;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.helix.zookeeper.zkclient.IZkStateListener;
+import org.apache.helix.zookeeper.zkclient.exception.ZkException;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.apache.zookeeper.CreateMode;
 import org.apache.zookeeper.Watcher;
 import org.slf4j.Logger;
@@ -1831,7 +1831,7 @@ public class ZkAdapter {
     }
 
     @Override
-    public void handleNewSession() {
+    public void handleNewSession(final String sessionId) {
       synchronized (_zkSessionLock) {
         LOG.info("ZkStateChangeListener::A new session has been established.");
         if (_reinitOnNewSession) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -1833,7 +1833,7 @@ public class ZkAdapter {
     @Override
     public void handleNewSession(final String sessionId) {
       synchronized (_zkSessionLock) {
-        LOG.info("ZkStateChangeListener::A new session has been established.");
+        LOG.info("ZkStateChangeListener::A new session with ID {} has been established.", sessionId);
         if (_reinitOnNewSession) {
           onNewSession();
         }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
@@ -16,8 +16,6 @@ import org.apache.helix.zookeeper.zkclient.serialize.ZkSerializer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.annotations.VisibleForTesting;
-
 
 /**
  * ZKClient is a wrapper of {@link org.apache.helix.zookeeper.impl.client.ZkClient}. It provides the following
@@ -214,14 +212,6 @@ public class ZkClient extends org.apache.helix.zookeeper.impl.client.ZkClient {
       return null;
     }
     return (T) _zkSerializer.deserialize(data);
-  }
-
-  /**
-   * Get Zk sessions session ID
-   */
-  @VisibleForTesting
-  public long getSessionId() {
-    return super.getSessionId();
   }
 
   private static class ZKStringSerializer implements ZkSerializer {

--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
@@ -72,13 +72,8 @@ public class TestZkClient {
     String electionNodeName = electionPath + "/coordinator-";
 
     // now create this node with persistent mode
-    try {
-      zkClient.create(electionNodeName, "test", CreateMode.PERSISTENT_SEQUENTIAL);
-    } catch (ZkNoNodeException e) {
-      zkClient.close();
-      return;
-    }
-    throw new Exception("Test failed, expected ZkNoNodeException");
+    Assert.assertThrows(ZkNoNodeException.class,
+        () -> zkClient.create(electionNodeName, "test", CreateMode.PERSISTENT_SEQUENTIAL));
   }
 
   @Test
@@ -89,13 +84,8 @@ public class TestZkClient {
     String electionNodeName = electionPath + "/coordinator-";
 
     // now create this node with persistent mode
-    try {
-      zkClient.create(null, "test", CreateMode.PERSISTENT_SEQUENTIAL);
-    } catch (NullPointerException e) {
-      zkClient.close();
-      return;
-    }
-    throw new Exception("Test failed, expected NullPointerException");
+    Assert.assertThrows(NullPointerException.class,
+        () -> zkClient.create(null, "test", CreateMode.PERSISTENT_SEQUENTIAL));
   }
 
   @Test

--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
@@ -10,6 +10,7 @@ import java.util.List;
 
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
+import org.apache.helix.zookeeper.zkclient.exception.ZkNoNodeException;
 import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -61,6 +62,40 @@ public class TestZkClient {
     Assert.assertTrue(zkClient.exists(rootZNode, false));
 
     zkClient.close();
+  }
+
+  @Test
+  public void testCreateNoNodeException() throws Exception {
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+
+    String electionPath = "/leaderelection";
+    String electionNodeName = electionPath + "/coordinator-";
+
+    // now create this node with persistent mode
+    try {
+      zkClient.create(electionNodeName, "test", CreateMode.PERSISTENT_SEQUENTIAL);
+    } catch (ZkNoNodeException e) {
+      zkClient.close();
+      return;
+    }
+    throw new Exception("Test failed, expected ZkNoNodeException");
+  }
+
+  @Test
+  public void testCreateIllegalArgumentException() throws Exception {
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+
+    String electionPath = "/leaderelection";
+    String electionNodeName = electionPath + "/coordinator-";
+
+    // now create this node with persistent mode
+    try {
+      zkClient.create(null, "test", CreateMode.PERSISTENT_SEQUENTIAL);
+    } catch (NullPointerException e) {
+      zkClient.close();
+      return;
+    }
+    throw new Exception("Test failed, expected NullPointerException");
   }
 
   @Test

--- a/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
+++ b/datastream-utils/src/test/java/com/linkedin/datastream/common/zk/TestZkClient.java
@@ -8,8 +8,8 @@ package com.linkedin.datastream.common.zk;
 import java.io.IOException;
 import java.util.List;
 
-import org.I0Itec.zkclient.IZkChildListener;
-import org.I0Itec.zkclient.IZkDataListener;
+import org.apache.helix.zookeeper.zkclient.IZkChildListener;
+import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.zookeeper.CreateMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -20,5 +20,5 @@ ext {
     testngVersion = "7.1.0"
     zkclientVersion = "0.11"
     zookeeperVersion = "3.4.13"
-    helixZkclientVersion = "1.0.1"
+    helixZkclientVersion = "1.0.2"
 }

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -18,7 +18,6 @@ ext {
     scalaVersion = "2.12"
     slf4jVersion = "1.7.5"
     testngVersion = "7.1.0"
-    zkclientVersion = "0.11"
     zookeeperVersion = "3.4.13"
     helixZkclientVersion = "1.0.2"
 }

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "3.0.0"
+  version = "4.0.0"
 }
 
 subprojects {


### PR DESCRIPTION
Use helix version 1.0.2. Extend common/zk/ZkClient.java from helix zookeeper client and refactoring
some code. Updating the major version to 4.0.0

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
