### PR TITLE
Add support for post datastream create,update,delete and state change action

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.datastream.server.api.connector;
 
+import com.linkedin.datastream.common.DatastreamException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -131,7 +132,7 @@ public interface Connector extends MetricsAware, DatastreamChangeListener {
    * with its set of initializations.
    *
    * NOTE: This method is called by the Rest.li service before the datastream is written to ZooKeeper, so please make
-   *   sure this call doesn't block for more then few seconds otherwise the REST call will timeout.
+   *   sure this call doesn't block for more than few seconds otherwise the REST call will timeout.
    * @param stream Datastream being initialized
    * @param allDatastreams all existing datastreams in the system of connector type of the datastream that is being
    *                       initialized.
@@ -141,13 +142,15 @@ public interface Connector extends MetricsAware, DatastreamChangeListener {
   }
 
   /**
-   * Hook that can be used to do any additional operations once the datastream has been created, update or deleted.
-   * This method will be invoked for datastream state change too.
+   * Hook that can be used to do any additional operations once the datastream has been created, update or deleted
+   * successfully on the ZooKeeper. This method will be invoked for datastream state change too.
    *
-   * NOTE: This method is called after the datastream is written to/deleted from ZooKeeper
+   * NOTE: This method is called by the Rest.li service after the datastream is written to/deleted from ZooKeeper. So
+   * please make sure this call doesn't block for more than few seconds otherwise the REST call will timeout. If you
+   * have non-critical work, see if that can be done as an async operation or on a separate thread.
    * @param stream the datastream
-   * @throws Exception
+   * @throws DatastreamException on fail to perform post datastream state change operations successfully.
    */
-  default void postDatastreamStateChangeAction(Datastream stream) throws Exception {
+  default void postDatastreamStateChangeAction(Datastream stream) throws DatastreamException {
   }
 }

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -5,7 +5,6 @@
  */
 package com.linkedin.datastream.server.api.connector;
 
-import com.linkedin.datastream.common.DatastreamException;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -16,6 +15,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamConstants;
+import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.metrics.MetricsAware;
 import com.linkedin.datastream.server.DatastreamTask;

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/connector/Connector.java
@@ -139,4 +139,15 @@ public interface Connector extends MetricsAware, DatastreamChangeListener {
   default void postDatastreamInitialize(Datastream stream, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
   }
+
+  /**
+   * Hook that can be used to do any additional operations once the datastream has been created, update or deleted.
+   * This method will be invoked for datastream state change too.
+   *
+   * NOTE: This method is called after the datastream is written to/deleted from ZooKeeper
+   * @param stream the datastream
+   * @throws Exception
+   */
+  default void postDatastreamStateChangeAction(Datastream stream) throws Exception {
+  }
 }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -500,8 +500,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
     LOG.info("Completed request for stopping datastream {}", _store.getDatastream(datastream.getName()));
 
-    // above check guarantees us that datastreams will be in STOPPED state only, so need to fetch the latest state
-    // from store
+    // above check guarantees us that datastreams will be in STOPPED state only, so not need to fetch the latest state
+    // from store explicitly
     datastreamsToStop.forEach(ds -> {
       // set the status as STOPPED as the original status would be READY, PAUSED or STOPPING
       ds.setStatus(DatastreamStatus.STOPPED);

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -742,7 +742,6 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, DELETE_CALL, 1);
       Instant startTime = Instant.now();
-      datastream.setStatus(DatastreamStatus.DELETING);
       _store.deleteDatastream(datastreamName);
       DELETE_CALL_LATENCY_MS.set(Duration.between(startTime, Instant.now()).toMillis());
 

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -734,6 +734,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, DELETE_CALL, 1);
       Instant startTime = Instant.now();
+      datastream.setStatus(DatastreamStatus.DELETING);
       _store.deleteDatastream(datastreamName);
       DELETE_CALL_LATENCY_MS.set(Duration.between(startTime, Instant.now()).toMillis());
 

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -303,6 +303,9 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       // are updated before we touch the "assignments" node to avoid race condition
       for (String key : datastreamMap.keySet()) {
         _store.updateDatastream(key, datastreamMap.get(key), false);
+
+        // invoke post datastream state change action for recently updated datastream
+        invokePostDSStateChangeAction(datastreamMap.get(key));
       }
       _coordinator.broadcastDatastreamUpdate();
     } catch (DatastreamException e) {
@@ -359,6 +362,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
         if (DatastreamStatus.READY.equals(datastream.getStatus())) {
           d.setStatus(DatastreamStatus.PAUSED);
           _store.updateDatastream(d.getName(), d, true);
+          // invoke post datastream state change action for recently paused datastream
+          invokePostDSStateChangeAction(d);
         } else {
           LOG.warn("Cannot pause datastream {}, as it is not in READY state. State: {}", d, datastream.getStatus());
         }
@@ -467,12 +472,16 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           d.setStatus(DatastreamStatus.STOPPING);
           _store.updateDatastream(d.getName(), d, true);
           _store.deleteDatastreamNumTasks(d.getName());
+          // invoke post datastream state change action for recently stopped datastream
+          invokePostDSStateChangeAction(d);
         } else if (DatastreamStatus.STOPPING.equals(d.getStatus())) {
           // this check helps in preventing any datastream from being stuck in STOPPING state indefinitely
           LOG.warn("Datastream {} is already in {} state. Notifying leader to initiate transition", d,
               d.getStatus());
           _store.updateDatastream(d.getName(), d, true);
           _store.deleteDatastreamNumTasks(d.getName());
+          // invoke post datastream state change action for recently stopped datastream
+          invokePostDSStateChangeAction(d);
         } else {
           LOG.warn("Cannot stop datastream {}, as it is not in READY/PAUSED state. State: {}", d, d.getStatus());
         }
@@ -528,6 +537,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
             DatastreamStatus.STOPPED.equals(datastream.getStatus())) {
           d.setStatus(DatastreamStatus.READY);
           _store.updateDatastream(d.getName(), d, true);
+          // invoke post datastream state change action for recently resumed datastream
+          invokePostDSStateChangeAction(d);
         } else {
           LOG.warn("Will not resume datastream {}, as it is not already in PAUSED/STOPPED state", d);
         }
@@ -712,7 +723,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
   @Override
   public UpdateResponse delete(String datastreamName) {
-    if (null == _store.getDatastream(datastreamName)) {
+    final Datastream datastream = _store.getDatastream(datastreamName);
+    if (null == datastream) {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_404_NOT_FOUND,
           "Datastream requested to be deleted does not exist: " + datastreamName);
     }
@@ -724,6 +736,9 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       Instant startTime = Instant.now();
       _store.deleteDatastream(datastreamName);
       DELETE_CALL_LATENCY_MS.set(Duration.between(startTime, Instant.now()).toMillis());
+
+      // invoke post datastream state change action for recently deleted datastream
+      invokePostDSStateChangeAction(datastream);
 
       return new UpdateResponse(HttpStatus.S_200_OK);
     } catch (Exception e) {
@@ -893,6 +908,10 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       CREATE_CALL_LATENCY_MS.set(delta.toMillis());
 
       LOG.info("Datastream persisted to zookeeper, total time used: {} ms", delta.toMillis());
+
+      // invoke post datastream state change action for recently created datastream
+      invokePostDSStateChangeAction(datastream);
+
       return new CreateResponse(datastream.getName(), HttpStatus.S_201_CREATED);
     } catch (IllegalArgumentException e) {
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, CALL_ERROR, 1);
@@ -918,6 +937,17 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
     // Should never get here because we throw on any errors
     return null;
