### PR TITLE
Set datastream status to deleting for delete call

### DIFF
--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -745,7 +745,10 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       _store.deleteDatastream(datastreamName);
       DELETE_CALL_LATENCY_MS.set(Duration.between(startTime, Instant.now()).toMillis());
 
-      // invoke post datastream state change action for recently deleted datastream
+      // EXPLICITLY set the status to DatastreamStatus.DELETING as `_store.deleteDatastream(datastreamName);`
+      // creates new Datastream instance and sets the status on that, which will not be reflected here into
+      // original Datastream instance then invoke post datastream state change action for recently deleted datastream
+      datastream.setStatus(DatastreamStatus.DELETING);
       invokePostDSStateChangeAction(datastream);
 
       return new UpdateResponse(HttpStatus.S_200_OK);

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.0.0-SNAPSHOT"
+  version = "5.0.1-SNAPSHOT"
 }
 
 subprojects {


### PR DESCRIPTION
EXPLICITLY set the status to DatastreamStatus.DELETING as `_store.deleteDatastream(datastreamName);` creates new Datastream instance and sets the status on that, which will not be reflected here into original Datastream instance then invoke post datastream state change action for recently deleted datastream

Testing: when delete API gets called, it fetches the datastream from ZK and uses that object to set the status as delete, this is being done in ZookeeperBackedDatastreamStore::deleteDatastream and DatastreamResources::delete() does not have visibility into this object. So when it calls `invokePostDSStateChangeAction` it passes the instance of Datastream that has status set before delete call.  See below, for datastream `mp-test-final` was in `READY` state when delete API call happened and it passes the `Status=READY` to `invokePostDSStateChangeAction ` which suppose to be DELETING. This PR fixes that.

```
2022/11/30 21:36:19.847 INFO [DatastreamResources] [qtp307605969-70] [brooklin-service] [AAXutuUrhM+kEcZT/gwPUA==] Delete datastream called for datastream mp-test-final
2022/11/30 21:36:19.850 INFO [DatastreamMetadataProducer] [qtp307605969-70] [brooklin-service] [AAXutuUrhM+kEcZT/gwPUA==] Perform postDatastreamStateChangeAction datastreamName=mp-test-final
2022/11/30 21:36:19.850 INFO [DatastreamResources] [qtp307605969-70] [brooklin-service] [AAXutuUrhM+kEcZT/gwPUA==] Invoked post datastream state change action datastream={**Status=READY**, metadata={------}}
2022/11/30 21:36:19.850 INFO [DatastreamMetadataProducer] [pool-30-thread-1] [brooklin-service] [] publish metadata for datastreamName=mp-test-final status=READY
```
