### PR TITLE
BMM Restart Improvements Part 3. Leader polls for unclaimed tokens before declaring a datastream STOPPED

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2190,6 +2190,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
      */
     public enum Meter {
       NUM_REBALANCES("numRebalances"),
+      NUM_FAILED_STOPS("numFailedStops"),
       NUM_ASSIGNMENT_CHANGES("numAssignmentChanges"),
       NUM_PARTITION_ASSIGNMENTS("numPartitionAssignments"),
       NUM_PARTITION_MOVEMENTS("numPartitionMovements"),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -166,6 +166,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
   private static final long EVENT_THREAD_LONG_JOIN_TIMEOUT = 90000L;
   private static final long EVENT_THREAD_SHORT_JOIN_TIMEOUT = 3000L;
+  // how long should the leader wait between consecutive polls to zookeeper to confirm that the datastreams have stopped
   private static final long STOP_PROPAGATION_RETRY_MS = 5000L;
 
   private static final Duration ASSIGNMENT_TIMEOUT = Duration.ofSeconds(90);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1241,8 +1241,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         _log.error("Stop failed to propagate within {}ms for streams: {}. The following hosts failed to claim their token(s): {}",
             _config.getStopPropagationTimeout(), failedStreams, hosts);
         revokeUnclaimedAssignmentTokens(unclaimedTokens);
-        _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.HANDLE_LEADER_DO_ASSIGNMENT_NUM_FAILED_STOPS,
-            failedStreams.size());
+        _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_FAILED_STOPS, failedStreams.size());
       }
 
       // TODO Explore introduction of UNKNOWN/WARN state for streams that failed to stop
@@ -2017,7 +2016,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     private static final String NUM_RETRIES = "numRetries";
     private static final String NUM_ERRORS = "numErrors";
     private static final String HANDLE_EVENT_PREFIX = "handleEvent";
-    private static final String NUM_FAILED_STOPS = "numFailedStops";
 
     // Gauge metrics
     private static final String MAX_PARTITION_COUNT_IN_TASK = "maxPartitionCountInTask";