+  }
+
+  private void invokePostDSStateChangeAction(Datastream datastream) throws DatastreamException {
+    try {
+      LOG.debug("Invoke post datastream state change action datastream={}", datastream);
+      _coordinator.invokePostDataStreamStateChangeAction(datastream);
+      LOG.info("Invoked post datastream state change action datastream={}", datastream);
+    } catch (DatastreamException e) {
+      LOG.error("Failed to perform post datastream state change action datastream={}", datastream, e);
+      throw e;
+    }
   }
 
   /**

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1385,7 +1385,7 @@ public class TestCoordinator {
     Assert.assertTrue(coordinator1.getIsLeader().getAsBoolean());
 
     // connector1 is assigned on coordinator1 which is a leader
-    // and post datastream create/update/delete or state chance method will be invoked only for a leader instance
+    // and post datastream create/delete or state chance method should be invoked only for a leader instance
     Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 1);
 
     // update datastream
@@ -1407,7 +1407,7 @@ public class TestCoordinator {
     LOG.info("Deleting datastream: {}", datastream);
     datastreamResources.delete(datastream.getName());
 
-    // post datastream state chance method for UPDATE should be invoked only for a leader instance
+    // post datastream state chance method for DELETE should be invoked only for a leader instance
     PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 3, 200, WAIT_TIMEOUT_MS);
     Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 3);
     Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 1);
@@ -1652,7 +1652,7 @@ public class TestCoordinator {
     Assert.assertFalse(instance2.getIsLeader().getAsBoolean());
 
     // connector1 is assigned on instance1 which is a leader
-    // and post datastream create/update/delete or state chance method will be invoked only for a leader instance
+    // and post datastream create/delete method will be invoked only for a leader instance
     Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), concurrencyLevel);
     Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
 

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2059,7 +2059,7 @@ public class TestCoordinator {
     assertConnectorAssignment(connector3, WAIT_TIMEOUT_MS, "datastream0", "datastream2", "datastream4", "datastream1",
         "datastream3", "datastream5");
 
-    // instance2 should be a leader
+    // instance3 should be a leader
     Assert.assertTrue(instance3.getIsLeader().getAsBoolean());
     // post datastream create/update/delete or state chance method should not be invoked on leader re-assignement
     Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
@@ -3386,7 +3386,6 @@ public class TestCoordinator {
     public void postDatastreamStateChangeAction(Datastream stream) throws Exception {
       ++postDSCount;
       Assert.assertNotNull(stream);
-//      Connector.super.postDatastreamStateChangeAction(stream);
     }
 
     @Override

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2481,17 +2481,11 @@ public class TestCoordinator {
 
     // Make sure connector has received the assignment (timeout in 30 seconds)
     assertConnectorAssignment(setup._connector, 30000, datastreamName);
-    // post datastream create/update/delete or state chance method should be called
-    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 1,
-        200, WAIT_TIMEOUT_MS));
 
     // Delete the data stream and verify proper cleanup
     UpdateResponse deleteResponse = setup._resource.delete(stream.getName());
     Assert.assertEquals(deleteResponse.getStatus(), HttpStatus.S_200_OK);
     assertConnectorAssignment(setup._connector, 30000);
-    // post datastream create/update/delete or state chance method should be called
-    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 2,
-        200, WAIT_TIMEOUT_MS));
   }
 
   @Test
@@ -2626,10 +2620,6 @@ public class TestCoordinator {
     Assert.assertNull(createResponse.getError());
     Assert.assertEquals(createResponse.getStatus(), HttpStatus.S_201_CREATED);
 
-    // post datastream create/update/delete or state chance method should be called
-    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 1, 200,
-        WAIT_TIMEOUT_MS));
-
     // Creating a stream2 which should trigger stream1 to be deleted
     createResponse = setup._resource.create(streams[1]);
     Assert.assertNull(createResponse.getError());
@@ -2645,11 +2635,6 @@ public class TestCoordinator {
         return true;
       }
     }, 200, Duration.ofSeconds(30).toMillis());
-
-    // post datastream create/update/delete or state chance method should be called
-    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 2, 200,
-        WAIT_TIMEOUT_MS));
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 2);
   }
 
   @Test

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1399,17 +1399,17 @@ public class TestCoordinator {
     datastreamResources.update(datastream.getName(), datastream);
 
     assertConnectorReceiveDatastreamUpdate(connector1, datastream);
-    PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 2, 200, WAIT_TIMEOUT_MS);
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 2);
-    PollUtils.poll(() -> connector2.getPostDSStatechangeActionInvokeCount() == 1, 200, WAIT_TIMEOUT_MS);
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 1);
+    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 2, 200,
+        WAIT_TIMEOUT_MS));
+    Assert.assertTrue(PollUtils.poll(() -> connector2.getPostDSStatechangeActionInvokeCount() == 1, 200,
+        WAIT_TIMEOUT_MS));
 
     LOG.info("Deleting datastream: {}", datastream);
     datastreamResources.delete(datastream.getName());
 
     // post datastream state chance method for DELETE should be invoked only for a leader instance
-    PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 3, 200, WAIT_TIMEOUT_MS);
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 3);
+    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 3, 200,
+        WAIT_TIMEOUT_MS));
     Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 1);
 
     coordinator1.stop();
@@ -1653,7 +1653,8 @@ public class TestCoordinator {
 
     // connector1 is assigned on instance1 which is a leader
     // and post datastream create/delete method will be invoked only for a leader instance
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), concurrencyLevel);
+    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == concurrencyLevel,
+        200, WAIT_TIMEOUT_MS));
     Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
 
     instance1.stop();
@@ -2012,7 +2013,8 @@ public class TestCoordinator {
 
     // connector1 is assigned on instance1 which is a leader
     // and post datastream create/update/delete or state chance method will be invoked only for a leader instance
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), dsCount);
+    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == dsCount, 200,
+        WAIT_TIMEOUT_MS));
     Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
     Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
 
@@ -2345,7 +2347,7 @@ public class TestCoordinator {
     PollUtils.poll(() -> connector1.getAssignmentCount() == 12, 200, WAIT_TIMEOUT_MS);
     int childrenCount = zkClient.countChildren(errorPath);
     Assert.assertTrue(childrenCount <= 10);
-    Assert.assertEquals(connector1.getPostDSCount(), 12);
+    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSCount() == 12, 200, WAIT_TIMEOUT_MS));
     //
     // clean up
     //
@@ -2480,14 +2482,16 @@ public class TestCoordinator {
     // Make sure connector has received the assignment (timeout in 30 seconds)
     assertConnectorAssignment(setup._connector, 30000, datastreamName);
     // post datastream create/update/delete or state chance method should be called
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 1);
+    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 1,
+        200, WAIT_TIMEOUT_MS));
 
     // Delete the data stream and verify proper cleanup
     UpdateResponse deleteResponse = setup._resource.delete(stream.getName());
     Assert.assertEquals(deleteResponse.getStatus(), HttpStatus.S_200_OK);
     assertConnectorAssignment(setup._connector, 30000);
     // post datastream create/update/delete or state chance method should be called
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 2);
+    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 2,
+        200, WAIT_TIMEOUT_MS));
   }
 
   @Test
@@ -2623,7 +2627,8 @@ public class TestCoordinator {
     Assert.assertEquals(createResponse.getStatus(), HttpStatus.S_201_CREATED);
 
     // post datastream create/update/delete or state chance method should be called
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 1);
+    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 1, 200,
+        WAIT_TIMEOUT_MS));
 
     // Creating a stream2 which should trigger stream1 to be deleted
     createResponse = setup._resource.create(streams[1]);
@@ -2642,6 +2647,8 @@ public class TestCoordinator {
     }, 200, Duration.ofSeconds(30).toMillis());
 
     // post datastream create/update/delete or state chance method should be called
+    Assert.assertTrue(PollUtils.poll(() -> setup._connector.getPostDSStatechangeActionInvokeCount() == 2, 200,
+        WAIT_TIMEOUT_MS));
     Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 2);
   }
 

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1155,6 +1155,46 @@ public class TestCoordinator {
     zkClient.close();
   }
 
+  @Test
+  public void testInvokePostDataStreamStateChangeAction() throws Exception {
+    String testCluster = "testDatastreamCreateUpdateDelete";
+    String connectorType = "connectorType";
+
+    TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
+    Coordinator coordinator1 = createCoordinator(_zkConnectionString, testCluster);
+    coordinator1.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()),
+        false, new SourceBasedDeduper(), null);
+    coordinator1.start();
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+
+    // create datastream
+    Datastream[] list = DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType,
+        "datastream1");
+    Datastream datastream1 = list[0];
+    LOG.info("Created datastream1: {}", datastream1);
+
+    coordinator1.invokePostDataStreamStateChangeAction(datastream1);
+    Assert.assertTrue(coordinator1.getIsLeader().getAsBoolean());
+    // post datastream state change action method should be invoked for created datastream
+    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 1);
+
+    // update datastream
+    datastream1.getMetadata().put("key", "value");
+    datastream1.getSource().setConnectionString("newSource");
+
+    LOG.info("Updating datastream: {}", datastream1);
+    CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, testCluster);
+    ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, testCluster);
+    DatastreamResources datastreamResources = new DatastreamResources(dsStore, coordinator1);
+    datastreamResources.update(datastream1.getName(), datastream1);
+
+    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 2);
+
+    coordinator1.stop();
+    coordinator1.getDatastreamCache().getZkclient().close();
+    zkClient.close();
+  }
+
   /**
    * Test datastream creation with Connector-managed destination; coordinator should not create or delete topics.
    */
