### PR TITLE
BMM Restart Improvements Part 4. Edge cases, cleanup and general improvements

### DIFF
--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -483,7 +483,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
             // leader failed to do so. This needs to be used only if attempts to stop a stream regularly fail
             LOG.info("Force stop for datastream {} requested. Setting the datastream to STOPPED state and invoking cleanup",
                 d.getName());
-            _store.deleteAssignmentTokens(d.getName());
+            _store.forceCleanupDatastream(d.getName());
             d.setStatus(DatastreamStatus.STOPPED);
             _store.updateDatastream(d.getName(), d, false);
           } else {

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -479,6 +479,10 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           LOG.warn("Datastream {} is already in {} state. Notifying leader to initiate transition", d,
               d.getStatus());
           if (force) {
+            // force stop recover the setup (i.e. set the datastream to STOPPED state) and do cleanup in case
+            // leader failed to do so. This needs to be used only if attempts to stop a stream regularly fail
+            LOG.info("Force stop for datastream {} requested. Setting the datastream to STOPPED state and invoking cleanup",
+                d.getName());
             _store.deleteAssignmentTokens(d.getName());
             d.setStatus(DatastreamStatus.STOPPED);
             _store.updateDatastream(d.getName(), d, false);

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -478,7 +478,13 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           // this check helps in preventing any datastream from being stuck in STOPPING state indefinitely
           LOG.warn("Datastream {} is already in {} state. Notifying leader to initiate transition", d,
               d.getStatus());
-          _store.updateDatastream(d.getName(), d, true);
+          if (force) {
+            _store.deleteAssignmentTokens(d.getName());
+            d.setStatus(DatastreamStatus.STOPPED);
+            _store.updateDatastream(d.getName(), d, false);
+          } else {
+            _store.updateDatastream(d.getName(), d, true);
+          }
           _store.deleteDatastreamNumTasks(d.getName());
           // invoke post datastream state change action for recently stopped datastream
           invokePostDSStateChangeAction(d);

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -102,7 +102,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
   // To support retries on the request timeouts
   public static final String CONFIG_STOP_TRANSITION_TIMEOUT_MS = "stopTransitionTimeoutMs";
   public static final String CONFIG_STOP_TRANSITION_RETRY_PERIOD_MS = "stopTransitionRetryPeriodMs";
-  private static final Long STOP_TRANSITION_TIMEOUT_MS_DEFAULT = Duration.ofMillis(60000).toMillis();
+  private static final Long STOP_TRANSITION_TIMEOUT_MS_DEFAULT = Duration.ofMillis(90000).toMillis();
   private static final Long STOP_TRANSITION_RETRY_PERIOD_MS_DEFAULT = Duration.ofMillis(1000).toMillis();
 
   private final DatastreamStore _store;

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -71,5 +71,5 @@ public interface DatastreamStore {
    * Delete the assignment tokens (if any) associated with the provided key
    * @param key Name of the datastream whose assignment tokens have to be deleted
    */
-  void deleteAssignmentTokens(String key);
+  void forceCleanupDatastream(String key);
 }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -66,4 +66,10 @@ public interface DatastreamStore {
    * @param key Name of the original datastream whose numTasks znode is to be deleted
    */
   void deleteDatastreamNumTasks(String key);
+
+  /**
+   * Delete the assignment tokens (if any) associated with the provided key
+   * @param key Name of the datastream whose assignment tokens have to be deleted
+   */
+  void deleteAssignmentTokens(String key);
 }

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/ZookeeperBackedDatastreamStore.java
@@ -242,6 +242,18 @@ public class ZookeeperBackedDatastreamStore implements DatastreamStore {
     _zkClient.delete(path);
   }
 
+  @Override
+  public void deleteAssignmentTokens(String key) {
+    String assignmentTokensPath = KeyBuilder.datastreamAssignmentTokens(_cluster, key);
+
+    if (!_zkClient.exists(assignmentTokensPath)) {
+      LOG.info("Assignment tokens path clear for datastream {}. Nothing to delete", key);
+      return;
+    }
+
+    _zkClient.deleteRecursively(assignmentTokensPath);
+  }
+
   private void notifyLeaderOfDataChange() {
     String dmsPath = KeyBuilder.datastreams(_cluster);
     // Update the /dms to notify that coordinator needs to act on a deleted or changed datastream.

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -449,10 +449,18 @@ public class TestDatastreamResources {
     Assert.assertNotNull(ds);
     Assert.assertEquals(ds.getStatus(), DatastreamStatus.STOPPING);
 
+    // Setting status to STOPPING again explicitly to perform testing.
+    datastreamToCreate.setStatus(DatastreamStatus.STOPPING);
+    store.updateDatastream(datastreamName, datastreamToCreate, false);
+
+    // Attempting to force stop a datastream in stopping state
+    Assert.assertEquals(resource1.stop(pathKey, true).getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(resource1.get(datastreamName).getStatus(), DatastreamStatus.STOPPED);
+
     // Attempting to delete a datastream in stopping state, which should get executed without exception.
     Assert.assertEquals(resource1.delete(datastreamName).getStatus(), HttpStatus.S_200_OK);
     Assert.assertEquals(resource1.get(datastreamName).getStatus(), DatastreamStatus.DELETING);
-    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 4);
+    Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 6);
   }
 
   @Test

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
@@ -333,7 +333,7 @@ public class TestZookeeperBackedDatastreamStore {
     Assert.assertTrue(_zkClient.exists(token1Path));
     Assert.assertTrue(_zkClient.exists(token2Path));
 
-    _store.deleteAssignmentTokens(ds.getName());
+    _store.forceCleanupDatastream(ds.getName());
 
     // Make sure nodes for tokens were deleted
     Assert.assertFalse(_zkClient.exists(tokensRootPath));

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestZookeeperBackedDatastreamStore.java
@@ -314,4 +314,30 @@ public class TestZookeeperBackedDatastreamStore {
 
     Assert.assertNull(_store.getAssignedTaskInstance(datastreamName, null));
   }
+
+  @Test
+  public void testDeleteAssignmentTokens() {
+    Datastream ds = generateDatastream(0);
+    _store.createDatastream(ds.getName(), ds);
+
+    // Create assignment tokens under datastream
+    String tokensRootPath = KeyBuilder.datastreamAssignmentTokens(_clusterName, ds.getName());
+    String token1Path = KeyBuilder.datastreamAssignmentTokenForInstance(_clusterName, ds.getName(), "instance1");
+    String token2Path = KeyBuilder.datastreamAssignmentTokenForInstance(_clusterName, ds.getName(), "instance2");
+    _zkClient.create(tokensRootPath, null, CreateMode.PERSISTENT);
+    _zkClient.create(token1Path, null, CreateMode.PERSISTENT);
+    _zkClient.create(token2Path, null, CreateMode.PERSISTENT);
+
+    // Make sure nodes for tokens were created
+    Assert.assertTrue(_zkClient.exists(tokensRootPath));
+    Assert.assertTrue(_zkClient.exists(token1Path));
+    Assert.assertTrue(_zkClient.exists(token2Path));
+
+    _store.deleteAssignmentTokens(ds.getName());
+
+    // Make sure nodes for tokens were deleted
+    Assert.assertFalse(_zkClient.exists(tokensRootPath));
+    Assert.assertFalse(_zkClient.exists(token1Path));
+    Assert.assertFalse(_zkClient.exists(token2Path));
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -809,7 +809,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   @VisibleForTesting
   void maybeClaimAssignmentTokensForStoppingStreams(List<DatastreamTask> newAssignment,
       List<DatastreamTask> oldAssignment) {
-    // TODO Add metrics for number of streams that are inferred as stopping
     Map<String, List<DatastreamTask>> newAssignmentPerConnector = new HashMap<>();
     for (DatastreamTask task : newAssignment) {
       String connectorType = task.getConnectorType();
@@ -839,6 +838,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       Set<String> stoppingStreamNames = stoppingStreams.stream().map(Datastream::getName).collect(Collectors.toSet());
 
       if (!stoppingStreamNames.isEmpty()) {
+        _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_INFERRED_STOPPING_STREAMS, stoppingStreams.size());
         _log.info("Trying to claim assignment tokens for connector {}, streams: {}", connector, stoppingStreamNames);
 
         Set<String> stoppingDatastreamTasks = removedTasks.stream().
@@ -2317,6 +2317,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     public enum Meter {
       NUM_REBALANCES("numRebalances"),
       NUM_FAILED_STOPS("numFailedStops"),
+      NUM_INFERRED_STOPPING_STREAMS("numInferredStoppingStreans"),
       NUM_ASSIGNMENT_CHANGES("numAssignmentChanges"),
       NUM_PARTITION_ASSIGNMENTS("numPartitionAssignments"),
       NUM_PARTITION_MOVEMENTS("numPartitionMovements"),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2317,7 +2317,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     public enum Meter {
       NUM_REBALANCES("numRebalances"),
       NUM_FAILED_STOPS("numFailedStops"),
-      NUM_INFERRED_STOPPING_STREAMS("numInferredStoppingStreans"),
+      NUM_INFERRED_STOPPING_STREAMS("numInferredStoppingStreams"),
       NUM_ASSIGNMENT_CHANGES("numAssignmentChanges"),
       NUM_PARTITION_ASSIGNMENTS("numPartitionAssignments"),
       NUM_PARTITION_MOVEMENTS("numPartitionMovements"),

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1363,12 +1363,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         revokeUnclaimedAssignmentTokens(unclaimedTokens, stoppingDatastreamGroups);
       }
 
-      // TODO Explore introduction of UNKNOWN/WARN state for streams that failed to stop
-
+      boolean forceStop = _config.getForceStopStreamsOnFailure();
       for (DatastreamGroup datastreamGroup : stoppingDatastreamGroups) {
         for (Datastream datastream : datastreamGroup.getDatastreams()) {
-          // Only streams that were confirmed to have stopped successfully will be transitioned to STOPPED state
-          if (!failedStreams.contains(datastream.getName())) {
+          // If no force stop is configured, only streams that were confirmed to have stopped successfully will be
+          // transitioned to STOPPED state
+          if (forceStop || !failedStreams.contains(datastream.getName())) {
             datastream.setStatus(DatastreamStatus.STOPPED);
             if (!_adapter.updateDatastream(datastream)) {
               _log.warn("Failed to update datastream: {} to stopped state", datastream.getName());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1350,6 +1350,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         Set<String> hosts = unclaimedTokens.values().stream().flatMap(List::stream).
             map(AssignmentToken::getIssuedFor).collect(Collectors.toSet());
 
+        // We skip emitting the NUM_FAILED_STOPS metric in case of leader failover. This is because new leader may
+        // issue extra tokens and revoke them later.
         if (!isNewlyElectedLeader) {
           _log.error("Stop failed to propagate within {}ms for streams: {}. The following hosts failed to claim their token(s): {}",
               _config.getStopPropagationTimeout(), failedStreams, hosts);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -39,6 +39,8 @@ public final class CoordinatorConfig {
   public static final String CONFIG_TASK_STOP_CHECK_TIMEOUT_MS = PREFIX + "taskStopCheckTimeoutMs";
   // how long should the coordinator wait in between two consecutive calls to check if a connector's tasks have stopped
   public static final String CONFIG_TASK_STOP_CHECK_RETRY_PERIOD_MS = PREFIX + "taskStopCheckRetryPeriodMs";
+  // should the coordinator declare a stream stopped if there's no confirmation from at least one follower
+  public static final String CONFIG_FORCE_STOP_STREAMS_ON_FAILURE = PREFIX + "forceStopStreamsOnFailure";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60000;
@@ -65,6 +67,7 @@ public final class CoordinatorConfig {
   private final long _stopPropagationTimeout;
   private final long _taskStopCheckTimeoutMs;
   private final long _taskStopCheckRetryPeriodMs;
+  private final boolean _forceStopStreamsOnFailure;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -95,6 +98,7 @@ public final class CoordinatorConfig {
     _taskStopCheckTimeoutMs = _properties.getLong(CONFIG_TASK_STOP_CHECK_TIMEOUT_MS, DEFAULT_TASK_STOP_CHECK_TIMEOUT_MS);
     _taskStopCheckRetryPeriodMs = _properties.getLong(CONFIG_TASK_STOP_CHECK_RETRY_PERIOD_MS,
         DEFAULT_TASK_STOP_CHECK_RETRY_PERIOD_MS);
+    _forceStopStreamsOnFailure = _properties.getBoolean(CONFIG_FORCE_STOP_STREAMS_ON_FAILURE, false);
   }
 
   public Properties getConfigProperties() {
@@ -171,5 +175,9 @@ public final class CoordinatorConfig {
 
   public long getStopPropagationTimeout() {
     return _stopPropagationTimeout;
+  }
+
+  public boolean getForceStopStreamsOnFailure() {
+    return _forceStopStreamsOnFailure;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -59,12 +59,12 @@ public class CoordinatorEvent {
 
   /**
    * Returns an event that indicates a new assignment needs to be done (this is a leader-specific event).
-   * cleanUpOrphanConnectorTasks should be set to true once when the coordinator becomes leader.
+   * isNewlyElectedLeader should be set to true once when the coordinator becomes leader.
    * If this is set to true, coordinator will check if there are any orphan connector tasks that have no
    * binding with any live instance, and will verify/clean those nodes from zookeeper.
    */
-  public static CoordinatorEvent createLeaderDoAssignmentEvent(boolean cleanUpOrphanConnectorTasks) {
-    return new CoordinatorEvent(EventType.LEADER_DO_ASSIGNMENT, cleanUpOrphanConnectorTasks);
+  public static CoordinatorEvent createLeaderDoAssignmentEvent(boolean isNewlyElectedLeader) {
+    return new CoordinatorEvent(EventType.LEADER_DO_ASSIGNMENT, isNewlyElectedLeader);
   }
 
   /**

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -798,8 +798,12 @@ public class ZkAdapter {
         for (String instance : instances) {
           String assignmentTokenPath = KeyBuilder.datastreamAssignmentTokenForInstance(_cluster,
               stoppingStream.getName(), instance);
-          AssignmentToken token = new AssignmentToken(_instanceName, instance, System.currentTimeMillis());
-          _zkclient.create(assignmentTokenPath, token.toJson(), CreateMode.PERSISTENT);
+          if (_zkclient.exists(assignmentTokenPath)) {
+            LOG.warn("Assignment token already issued for instance {}, stream {}", instance, stoppingStream.getName());
+          } else {
+            AssignmentToken token = new AssignmentToken(_instanceName, instance, System.currentTimeMillis());
+            _zkclient.create(assignmentTokenPath, token.toJson(), CreateMode.PERSISTENT);
+          }
         }
       }
     }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
@@ -59,4 +59,14 @@ public class TestCoordinatorConfig {
     Assert.assertEquals(CoordinatorConfig.DEFAULT_TASK_STOP_CHECK_RETRY_PERIOD_MS, config.getTaskStopCheckRetryPeriodMs());
     Assert.assertEquals(CoordinatorConfig.DEFAULT_TASK_STOP_CHECK_TIMEOUT_MS, config.getTaskStopCheckTimeoutMs());
   }
+
+  @Test
+  public void testForceStopStreamsOnFailureConfig() {
+    Properties props = new Properties();
+    CoordinatorConfig config = createCoordinatorConfig(props);
+    Assert.assertFalse(config.getForceStopStreamsOnFailure());
+    props.put(CoordinatorConfig.CONFIG_FORCE_STOP_STREAMS_ON_FAILURE, "true");
+    config = createCoordinatorConfig(props);
+    Assert.assertTrue(config.getForceStopStreamsOnFailure());
+  }
 }


### PR DESCRIPTION
This pull request is part of a series of changes that are meant to improve BMM Restart and make it easier to debug restart failures and trace them to the faulty hosts. Part 4 handles edge cases such as leader failover. It also introduces the following improvements suggested in the previous parts:

- A metric for the number of datastreams that are inferred as stopping has been added to help debug the feature (@vmaheshw's suggestion)
- Timeout for the rest.li request handler node waiting on the leader to mark the datastream as STOPPED has been increased from 60 seconds to 90 seconds. This is done to make sure the leader will have time to handle stop propagation (which has a 60 second timeout of its own). (@shrinandthakkar's suggestion)

The PRs in this series deal with the following aspects:
Part 1 – Introduction of assignment tokens and support for issuing tokens by the leader coordinator (https://github.com/linkedin/brooklin/pull/919)
Part 2 – Changes to the followers' handleAssignmentChange to make them claim the tokens issued by the leader. (https://github.com/linkedin/brooklin/pull/921)
Part 3 – Changes to the leader to make it poll the ZooKeeper and wait for the assignment change (stop) to be propagated and executed by the cluster. ((https://github.com/linkedin/brooklin/pull/922)
**Part 4 – Edge cases and cleanup and general improvements**