### PR TITLE
Upgrade Zookeeper version to 3.6.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ subprojects {
   }
 
   findbugs {
-    toolVersion = "3.0.1"
+    toolVersion = "$findbugsVersion"
     sourceSets = [sourceSets.main] // Test code is not included
     reportsDir = file("$project.buildDir/findbugsReports")
     reportLevel = "medium"
@@ -249,6 +249,7 @@ project(":datastream-testcommon") {
     compile "com.intellij:annotations:$intellijAnnotationsVersion"
     compile "commons-cli:commons-cli:$commonsCliVersion"
     compile "org.apache.avro:avro:$avroVersion"
+    compile "com.google.code.findbugs:findbugs:$findbugsVersion"
     compile "org.apache.zookeeper:zookeeper:$zookeeperVersion"
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "org.testng:testng:$testngVersion"

--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -6,6 +6,7 @@ ext {
     commonsIOVersion = "2.4"
     commonslang3Version = "3.4"
     commonsValidatorVersion = "1.5.1"
+    findbugsVersion = "3.0.1"
     guavaVersion = "25.0-jre"
     intellijAnnotationsVersion = "12.0"
     jacksonVersion = "2.10.0"
@@ -18,6 +19,6 @@ ext {
     scalaVersion = "2.12"
     slf4jVersion = "1.7.5"
     testngVersion = "7.1.0"
-    zookeeperVersion = "3.4.13"
+    zookeeperVersion = "3.6.3"
     helixZkclientVersion = "1.0.2"
 }


### PR DESCRIPTION
Upgrade Zookeeper version to 3.6.3

Needed to add an explicit compile dependency to satisfy a transitive dependency error introduced by the new version of Zookeeper.:
```
/Users/jogrogan/.gradle/caches/modules-2/files-2.1/org.apache.zookeeper/zookeeper/3.6.3/a6e74f826db85ff8c51c15ef0fa2ea0b462aef25/zookeeper-3.6.3.jar(/org/apache/zookeeper/server/ZooKeeperServer.class):
warning: Cannot find annotation method 'value()' in type 'SuppressFBWarnings': class file for edu.umd.cs.findbugs.annotations.SuppressFBWarnings not found
```