@@ -1345,77 +1385,6 @@ public class TestCoordinator {
     coordinator.validateDatastreamsUpdate(Arrays.asList(datastreams.get(2), datastreams.get(3)));
     coordinator.stop();
     coordinator.getDatastreamCache().getZkclient().close();
-    zkClient.close();
-  }
-
-  @Test
-  public void testDatastreamCreateUpdateDelete() throws Exception {
-    String testCluster = "testDatastreamCreateUpdateDelete";
-    String connectorType = "connectorType";
-
-    TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
-    TestHookConnector connector2 = new TestHookConnector("connector2", connectorType);
-
-    Coordinator coordinator1 = createCoordinator(_zkConnectionString, testCluster);
-    coordinator1.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
-        new SourceBasedDeduper(), null);
-    coordinator1.start();
-
-    Coordinator coordinator2 = createCoordinator(_zkConnectionString, testCluster);
-    coordinator2.addConnector(connectorType, connector2, new BroadcastStrategy(Optional.empty()), false,
-        new SourceBasedDeduper(), null);
-    coordinator2.start();
-
-    ZkClient zkClient = new ZkClient(_zkConnectionString);
-
-    Datastream[] list =
-        DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, "datastream1");
-    Datastream datastream = list[0];
-    LOG.info("Created datastream: {}", datastream);
-
-    // wait for datastream to be READY
-    PollUtils.poll(() -> DatastreamTestUtils.getDatastream(zkClient, testCluster, "datastream1")
-        .getStatus()
-        .equals(DatastreamStatus.READY), 1000, WAIT_TIMEOUT_MS);
-    datastream = DatastreamTestUtils.getDatastream(zkClient, testCluster, datastream.getName());
-    assertConnectorAssignment(connector1, WAIT_TIMEOUT_MS, datastream.getName());
-
-    // ZK chooses instance with lower index count as a leader from the cluster
-    // coordinator1 has to be leader as it gets created first with lower index counter
-    Assert.assertTrue(coordinator1.getIsLeader().getAsBoolean());
-
-    // connector1 is assigned on coordinator1 which is a leader
-    // and post datastream create/delete or state chance method should be invoked only for a leader instance
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 1);
-
-    // update datastream
-    datastream.getMetadata().put("key", "value");
-    datastream.getSource().setConnectionString("newSource");
-
-    LOG.info("Updating datastream: {}", datastream);
-    CachedDatastreamReader datastreamCache = new CachedDatastreamReader(zkClient, testCluster);
-    ZookeeperBackedDatastreamStore dsStore = new ZookeeperBackedDatastreamStore(datastreamCache, zkClient, testCluster);
-    DatastreamResources datastreamResources = new DatastreamResources(dsStore, coordinator1);
-    datastreamResources.update(datastream.getName(), datastream);
-
-    assertConnectorReceiveDatastreamUpdate(connector1, datastream);
-    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 2, 200,
-        WAIT_TIMEOUT_MS));
-    Assert.assertTrue(PollUtils.poll(() -> connector2.getPostDSStatechangeActionInvokeCount() == 1, 200,
-        WAIT_TIMEOUT_MS));
-
-    LOG.info("Deleting datastream: {}", datastream);
-    datastreamResources.delete(datastream.getName());
-
-    // post datastream state chance method for DELETE should be invoked only for a leader instance
-    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 3, 200,
-        WAIT_TIMEOUT_MS));
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 1);
-
-    coordinator1.stop();
-    coordinator1.getDatastreamCache().getZkclient().close();
-    coordinator2.stop();
-    coordinator2.getDatastreamCache().getZkclient().close();
     zkClient.close();
   }
 
@@ -1645,17 +1614,6 @@ public class TestCoordinator {
 
     assertConnectorAssignment(connector1, WAIT_TIMEOUT_MS, datastreamNames);
     assertConnectorAssignment(connector2, WAIT_TIMEOUT_MS, datastreamNames);
-
-    // ZK chooses instance with lower index count as a leader from the cluster
-    // instance1 has to be leader as it gets created first with lower index counter
-    Assert.assertTrue(instance1.getIsLeader().getAsBoolean());
-    Assert.assertFalse(instance2.getIsLeader().getAsBoolean());
-
-    // connector1 is assigned on instance1 which is a leader
-    // and post datastream create/delete method will be invoked only for a leader instance
-    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == concurrencyLevel,
-        200, WAIT_TIMEOUT_MS));
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
 
     instance1.stop();
     instance2.stop();
