### PR TITLE
BMM Restart Improvements Part 1. Leader Coordinator Issuing Assignment Tokens

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentToken.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentToken.java
@@ -12,7 +12,7 @@ import com.linkedin.datastream.common.JsonUtils;
  * Data structure to store assignment tokens. These are used as a mechanism for followers to signal the leader that
  * they handled assignment change
  */
-public class AssignmentToken {
+public final class AssignmentToken {
   private String _issuedBy;
   private String _issuedFor;
   private long  _timestamp;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentToken.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentToken.java
@@ -1,0 +1,91 @@
+/**
+ *  Copyright 2022 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server;
+
+import com.linkedin.datastream.common.JsonUtils;
+
+
+/**
+ * Data structure to store assignment tokens. These are used as a mechanism for followers to signal the leader that
+ * they handled assignment change
+ */
+public class AssignmentToken {
+  private String _issuedBy;
+  private String _issuedFor;
+  private long  _timestamp;
+
+  /**
+   * Constructor for {@link AssignmentToken}
+   */
+  public AssignmentToken(String issuedBy, String issuedFor) {
+    _issuedBy = issuedBy;
+    _issuedFor = issuedFor;
+    _timestamp = System.currentTimeMillis();
+  }
+
+  /**
+   * Default constructor for {@link AssignmentToken}, required for json ser/de
+   */
+  public AssignmentToken() {
+
+  }
+
+  /**
+   * Creates {@link AssignmentToken} instance from JSON
+   */
+  public static AssignmentToken fromJson(String json) {
+    return JsonUtils.fromJson(json, AssignmentToken.class);
+  }
+
+  /**
+   * Converts the object to JSON
+   */
+  public String toJson() {
+    return JsonUtils.toJson(this);
+  }
+
+  /**
+   * Gets the name of the leader host that issued the token
+   */
+  public String getIssuedBy() {
+    return _issuedBy;
+  }
+
+  /**
+   * Gets the name of the host for which the token was issued
+   */
+  public String getIssuedFor() {
+    return _issuedFor;
+  }
+
+  /**
+   * Gets the timestamp (in UNIX epoch format) for when the token was issued
+   */
+  public long getTimestamp() {
+    return _timestamp;
+  }
+
+  /**
+   * Sets the name of the leader host that issued the token
+   */
+  public void setIssuedBy(String issuedBy) {
+    _issuedBy = issuedBy;
+  }
+
+  /**
+   * Sets the name of the host for which the token was issued
+   */
+  public void setIssuedFor(String issuedFor) {
+    _issuedFor = issuedFor;
+  }
+
+  /**
+   * Sets the timestamp (in UNIX epoch format) for when the token was issued
+   */
+  public void setTimestamp(long timestamp) {
+    _timestamp = timestamp;
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1219,7 +1219,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // assignment and do remove and add zNodes accordingly. In the case of ZooKeeper failure (when
       // it failed to create or delete zNodes), we will do our best to continue the current process
       // and schedule a retry. The retry should be able to diff the remaining ZooKeeper work
-      _adapter.updateAllAssignments(newAssignmentsByInstance);
+      if (_config.getEnableAssignmentTokens()) {
+        _adapter.updateAllAssignmentsAndIssueTokens(newAssignmentsByInstance, stoppingDatastreamGroups);
+      } else {
+        _adapter.updateAllAssignments(newAssignmentsByInstance);
+      }
 
       for (DatastreamGroup datastreamGroup : stoppingDatastreamGroups) {
         for (Datastream datastream : datastreamGroup.getDatastreams()) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -31,6 +31,7 @@ public final class CoordinatorConfig {
   public static final String CONFIG_PERFORM_PRE_ASSIGNMENT_CLEANUP = PREFIX + "performPreAssignmentCleanup";
   public static final String CONFIG_REINIT_ON_NEW_ZK_SESSION = PREFIX + "reinitOnNewZKSession";
   public static final String CONFIG_MAX_ASSIGNMENT_RETRY_COUNT = PREFIX + "maxAssignmentRetryCount";
+  public static final String CONFIG_ENABLE_ASSIGNMENT_TOKENS = PREFIX + "enableAssignmentTokens";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
 
@@ -50,6 +51,7 @@ public final class CoordinatorConfig {
   private final boolean _performPreAssignmentCleanup;
   private final boolean _reinitOnNewZkSession;
   private final int _maxAssignmentRetryCount;
+  private final boolean _enableAssignmentTokens;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -75,6 +77,7 @@ public final class CoordinatorConfig {
     _performPreAssignmentCleanup = _properties.getBoolean(CONFIG_PERFORM_PRE_ASSIGNMENT_CLEANUP, false);
     _reinitOnNewZkSession = _properties.getBoolean(CONFIG_REINIT_ON_NEW_ZK_SESSION, false);
     _maxAssignmentRetryCount = _properties.getInt(CONFIG_MAX_ASSIGNMENT_RETRY_COUNT, DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT);
+    _enableAssignmentTokens = _properties.getBoolean(CONFIG_ENABLE_ASSIGNMENT_TOKENS, false);
   }
 
   public Properties getConfigProperties() {
@@ -135,5 +138,9 @@ public final class CoordinatorConfig {
 
   public int getMaxAssignmentRetryCount() {
     return _maxAssignmentRetryCount;
+  }
+
+  public boolean getEnableAssignmentTokens() {
+    return _enableAssignmentTokens;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -22,6 +22,8 @@ public final class KeyBuilder {
   private static final String INSTANCE_ASSIGNMENT = "/%s/instances/%s/assignments/%s";
   private static final String DATASTREAMS = "/%s/dms";
   private static final String DATASTREAM = "/%s/dms/%s";
+  private static final String DATASTREAM_ASSIGNMENT_TOKENS = "/%s/dms/%s/assignmentTokens";
+  private static final String DATASTREAM_ASSIGNMENT_TOKEN_FOR_INSTANCE = "/%s/dms/%s/assignmentTokens/%s";
   private static final String CONNECTORS = "/%s/connectors";
   private static final String CONNECTOR = "/%s/connectors/%s";
 
@@ -198,6 +200,25 @@ public final class KeyBuilder {
    */
   public static String datastream(String cluster, String stream) {
     return String.format(DATASTREAM, cluster, stream);
+  }
+
+  /**
+   * Get the ZooKeeper znode for a datastream's assignment tokens in a Brooklin cluster
+   * @param cluster Brooklin cluster name
+   * @param stream Datastream name
+   */
+  public static String datastreamAssignmentTokens(String cluster, String stream) {
+    return String.format(DATASTREAM_ASSIGNMENT_TOKENS, cluster, stream);
+  }
+
+  /**
+   * Get the ZooKeeper znode for a datastream's assignment token for an instance in a Brooklin cluster
+   * @param cluster Brooklin cluster name
+   * @param stream Datastream name
+   * @param instance Instance name
+   */
+  public static String datastreamAssignmentTokenForInstance(String cluster, String stream, String instance) {
+    return String.format(DATASTREAM_ASSIGNMENT_TOKEN_FOR_INSTANCE, cluster, stream, instance);
   }
 
   /**

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -752,6 +752,7 @@ public class ZkAdapter {
         collect(Collectors.toMap(DatastreamGroup::getTaskPrefix, Function.identity()));
 
     // For each stopping datastream group, find all the instances that currently have tasks assigned
+    Map<DatastreamGroup, Set<String>> stoppingDgInstances = new HashMap<>();
     currentAssignment.keySet()
         .forEach(i -> currentAssignment.get(i).stream()
             .filter(t -> stoppingDatastreamTaskPrefixes.contains(t.getTaskPrefix()))

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.Validate;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.helix.zookeeper.zkclient.IZkDataListener;
 import org.apache.helix.zookeeper.zkclient.IZkStateListener;
@@ -741,6 +742,9 @@ public class ZkAdapter {
    */
   public void updateAllAssignmentsAndIssueTokens(Map<String, List<DatastreamTask>> assignmentsByInstance,
       List<DatastreamGroup> stoppingDatastreamGroups) {
+    Validate.notNull(assignmentsByInstance);
+    Validate.notNull(stoppingDatastreamGroups);
+
     Map<String, Set<DatastreamTask>> currentAssignment = getAllAssignedDatastreamTasks();
     Set<String> stoppingDatastreamTaskPrefixes = stoppingDatastreamGroups.stream().
         map(DatastreamGroup::getTaskPrefix).collect(toSet());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -5,8 +5,6 @@
  */
 package com.linkedin.datastream.server.zk;
 
-import com.linkedin.datastream.server.AssignmentToken;
-import com.linkedin.datastream.server.DatastreamGroup;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -49,6 +47,8 @@ import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.ErrorLogger;
 import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.server.AssignmentToken;
+import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;
 import com.linkedin.datastream.server.HostTargetAssignment;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -742,8 +742,8 @@ public class ZkAdapter {
    */
   public void updateAllAssignmentsAndIssueTokens(Map<String, List<DatastreamTask>> assignmentsByInstance,
       List<DatastreamGroup> stoppingDatastreamGroups) {
-    Validate.notNull(assignmentsByInstance);
-    Validate.notNull(stoppingDatastreamGroups);
+    Validate.notNull(assignmentsByInstance, "null assignmentsByInstance");
+    Validate.notNull(stoppingDatastreamGroups, "null stoppingDatastreamGroups");
 
     Map<String, Set<DatastreamTask>> currentAssignment = getAllAssignedDatastreamTasks();
     Set<String> stoppingDatastreamTaskPrefixes = stoppingDatastreamGroups.stream().

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -752,17 +752,13 @@ public class ZkAdapter {
         collect(Collectors.toMap(DatastreamGroup::getTaskPrefix, Function.identity()));
 
     // For each stopping datastream group, find all the instances that currently have tasks assigned
-    Map<DatastreamGroup, Set<String>> stoppingDgInstances = new HashMap<>();
-    for (String instance : currentAssignment.keySet()) {
-        Set<DatastreamTask> instanceTasks = currentAssignment.get(instance);
-        List<DatastreamTask> stoppingTasks = instanceTasks.stream().
-            filter(t -> stoppingDatastreamTaskPrefixes.contains(t.getTaskPrefix())).
-            collect(Collectors.toList());
-        for (DatastreamTask stoppingTask : stoppingTasks) {
-          DatastreamGroup datastreamGroup = taskPrefixDatastreamGroups.get(stoppingTask.getTaskPrefix());
-          stoppingDgInstances.computeIfAbsent(datastreamGroup, k -> new HashSet<>()).add(instance);
-        }
-      }
+    currentAssignment.keySet()
+        .forEach(i -> currentAssignment.get(i).stream()
+            .filter(t -> stoppingDatastreamTaskPrefixes.contains(t.getTaskPrefix()))
+            .forEach(st -> {
+              DatastreamGroup datastreamGroup = taskPrefixDatastreamGroups.get(st.getTaskPrefix());
+              stoppingDgInstances.computeIfAbsent(datastreamGroup, k -> new HashSet<>()).add(i);
+            }));
 
     String hostname = "localhost";
     try {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -5,7 +5,9 @@
  */
 package com.linkedin.datastream.server.zk;
 
+import com.linkedin.datastream.server.AssignmentToken;
 import java.io.IOException;
+import java.net.InetAddress;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1057,6 +1059,59 @@ public class TestZkAdapter {
     Assert.assertFalse(adapter.getZkClient().exists(KeyBuilder.instance(testCluster, "deadInstance-999")));
 
     adapter.disconnect();
+  }
+
+  @Test
+  public void testUpdateAllAssignmentAndIssueTokens() throws Exception {
+    String testCluster = "testUpdateAllAssignmentAndIssueTokens";
+    String connectorType = "connectorType";
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+    ZkAdapter adapter = createZkAdapter(testCluster);
+    adapter.connect();
+
+    // assigning 2 tasks to the cluster
+    Datastream[] datastreams1 = DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType,
+        "datastream1");
+    DatastreamGroup datastreamGroup1 = new DatastreamGroup(Arrays.asList(datastreams1));
+
+    Datastream[] datastreams2 = DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType,
+        "datastream2");
+    DatastreamGroup datastreamGroup2 = new DatastreamGroup(Arrays.asList(datastreams2));
+
+    DatastreamTaskImpl task1 = new DatastreamTaskImpl();
+    task1.setTaskPrefix(datastreamGroup1.getTaskPrefix());
+    task1.setConnectorType(connectorType);
+
+    DatastreamTaskImpl task2 = new DatastreamTaskImpl();
+    task2.setTaskPrefix(datastreamGroup2.getTaskPrefix());
+    task2.setConnectorType(connectorType);
+
+    Map<String, List<DatastreamTask>> oldAassignment = new HashMap<>();
+    oldAassignment.put("instance1", Collections.singletonList(task1));
+    oldAassignment.put("instance2", Collections.singletonList(task2));
+
+    adapter.updateAllAssignments(oldAassignment);
+
+    // simulating a stopping datastream which has a task assigned to instance2
+    List<DatastreamGroup> stoppingDatastreamGroups = Collections.singletonList(datastreamGroup2);
+    Map<String, List<DatastreamTask>> newAssignment = new HashMap<>();
+    newAssignment.put("instance1", Collections.singletonList(task1));
+    adapter.updateAllAssignmentsAndIssueTokens(newAssignment, stoppingDatastreamGroups);
+
+    // asserting that:
+    // (1) the assignment tokens path was created for stopping stream
+    // (2) a token has ben issued for instance2, and only for instance2
+    // (3) the token data is correct
+    String assignmentTokensPath = KeyBuilder.datastreamAssignmentTokens(testCluster, datastreamGroup2.getTaskPrefix());
+    Assert.assertTrue(zkClient.exists(assignmentTokensPath));
+    List<String> tokenNodes = zkClient.getChildren(assignmentTokensPath);
+    Assert.assertEquals(tokenNodes.size(), 1);
+    String tokenData = zkClient.readData(
+        KeyBuilder.datastreamAssignmentTokenForInstance(testCluster, datastreamGroup2.getTaskPrefix(), tokenNodes.get(0)));
+    AssignmentToken token = AssignmentToken.fromJson(tokenData);
+    Assert.assertEquals(token.getIssuedFor(), "instance2");
+    String hostname = InetAddress.getLocalHost().getHostName();
+    Assert.assertEquals(token.getIssuedBy(), hostname);
   }
 
   @Test

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -5,7 +5,6 @@
  */
 package com.linkedin.datastream.server.zk;
 
-import com.linkedin.datastream.server.AssignmentToken;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.time.Duration;
@@ -32,6 +31,7 @@ import com.google.common.collect.ImmutableSet;
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.server.AssignmentToken;
 import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DatastreamTaskImpl;


### PR DESCRIPTION
This pull request is part of a series of changes that are meant to improve BMM Restart and make it easier to debug restart failures and trace them to the faulty hosts. It introduces the concept of assignment tokens and adds support for issuing those tokens by the leader coordinator. This feature can be toggled by the newly introduced `brooklin.server.coordinator.enableAssignmentTokens` configuration.

The subsequent PRs will deal with the following aspects:
Part 2 – Changes to the followers' `onAssignmentChange` to make them claim the tokens issued by the leader.
Part 3 – Changes to the leader to make it poll the ZooKeeper and wait for the assignment change (stop) to be propagated and executed by the cluster. This will also include code for handling assignment failures and signals to the client that problem(s) occurred in the form of log messages and a new metric.
Part 4 – This one will deal with edge cases and cleanup. More specifically, what happens when a leader fails over during an assignment (assignment token nodes are persistent and their lifecycle is tied to that of the parent datastream).