@@ -2214,7 +2212,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     public enum KeyedMeter {
       HANDLE_DATASTREAM_ADD_OR_DELETE_NUM_RETRIES("handleDatastreamAddOrDelete", NUM_RETRIES),
       HANDLE_LEADER_DO_ASSIGNMENT_NUM_RETRIES("handleLeaderDoAssignment", NUM_RETRIES, true),
-      HANDLE_LEADER_DO_ASSIGNMENT_NUM_FAILED_STOPS("handleLeaderDoAssignment", NUM_FAILED_STOPS, true),
       HANDLE_LEADER_PARTITION_ASSIGNMENT_NUM_RETRIES("handleLeaderPartitionAssignment", NUM_RETRIES, true),
       HANDLE_LEADER_PARTITION_MOVEMENT_NUM_ERRORS("handleLeaderPartitionMovement", NUM_ERRORS),
       HANDLE_LEADER_PARTITION_MOVEMENT_NUM_RETRIES("handleLeaderPartitionMovement", NUM_RETRIES),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -198,7 +198,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   // handleEvent is synchronized and downstream code can misbehave.
   private final Duration _heartbeatPeriod;
 
-
   private final Logger _log = LoggerFactory.getLogger(Coordinator.class.getName());
   private final ScheduledExecutorService _executor = Executors.newSingleThreadScheduledExecutor();
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -144,7 +144,9 @@ public final class CoordinatorConfig {
     return _maxAssignmentRetryCount;
   }
 
-  public long getStopPropagationTimeout() { return  _stopPropagationTimeout; }
+  public long getStopPropagationTimeout() {
+    return  _stopPropagationTimeout;
+  }
 
   public boolean getEnableAssignmentTokens() {
     return _enableAssignmentTokens;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -32,8 +32,12 @@ public final class CoordinatorConfig {
   public static final String CONFIG_REINIT_ON_NEW_ZK_SESSION = PREFIX + "reinitOnNewZKSession";
   public static final String CONFIG_MAX_ASSIGNMENT_RETRY_COUNT = PREFIX + "maxAssignmentRetryCount";
   public static final String CONFIG_ENABLE_ASSIGNMENT_TOKENS = PREFIX + "enableAssignmentTokens";
+
+  // how long should the leader poll the zookeeper to confirm that stopping datastreams have stopped before giving up
   public static final String CONFIG_STOP_PROPAGATION_TIMEOUT_MS = PREFIX + "stopPropagationTimeout";
+  // how long should the coordinator wait for a connector's tasks to stop before giving up
   public static final String CONFIG_TASK_STOP_CHECK_TIMEOUT_MS = PREFIX + "taskStopCheckTimeoutMs";
+  // how long should the coordinator wait in between two consecutive calls to check if a connector's tasks have stopped
   public static final String CONFIG_TASK_STOP_CHECK_RETRY_PERIOD_MS = PREFIX + "taskStopCheckRetryPeriodMs";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -156,4 +156,16 @@ public final class CoordinatorConfig {
   public boolean getEnableAssignmentTokens() {
     return _enableAssignmentTokens;
   }
+
+  public long getTaskStopCheckTimeoutMs() {
+    return _taskStopCheckTimeoutMs;
+  }
+
+  public long getTaskStopCheckRetryPeriodMs() {
+    return _taskStopCheckRetryPeriodMs;
+  }
+
+  public long getStopPropagationTimeout() {
+    return _stopPropagationTimeout;
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -32,8 +32,10 @@ public final class CoordinatorConfig {
   public static final String CONFIG_REINIT_ON_NEW_ZK_SESSION = PREFIX + "reinitOnNewZKSession";
   public static final String CONFIG_MAX_ASSIGNMENT_RETRY_COUNT = PREFIX + "maxAssignmentRetryCount";
   public static final String CONFIG_ENABLE_ASSIGNMENT_TOKENS = PREFIX + "enableAssignmentTokens";
+  public static final String CONFIG_STOP_PROPAGATION_TIMEOUT_MS = PREFIX + "stopPropagationTimeout";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
+  public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60000;
 
   private final String _cluster;
   private final String _zkAddress;
@@ -52,6 +54,7 @@ public final class CoordinatorConfig {
   private final boolean _reinitOnNewZkSession;
   private final int _maxAssignmentRetryCount;
   private final boolean _enableAssignmentTokens;
+  private final long _stopPropagationTimeout;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -78,6 +81,7 @@ public final class CoordinatorConfig {
     _reinitOnNewZkSession = _properties.getBoolean(CONFIG_REINIT_ON_NEW_ZK_SESSION, false);
     _maxAssignmentRetryCount = _properties.getInt(CONFIG_MAX_ASSIGNMENT_RETRY_COUNT, DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT);
     _enableAssignmentTokens = _properties.getBoolean(CONFIG_ENABLE_ASSIGNMENT_TOKENS, false);
+    _stopPropagationTimeout = _properties.getLong(CONFIG_STOP_PROPAGATION_TIMEOUT_MS, DEFAULT_STOP_PROPAGATION_TIMEOUT_MS);
   }
 
   public Properties getConfigProperties() {
@@ -139,6 +143,8 @@ public final class CoordinatorConfig {
   public int getMaxAssignmentRetryCount() {
     return _maxAssignmentRetryCount;
   }
+
+  public long getStopPropagationTimeout() { return  _stopPropagationTimeout; }
 
   public boolean getEnableAssignmentTokens() {
     return _enableAssignmentTokens;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -29,7 +29,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
-import jdk.nashorn.internal.ir.Assignment;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Validate;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
@@ -8,8 +8,6 @@ package com.linkedin.datastream.server;
 import java.util.Properties;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterMethod;
-import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 /**
@@ -27,14 +25,6 @@ public class TestCoordinatorConfig {
     return config;
   }
 
-  @BeforeMethod
-  public void setup() {
-  }
-
-  @AfterMethod
-  public void teardown() {
-  }
-
   @Test
   public void testCoordinatorMaxAssignmentRetryCountFromConfig() throws Exception {
     Properties props = new Properties();
@@ -48,5 +38,17 @@ public class TestCoordinatorConfig {
     Properties props = new Properties();
     CoordinatorConfig config = createCoordinatorConfig(props);
     Assert.assertEquals(CoordinatorConfig.DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT, config.getMaxAssignmentRetryCount());
+  }
+
+  @Test
+  public void testStopPropagationTimeoutConfig() {
+    Properties props = new Properties();
+    CoordinatorConfig config = createCoordinatorConfig(props);
+    Assert.assertEquals(CoordinatorConfig.DEFAULT_STOP_PROPAGATION_TIMEOUT_MS, config.getStopPropagationTimeout());
+
+    String stopPropagationTimeoutValue = "1000";
+    props.put(CoordinatorConfig.CONFIG_STOP_PROPAGATION_TIMEOUT_MS, stopPropagationTimeoutValue);
+    CoordinatorConfig config2 = createCoordinatorConfig(props);
+    Assert.assertEquals(config2.getStopPropagationTimeout(), 1000);
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -1176,8 +1176,8 @@ public class TestZkAdapter {
 
     zkClient.ensurePath(KeyBuilder.datastreamAssignmentTokens(cluster, datastream1));
     zkClient.ensurePath(KeyBuilder.datastreamAssignmentTokens(cluster, datastream2));
-    AssignmentToken instance1Token = new AssignmentToken(localhost, instance1);
-    AssignmentToken instance2Token = new AssignmentToken(localhost, instance1);
+    AssignmentToken instance1Token = new AssignmentToken(localhost, instance1, System.currentTimeMillis());
+    AssignmentToken instance2Token = new AssignmentToken(localhost, instance1, System.currentTimeMillis());
     zkClient.create(KeyBuilder.datastreamAssignmentTokenForInstance(cluster, datastream1, instance1),
         instance1Token.toJson(), CreateMode.PERSISTENT);
     zkClient.create(KeyBuilder.datastreamAssignmentTokenForInstance(cluster, datastream1, instance2),


### PR DESCRIPTION
This pull request is part of a series of changes that are meant to improve BMM Restart and make it easier to debug restart failures and trace them to the faulty hosts. Part 3 introduces changes to the leader that make it poll the tokens for stop assignment and make sure that all followers claimed their tokens before declaring a stream `STOPPED`. If at least one follower failed to claim their token, a detailed error message is logged and a metric is emitted. Unclaimed tokens are revoked by the leader. Poll timeout is configurable.

The PRs in this series deal with the following aspects:
Part 1 – Introduction of assignment tokens and support for issuing tokens by the leader coordinator (https://github.com/linkedin/brooklin/pull/919)
Part 2 – Changes to the followers' handleAssignmentChange to make them claim the tokens issued by the leader. (https://github.com/linkedin/brooklin/pull/921)
**Part 3 – Changes to the leader to make it poll the ZooKeeper and wait for the assignment change (stop) to be propagated and executed by the cluster.**
Part 4 – This one will deal with edge cases and cleanup. More specifically, what happens when a leader fails over during an assignment (assignment token nodes are persistent and their lifecycle is tied to that of the parent datastream).