@@ -1983,16 +1941,11 @@ public class TestCoordinator {
         null);
     instance3.start();
 
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 0);
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
-    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
-
     LOG.info("Creating six datastreams");
     //
     // create 6 datastreams, [datastream0, ..., datastream5]
     //
-    final int dsCount = 6;
-    for (int i = 0; i < dsCount; i++) {
+    for (int i = 0; i < 6; i++) {
       DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, testConnectorType, datastreamName + i);
     }
 
@@ -2004,19 +1957,6 @@ public class TestCoordinator {
     assertConnectorAssignment(connector1, WAIT_DURATION_FOR_ZK, "datastream0", "datastream3");
     assertConnectorAssignment(connector2, WAIT_DURATION_FOR_ZK, "datastream1", "datastream4");
     assertConnectorAssignment(connector3, WAIT_DURATION_FOR_ZK, "datastream2", "datastream5");
-
-    // ZK chooses instance with lower index count as a leader from the cluster
-    // instance1 has to be leader as it gets created first with lower index counter
-    Assert.assertTrue(instance1.getIsLeader().getAsBoolean());
-    Assert.assertFalse(instance2.getIsLeader().getAsBoolean());
-    Assert.assertFalse(instance3.getIsLeader().getAsBoolean());
-
-    // connector1 is assigned on instance1 which is a leader
-    // and post datastream create/update/delete or state chance method will be invoked only for a leader instance
-    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == dsCount, 200,
-        WAIT_TIMEOUT_MS));
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
-    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
 
     List<DatastreamTask> tasks1 = new ArrayList<>(connector1.getTasks());
     tasks1.addAll(connector2.getTasks());
@@ -2039,13 +1979,6 @@ public class TestCoordinator {
     assertConnectorAssignment(connector2, WAIT_TIMEOUT_MS, "datastream0", "datastream2", "datastream4");
     assertConnectorAssignment(connector3, WAIT_TIMEOUT_MS, "datastream1", "datastream3", "datastream5");
 
-    // instance2 should be a leader
-    Assert.assertTrue(instance2.getIsLeader().getAsBoolean());
-    Assert.assertFalse(instance3.getIsLeader().getAsBoolean());
-    // post datastream create/update/delete or state chance method should not be invoked on leader re-assignement
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
-    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
-
     LOG.info("Stop the instance2 and delete the live instance");
 
     //
@@ -2060,11 +1993,6 @@ public class TestCoordinator {
     // verify all tasks assigned to instance3
     assertConnectorAssignment(connector3, WAIT_TIMEOUT_MS, "datastream0", "datastream2", "datastream4", "datastream1",
         "datastream3", "datastream5");
-
-    // instance3 should be a leader
-    Assert.assertTrue(instance3.getIsLeader().getAsBoolean());
-    // post datastream create/update/delete or state chance method should not be invoked on leader re-assignement
-    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
 
     LOG.info("Make sure strategy reused all the tasks as opposed to creating new ones");
 
@@ -2347,7 +2275,7 @@ public class TestCoordinator {
     PollUtils.poll(() -> connector1.getAssignmentCount() == 12, 200, WAIT_TIMEOUT_MS);
     int childrenCount = zkClient.countChildren(errorPath);
     Assert.assertTrue(childrenCount <= 10);
-    Assert.assertTrue(PollUtils.poll(() -> connector1.getPostDSCount() == 12, 200, WAIT_TIMEOUT_MS));
+
     //
     // clean up
     //
@@ -3222,7 +3150,7 @@ public class TestCoordinator {
     List<DatastreamTask> _tasks = new ArrayList<>();
     String _instance = "";
     String _name;
-    private int postDSStatechangeActionInvokeCount;
+    private int _postDSStatechangeActionInvokeCount;
 
     /**
      * Constructor for TestHookConnector
@@ -3255,7 +3183,7 @@ public class TestCoordinator {
     }
 
     public int getPostDSStatechangeActionInvokeCount() {
-      return postDSStatechangeActionInvokeCount;
+      return _postDSStatechangeActionInvokeCount;
     }
 
     @Override
@@ -3296,8 +3224,8 @@ public class TestCoordinator {
     }
 
     @Override
-    public void postDatastreamStateChangeAction(Datastream stream) throws Exception {
-      ++postDSStatechangeActionInvokeCount;
+    public void postDatastreamStateChangeAction(Datastream stream) throws DatastreamException {
+      ++_postDSStatechangeActionInvokeCount;
       Assert.assertNotNull(stream);
     }
 
@@ -3347,14 +3275,9 @@ public class TestCoordinator {
    */
   class BadConnector implements Connector {
     private int assignmentCount;
-    private int postDSCount;
 
     public int getAssignmentCount() {
       return assignmentCount;
-    }
-
-    public int getPostDSCount() {
-      return postDSCount;
     }
 
     @Override
@@ -3372,12 +3295,6 @@ public class TestCoordinator {
       ++assignmentCount;
       // throw a fake exception to trigger the error handling
       throw new RuntimeException();
-    }
-
-    @Override
-    public void postDatastreamStateChangeAction(Datastream stream) throws Exception {
-      ++postDSCount;
-      Assert.assertNotNull(stream);
     }
 
     @Override

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1187,6 +1187,12 @@ public class TestCoordinator {
     Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 1);
     Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
 
+    // wait for datastream to be READY
+    PollUtils.poll(() -> DatastreamTestUtils.getDatastream(zkClient, testCluster, "datastream1")
+        .getStatus()
+        .equals(DatastreamStatus.READY), 1000, WAIT_TIMEOUT_MS);
+    datastream1 = DatastreamTestUtils.getDatastream(zkClient, testCluster, datastream1.getName());
+
     // update datastream
     datastream1.getMetadata().put("key", "value");
     datastream1.getSource().setConnectionString("newSource");

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -1386,7 +1386,7 @@ public class TestCoordinator {
 
     // connector1 is assigned on coordinator1 which is a leader
     // and post datastream create/update/delete or state chance method will be invoked only for a leader instance
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount() , 1);
+    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 1);
 
     // update datastream
     datastream.getMetadata().put("key", "value");
@@ -1400,17 +1400,17 @@ public class TestCoordinator {
 
     assertConnectorReceiveDatastreamUpdate(connector1, datastream);
     PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 2, 200, WAIT_TIMEOUT_MS);
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount() , 2);
+    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 2);
     PollUtils.poll(() -> connector2.getPostDSStatechangeActionInvokeCount() == 1, 200, WAIT_TIMEOUT_MS);
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount() , 1);
+    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 1);
 
     LOG.info("Deleting datastream: {}", datastream);
     datastreamResources.delete(datastream.getName());
 
     // post datastream state chance method for UPDATE should be invoked only for a leader instance
     PollUtils.poll(() -> connector1.getPostDSStatechangeActionInvokeCount() == 3, 200, WAIT_TIMEOUT_MS);
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount() , 3);
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount() , 1);
+    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), 3);
+    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 1);
 
     coordinator1.stop();
     coordinator1.getDatastreamCache().getZkclient().close();
@@ -1653,8 +1653,8 @@ public class TestCoordinator {
 
     // connector1 is assigned on instance1 which is a leader
     // and post datastream create/update/delete or state chance method will be invoked only for a leader instance
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount() , concurrencyLevel);
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount() , 0);
+    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), concurrencyLevel);
+    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
 
     instance1.stop();
     instance2.stop();
@@ -2012,9 +2012,9 @@ public class TestCoordinator {
 
     // connector1 is assigned on instance1 which is a leader
     // and post datastream create/update/delete or state chance method will be invoked only for a leader instance
-    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount() , dsCount);
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount() , 0);
-    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount() , 0);
+    Assert.assertEquals(connector1.getPostDSStatechangeActionInvokeCount(), dsCount);
+    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
+    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
 
     List<DatastreamTask> tasks1 = new ArrayList<>(connector1.getTasks());
     tasks1.addAll(connector2.getTasks());
@@ -2041,8 +2041,8 @@ public class TestCoordinator {
     Assert.assertTrue(instance2.getIsLeader().getAsBoolean());
     Assert.assertFalse(instance3.getIsLeader().getAsBoolean());
     // post datastream create/update/delete or state chance method should not be invoked on leader re-assignement
-    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount() , 0);
-    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount() , 0);
+    Assert.assertEquals(connector2.getPostDSStatechangeActionInvokeCount(), 0);
+    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
 
     LOG.info("Stop the instance2 and delete the live instance");
 
@@ -2062,7 +2062,7 @@ public class TestCoordinator {
     // instance2 should be a leader
     Assert.assertTrue(instance3.getIsLeader().getAsBoolean());
     // post datastream create/update/delete or state chance method should not be invoked on leader re-assignement
-    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount() , 0);
+    Assert.assertEquals(connector3.getPostDSStatechangeActionInvokeCount(), 0);
 
     LOG.info("Make sure strategy reused all the tasks as opposed to creating new ones");
 
@@ -2480,14 +2480,14 @@ public class TestCoordinator {
     // Make sure connector has received the assignment (timeout in 30 seconds)
     assertConnectorAssignment(setup._connector, 30000, datastreamName);
     // post datastream create/update/delete or state chance method should be called
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount() , 1);
+    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Delete the data stream and verify proper cleanup
     UpdateResponse deleteResponse = setup._resource.delete(stream.getName());
     Assert.assertEquals(deleteResponse.getStatus(), HttpStatus.S_200_OK);
     assertConnectorAssignment(setup._connector, 30000);
     // post datastream create/update/delete or state chance method should be called
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount() , 2);
+    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 2);
   }
 
   @Test
@@ -2623,7 +2623,7 @@ public class TestCoordinator {
     Assert.assertEquals(createResponse.getStatus(), HttpStatus.S_201_CREATED);
 
     // post datastream create/update/delete or state chance method should be called
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount() , 1);
+    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Creating a stream2 which should trigger stream1 to be deleted
     createResponse = setup._resource.create(streams[1]);
@@ -2642,7 +2642,7 @@ public class TestCoordinator {
     }, 200, Duration.ofSeconds(30).toMillis());
 
     // post datastream create/update/delete or state chance method should be called
-    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount() , 2);
+    Assert.assertEquals(setup._connector.getPostDSStatechangeActionInvokeCount(), 2);
   }
 
   @Test

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -55,6 +55,7 @@ import com.linkedin.restli.server.PagingContext;
 import com.linkedin.restli.server.PathKeys;
 import com.linkedin.restli.server.RestLiServiceException;
 
+import static com.linkedin.datastream.server.TestDatastreamServer.DUMMY_CONNECTOR;
 import static com.linkedin.datastream.server.dms.DatastreamResources.CONFIG_STOP_TRANSITION_RETRY_PERIOD_MS;
 import static com.linkedin.datastream.server.dms.DatastreamResources.CONFIG_STOP_TRANSITION_TIMEOUT_MS;
 /**
@@ -205,6 +206,8 @@ public class TestDatastreamResources {
   public void testPauseDatastream() {
     DatastreamResources resource1 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
     DatastreamResources resource2 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+    DummyConnector connector = (DummyConnector) _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator()
+        .getConnector(DUMMY_CONNECTOR);
 
     // Create a Datastream.
     Datastream datastreamToCreate = generateDatastream(0);
@@ -217,6 +220,7 @@ public class TestDatastreamResources {
     PollUtils.poll(() -> resource1.get(datastreamName).getStatus() == DatastreamStatus.READY, 100, 10000);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Mock PathKeys
     PathKeys pathKey = Mockito.mock(PathKeys.class);
@@ -226,6 +230,7 @@ public class TestDatastreamResources {
     Assert.assertEquals(resource1.get(datastreamName).getStatus(), DatastreamStatus.READY);
     ActionResult<Void> pauseResponse = resource1.pause(pathKey, false);
     Assert.assertEquals(pauseResponse.getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 2);
 
     // Retrieve datastream and check that is in pause state.
     Datastream ds = resource2.get(datastreamName);
@@ -235,6 +240,7 @@ public class TestDatastreamResources {
     // Resume datastream.
     ActionResult<Void> resumeResponse = resource1.resume(pathKey, false);
     Assert.assertEquals(resumeResponse.getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 3);
 
     // Retrieve datastream and check that is not paused.
     Datastream ds2 = resource2.get(datastreamName);
@@ -246,6 +252,8 @@ public class TestDatastreamResources {
   public void testStopDatastream() {
     DatastreamResources resource1 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
     DatastreamResources resource2 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+    DummyConnector connector = (DummyConnector) _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator()
+        .getConnector(DUMMY_CONNECTOR);
 
     // Create a Datastream.
     Datastream datastreamToCreate = generateDatastream(0);
@@ -258,6 +266,7 @@ public class TestDatastreamResources {
     PollUtils.poll(() -> resource1.get(datastreamName).getStatus() == DatastreamStatus.READY, 100, 10000);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Mock PathKeys
     PathKeys pathKey = Mockito.mock(PathKeys.class);
@@ -267,6 +276,7 @@ public class TestDatastreamResources {
     Assert.assertEquals(resource1.get(datastreamName).getStatus(), DatastreamStatus.READY);
     ActionResult<Void> stopResponse = resource1.stop(pathKey, false);
     Assert.assertEquals(stopResponse.getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 2);
 
     // Retrieve datastream and check that is in STOPPED state.
     Datastream ds = resource2.get(datastreamName);
@@ -377,6 +387,8 @@ public class TestDatastreamResources {
   public void testPerformingAllActionsOnStoppingDatastream() throws DatastreamException {
     DatastreamResources resource1 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
     DatastreamStore store = _datastreamKafkaCluster.getPrimaryDatastreamServer().getDatastreamStore();
+    DummyConnector connector = (DummyConnector) _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator()
+        .getConnector(DUMMY_CONNECTOR);
 
     // Create a Datastream
     Datastream datastreamToCreate = generateDatastream(0);
@@ -389,6 +401,7 @@ public class TestDatastreamResources {
     PollUtils.poll(() -> resource1.get(datastreamName).getStatus() == DatastreamStatus.READY, 100, 10000);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Mock PathKeys
     PathKeys pathKey = Mockito.mock(PathKeys.class);
@@ -397,25 +410,34 @@ public class TestDatastreamResources {
     // Setting status to STOPPING explicitly to perform testing.
     datastreamToCreate.setStatus(DatastreamStatus.STOPPING);
     store.updateDatastream(datastreamName, datastreamToCreate, false);
+    // as we are updating datastream directly on store, post datastream state change action should not be invoked
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Retrieve datastream and check that is in STOPPING state.
     Datastream ds = resource1.get(datastreamName);
     Assert.assertNotNull(ds);
     Assert.assertEquals(ds.getStatus(), DatastreamStatus.STOPPING);
+    // datastream get should not invoke postDatastreamStateChangeAction
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Attempting to pause a datastream in stopping state, which should raise an exception.
     Assert.assertEquals(
         Assert.expectThrows(RestLiServiceException.class, () -> resource1.pause(pathKey, false)).getStatus(),
         HttpStatus.S_405_METHOD_NOT_ALLOWED);
+    // postDatastreamStateChangeAction should not be invoked
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Attempting to resume a datastream in stopping state, which should raise an exception.
     Assert.assertEquals(
         Assert.expectThrows(RestLiServiceException.class, () -> resource1.resume(pathKey, false)).getStatus(),
         HttpStatus.S_405_METHOD_NOT_ALLOWED);
+    // postDatastreamStateChangeAction should not be invoked
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Attempting to stop a datastream in stopping state, which should get executed without exception.
     Assert.assertEquals(resource1.stop(pathKey, false).getStatus(), HttpStatus.S_200_OK);
     Assert.assertEquals(resource1.get(datastreamName).getStatus(), DatastreamStatus.STOPPED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 2);
 
     // Setting status to STOPPING again explicitly to perform testing.
     datastreamToCreate.setStatus(DatastreamStatus.STOPPING);
@@ -429,6 +451,7 @@ public class TestDatastreamResources {
     // Attempting to delete a datastream in stopping state, which should get executed without exception.
     Assert.assertEquals(resource1.delete(datastreamName).getStatus(), HttpStatus.S_200_OK);
     Assert.assertEquals(resource1.get(datastreamName).getStatus(), DatastreamStatus.DELETING);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 3);
   }
 
   @Test
@@ -778,41 +801,51 @@ public class TestDatastreamResources {
   @Test
   public void testUpdateDatastream() throws Exception {
     DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+    DummyConnector connector = (DummyConnector) _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator()
+        .getConnector(DUMMY_CONNECTOR);
 
     Datastream originalDatastream1 = generateDatastream(1);
 
     checkBadRequest(() -> resource.update("none", originalDatastream1), HttpStatus.S_400_BAD_REQUEST);
     checkBadRequest(() -> resource.update(originalDatastream1.getName(), originalDatastream1),
         HttpStatus.S_404_NOT_FOUND);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 0);
 
     Datastream datastream1 = createAndWaitUntilInitialized(resource, originalDatastream1);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Cant update destination / status / connector / transport provider
     Datastream modifyDestination = generateDatastream(1);
     modifyDestination.getDestination().setConnectionString("updated");
     checkBadRequest(() -> resource.update(modifyDestination.getName(), modifyDestination),
         HttpStatus.S_400_BAD_REQUEST);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     Datastream modifyStatus = generateDatastream(1);
     modifyStatus.setStatus(DatastreamStatus.PAUSED);
     checkBadRequest(() -> resource.update(modifyStatus.getName(), modifyStatus), HttpStatus.S_400_BAD_REQUEST);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     Datastream modifyConnector = generateDatastream(1);
     modifyStatus.setConnectorName("Random");
     checkBadRequest(() -> resource.update(modifyConnector.getName(), modifyConnector), HttpStatus.S_400_BAD_REQUEST);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     Datastream modifyTransport = generateDatastream(1);
     modifyStatus.setTransportProviderName("Random");
     checkBadRequest(() -> resource.update(modifyTransport.getName(), modifyTransport), HttpStatus.S_400_BAD_REQUEST);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     Datastream modifyNumTasks = generateDatastream(1);
     modifyNumTasks.getMetadata().put("numTasks", "10");
     checkBadRequest(() -> resource.update(modifyNumTasks.getName(), modifyNumTasks), HttpStatus.S_400_BAD_REQUEST);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Create another datastream that gets deduped to datastream1.
     Datastream originalDatastream2 = generateDatastream(2);
     originalDatastream2.getDestination().setConnectionString("a different destination");
     final Datastream datastream2 = createAndWaitUntilInitialized(resource, originalDatastream2);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 2);
 
     // Update metadata for all streams in the group. It is up to the connector to validate if metadata updates are
     // allowed. Dummy connector allows it
@@ -825,6 +858,7 @@ public class TestDatastreamResources {
       BatchUpdateResult<String, Datastream> response = resource.batchUpdate(batchRequest);
       Assert.assertTrue(
           response.getResults().values().stream().allMatch(res -> res.getStatus().equals(HttpStatus.S_200_OK)));
+      Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 4);
     } catch (RestLiServiceException e) {
       Assert.fail("Valid batch update request failed");
     }
@@ -846,6 +880,8 @@ public class TestDatastreamResources {
     } catch (RestLiServiceException e) {
       // do nothing
     }
+    // post datastream state change should not get called on update failure
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 4);
 
     // make sure that on a failed batch update even the valid datastream update doesn't go through
     Thread.sleep(200);
@@ -856,14 +892,16 @@ public class TestDatastreamResources {
   }
 
   @Test
-  public void testCreateEncryptedDatastream() throws Exception {
+  public void testCreateEncryptedDatastream() {
     DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
-
+    DummyConnector connector = (DummyConnector) _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator()
+        .getConnector(DUMMY_CONNECTOR);
     // Happy Path
     Datastream encryptedDS = generateEncryptedDatastream(1, true, true);
     CreateResponse response = resource.create(encryptedDS);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // Regression for Byot
     Datastream justByotDS = generateEncryptedDatastream(3, false, true);
@@ -872,18 +910,22 @@ public class TestDatastreamResources {
     response = resource.create(justByotDS);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 2);
   }
 
   @Test
   public void testCreateDatastream() throws Exception {
     DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
     Set<String> missingFields = new HashSet<>();
+    DummyConnector connector = (DummyConnector) _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator()
+        .getConnector(DUMMY_CONNECTOR);
 
     // happy path
     Datastream fullDatastream = generateDatastream(0);
     CreateResponse response = resource.create(fullDatastream);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 1);
 
     // datastream names with leading and/or trailing whitespace are trimmed
     Datastream whitespaceDatastream = generateDatastream(1);
@@ -895,12 +937,14 @@ public class TestDatastreamResources {
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
     Assert.assertEquals(response.getId(), originalName);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 2);
 
     missingFields.add("target");
     Datastream allRequiredFields = generateDatastream(2, missingFields);
     response = resource.create(allRequiredFields);
     Assert.assertNull(response.getError());
     Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 3);
 
     // missing necessary fields
     missingFields.clear();
@@ -953,6 +997,8 @@ public class TestDatastreamResources {
     Datastream badDatastream = generateDatastream(0);
     badDatastream.getMetadata().put("numTasks", "100");
     checkBadRequest(() -> resource.create(badDatastream));
+    System.out.println("KHS11= " + connector.getPostDSStatechangeActionInvokeCount());
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 3);
   }
 
   private Datastream createDatastream(DatastreamResources resource, String name, int seed) {
@@ -971,11 +1017,14 @@ public class TestDatastreamResources {
   @Test
   public void testCreateGetAllDatastreams() throws Exception {
     DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+    DummyConnector connector = (DummyConnector) _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator()
+        .getConnector(DUMMY_CONNECTOR);
 
     Assert.assertEquals(resource.getAll(NO_PAGING).size(), 0);
 
     String datastreamName = "TestDatastream-";
     List<Datastream> datastreams = createDatastreams(resource, datastreamName, 10);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 10);
 
     // Get All
     Optional<List<Datastream>> result =
@@ -994,12 +1043,14 @@ public class TestDatastreamResources {
     // Delete one entry
     Datastream removed = queryStreams.remove(0);
     Assert.assertEquals(resource.delete(removed.getName()).getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 11);
 
     // Get All
     List<Datastream> remainingQueryStreams = resource.getAll(NO_PAGING)
         .stream()
         .filter(x -> x.getStatus() != DatastreamStatus.DELETING)
         .collect(Collectors.toList());
+    // getAll should not invoke postDatastreamStateChangeAction
 
     // Compare datastreams set only by name since destination is empty upon creation and later populated
     Assert.assertEquals(queryStreams.stream().map(Datastream::getName).collect(Collectors.toSet()),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -249,4 +249,21 @@ public class ConnectorWrapper {
 
     logApiEnd("postDatastreamInitialize");
   }
+
+  /**
+   * Hook that can be used to perform action for post datastream upsert/deletion or state change. This will be called
+   * by the leader coordinator thread
+   *
+   * @param stream the modified(created, updated, deleted, state changed) Datastream
+   */
+  public void postDatastreamStateChangeAction(Datastream stream) throws Exception {
+    logApiStart("postDatastreamStateChangeAction");
+    try {
+      _connector.postDatastreamStateChangeAction(stream);
+    } catch (Exception e) {
+      logErrorAndException("postDatastreamStateChangeAction", e);
+      throw e;
+    }
+    logApiEnd("postDatastreamStateChangeAction");
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/ConnectorWrapper.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamConstants;
 import com.linkedin.datastream.common.DatastreamDestination;
+import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.server.api.connector.Connector;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 import com.linkedin.datastream.server.providers.CheckpointProvider;
@@ -252,15 +253,15 @@ public class ConnectorWrapper {
 
   /**
    * Hook that can be used to perform action for post datastream upsert/deletion or state change. This will be called
-   * by the leader coordinator thread
+   * as part of the Rest.li call once the ZooKeeper has been updated.
    *
    * @param stream the modified(created, updated, deleted, state changed) Datastream
    */
-  public void postDatastreamStateChangeAction(Datastream stream) throws Exception {
+  public void postDatastreamStateChangeAction(Datastream stream) throws DatastreamException {
     logApiStart("postDatastreamStateChangeAction");
     try {
       _connector.postDatastreamStateChangeAction(stream);
-    } catch (Exception e) {
+    } catch (DatastreamException e) {
       logErrorAndException("postDatastreamStateChangeAction", e);
       throw e;
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -989,7 +989,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
    * This method performs following tasks:
    * 1) initializes destination for a newly created datastream and update it in ZooKeeper
    * 2) delete an existing datastream if it is marked as deleted or its TTL has expired.
-   * 3) perform post datastream add or delete action
+   * 3) perform post datastream add or delete action, this will be invoked as an async call
    *
    * If #2 occurs, it also invalidates the datastream cache for the next assignment.
    *

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1104,7 +1104,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       connectorInfo.getConnector().postDatastreamStateChangeAction(datastreamCopy);
     } catch (CloneNotSupportedException e) {
       _log.error("Failed to copy object for datastream={}", datastream.getName());
-      throw new DatastreamException();
+      throw new DatastreamException("Failed to copy datastream object", e);
     } catch (DatastreamException e) {
       _log.error("Failed to perform post datastream state change action datastream={}", datastream.getName());
       _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.POST_DATASTREAMS_STATE_CHANGE_ACTION_NUM_ERRORS, 1);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1098,12 +1098,16 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   public void invokePostDataStreamStateChangeAction(final Datastream datastream) throws DatastreamException {
     _log.info("Invoke post datastream state change action");
     try {
-      final String connectorName = datastream.getConnectorName();
+      Datastream datastreamCopy = datastream.copy();
+      final String connectorName = datastreamCopy.getConnectorName();
       final ConnectorInfo connectorInfo = _connectors.get(connectorName);
-      connectorInfo.getConnector().postDatastreamStateChangeAction(datastream);
+      connectorInfo.getConnector().postDatastreamStateChangeAction(datastreamCopy);
+    } catch (CloneNotSupportedException e) {
+      _log.error("Failed to copy object for datastream={}", datastream.getName());
+      throw new DatastreamException();
     } catch (DatastreamException e) {
-      _log.error("Failed to perform post datastream state change action datastream={}", datastream);
-      _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.VALIDATE_DATASTREAMS_UPDATE_NUM_ERRORS, 1);
+      _log.error("Failed to perform post datastream state change action datastream={}", datastream.getName());
+      _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.POST_DATASTREAMS_STATE_CHANGE_ACTION_NUM_ERRORS, 1);
       throw e;
     }
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -49,6 +49,7 @@ import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamAlreadyExistsException;
 import com.linkedin.datastream.common.DatastreamConstants;
 import com.linkedin.datastream.common.DatastreamDestination;
+import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.DatastreamStatus;
@@ -438,7 +439,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
             datastreamGroups.stream().filter(x -> x.getTaskPrefix().equals(task.getTaskPrefix())).findFirst();
         if (dg.isPresent()) {
           ((DatastreamTaskImpl) task).setDatastreams(dg.get().getDatastreams());
-          dg.get().getDatastreams().forEach(this::invokePostDataStreamStateChangeAction);
         } else {
           _log.warn("Can't find datastream group for task {}", task);
         }
@@ -986,10 +986,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   }
 
   /**
-   * This method performs following tasks:
+   * This method performs two tasks:
    * 1) initializes destination for a newly created datastream and update it in ZooKeeper
    * 2) delete an existing datastream if it is marked as deleted or its TTL has expired.
-   * 3) perform post datastream add or delete action, this will be invoked as an async call
    *
    * If #2 occurs, it also invalidates the datastream cache for the next assignment.
    *
@@ -1032,9 +1031,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
             _log.warn("Failed to update datastream: {} after initializing. This datastream will not be scheduled for "
                 + "producing events ", ds.getName());
             shouldRetry = true;
-          } else {
-            // invoke post datastream upsert/delete or state modify actions
-            invokePostDataStreamStateChangeAction(ds);
           }
         } catch (Exception e) {
           _log.warn("Failed to update the destination of new datastream {}", ds, e);
@@ -1092,20 +1088,24 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
 
     _adapter.deleteDatastream(ds.getName());
-    invokePostDataStreamStateChangeAction(ds);
   }
 
-  private void invokePostDataStreamStateChangeAction(final Datastream ds) {
-    Executors.newSingleThreadExecutor().submit(() -> {
-      try {
-        final String connectorName = ds.getConnectorName();
-        final ConnectorInfo connectorInfo = _connectors.get(connectorName);
-        connectorInfo.getConnector().postDatastreamStateChangeAction(ds);
-      } catch (Exception e) {
-        // no need to re-throw the exception as we do not want to kill the leader thread
-        _log.warn("Failed to perform postDatastreamStageChangeAction", e);
-      }
-    });
+  /**
+   * Invokes post datastream state change action of connector for given datastream.
+   * @param datastream the datastream
+   * @throws DatastreamException if fails to perform post datastream action
+   */
+  public void invokePostDataStreamStateChangeAction(final Datastream datastream) throws DatastreamException {
+    _log.info("Invoke post datastream state change action");
+    try {
+      final String connectorName = datastream.getConnectorName();
+      final ConnectorInfo connectorInfo = _connectors.get(connectorName);
+      connectorInfo.getConnector().postDatastreamStateChangeAction(datastream);
+    } catch (DatastreamException e) {
+      _log.error("Failed to perform post datastream state change action datastream={}", datastream);
+      _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.VALIDATE_DATASTREAMS_UPDATE_NUM_ERRORS, 1);
+      throw e;
+    }
   }
 
   private void createTopic(Datastream datastream) {
@@ -2176,6 +2176,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       IS_PARTITION_ASSIGNMENT_SUPPORTED_NUM_ERRORS("isPartitionAssignmentSupported", NUM_ERRORS),
       IS_DATASTREAM_UPDATE_TYPE_SUPPORTED_NUM_ERRORS("isDatastreamUpdateTypeSupported", NUM_ERRORS),
       INITIALIZE_DATASTREAM_NUM_ERRORS("initializeDatastream", NUM_ERRORS),
+      POST_DATASTREAMS_STATE_CHANGE_ACTION_NUM_ERRORS("postDatastreamStateChangeAction", NUM_ERRORS),
       /* Coordinator event metrics */
       LEADER_DO_ASSIGNMENT_NUM_ERRORS(HANDLE_EVENT_PREFIX + EventType.LEADER_DO_ASSIGNMENT, NUM_ERRORS),
       LEADER_PARTITION_ASSIGNMENT_NUM_ERRORS(HANDLE_EVENT_PREFIX + EventType.LEADER_PARTITION_ASSIGNMENT, NUM_ERRORS),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -438,6 +438,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
             datastreamGroups.stream().filter(x -> x.getTaskPrefix().equals(task.getTaskPrefix())).findFirst();
         if (dg.isPresent()) {
           ((DatastreamTaskImpl) task).setDatastreams(dg.get().getDatastreams());
+          dg.get().getDatastreams().forEach(this::invokePostDataStreamStateChangeAction);
         } else {
           _log.warn("Can't find datastream group for task {}", task);
         }
@@ -985,9 +986,10 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   }
 
   /**
-   * This method performs two tasks:
+   * This method performs following tasks:
    * 1) initializes destination for a newly created datastream and update it in ZooKeeper
    * 2) delete an existing datastream if it is marked as deleted or its TTL has expired.
+   * 3) perform post datastream add or delete action
    *
    * If #2 occurs, it also invalidates the datastream cache for the next assignment.
    *
@@ -1030,6 +1032,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
             _log.warn("Failed to update datastream: {} after initializing. This datastream will not be scheduled for "
                 + "producing events ", ds.getName());
             shouldRetry = true;
+          } else {
+            // invoke post datastream upsert/delete or state modify actions
+            invokePostDataStreamStateChangeAction(ds);
           }
         } catch (Exception e) {
           _log.warn("Failed to update the destination of new datastream {}", ds, e);
@@ -1087,6 +1092,20 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
 
     _adapter.deleteDatastream(ds.getName());
+    invokePostDataStreamStateChangeAction(ds);
+  }
+
+  private void invokePostDataStreamStateChangeAction(final Datastream ds) {
+    Executors.newSingleThreadExecutor().submit(() -> {
+      try {
+        final String connectorName = ds.getConnectorName();
+        final ConnectorInfo connectorInfo = _connectors.get(connectorName);
+        connectorInfo.getConnector().postDatastreamStateChangeAction(ds);
+      } catch (Exception e) {
+        // no need to re-throw the exception as we do not want to kill the leader thread
+        _log.warn("Failed to perform postDatastreamStageChangeAction", e);
+      }
+    });
   }
 
   private void createTopic(Datastream datastream) {

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/connectors/DummyConnector.java
@@ -9,8 +9,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
+import org.testng.Assert;
+
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamConstants;
+import com.linkedin.datastream.common.DatastreamException;
 import com.linkedin.datastream.common.DiagnosticsAware;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.server.DatastreamTask;
@@ -28,6 +31,7 @@ public class DummyConnector implements Connector, DiagnosticsAware {
   public static final String CONNECTOR_TYPE = "DummyConnector";
 
   private final Properties _properties;
+  private int _postDSStatechangeActionInvokeCount;
 
   /**
    * Constructor for DummyConnector
@@ -41,6 +45,10 @@ public class DummyConnector implements Connector, DiagnosticsAware {
     if (!dummyConfigValue.equals("dummyValue")) {
       throw new Exception("Invalid config value for dummyProperty. Expected: dummyValue");
     }
+  }
+
+  public int getPostDSStatechangeActionInvokeCount() {
+    return _postDSStatechangeActionInvokeCount;
   }
 
   @Override
@@ -70,6 +78,12 @@ public class DummyConnector implements Connector, DiagnosticsAware {
   @Override
   public void validateUpdateDatastreams(List<Datastream> datastreams, List<Datastream> allDatastreams)
       throws DatastreamValidationException {
+  }
+
+  @Override
+  public void postDatastreamStateChangeAction(Datastream stream) throws DatastreamException {
+    ++_postDSStatechangeActionInvokeCount;
+    Assert.assertNotNull(stream);
   }
 
   @Override

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "4.0.0"
+  version = "4.1.0"
 }
 
 subprojects {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.9.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip


### PR DESCRIPTION
- `Connector::postDatastreamStateChangeAction(Datastream stream)` Added to expose the hook for post datastream add/update/delete and state change action. The default has no implementation, any interested connectors need to add support by implementing this method.

- In` DatastreamResource`, call this newly added method in Coordinator after create, update, delete, state change(Pause, Resume, Stop).

- Add unit test to handle this new method functionality.