### PR TITLE
Moved the datastream stop check poll to a separate thread to avoid blocking the event queue

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -3491,9 +3491,10 @@ public class TestCoordinator {
         new SourceBasedDeduper(), null);
     Datastream testStream = DatastreamTestUtils.
         createAndStoreDatastreams(zkClient, testCluster, connectorName, streamName)[0];
-    testStream.setStatus(DatastreamStatus.STOPPING);
     coordinator.start();
     ZkAdapter zkAdapter = coordinator.getZkAdapter();
+    testStream.setStatus(DatastreamStatus.STOPPING);
+    zkAdapter.updateDatastream(testStream);
     DatastreamGroup datastreamGroup = new DatastreamGroup(Collections.singletonList(testStream));
 
     // Store an assignment token

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -266,10 +266,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _adapter.connect(_config.getReinitOnNewZkSession());
 
     // Initializing executor services
-    _tokenClaimExecutor = Executors.newSingleThreadExecutor(
-        new ThreadFactoryBuilder().setNameFormat("CoordinatorTokenClaimExecutor-%d").build());
     _scheduledExecutor = Executors.newSingleThreadScheduledExecutor(
         new ThreadFactoryBuilder().setNameFormat("CoordinatorScheduledExecutor-%d").build());
+    // TODO Assess whether having a single threaded executor for token claim tasks is sufficient or it will be exhausted
+    _tokenClaimExecutor = Executors.newSingleThreadExecutor(
+        new ThreadFactoryBuilder().setNameFormat("CoordinatorTokenClaimExecutor-%d").build());
 
     for (String connectorType : _connectors.keySet()) {
       ConnectorInfo connectorInfo = _connectors.get(connectorType);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1372,12 +1372,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
   }
 
-  void scheduleLeaderDoAssignmentRetry(boolean cleanUpOrphanNodes) {
+  private void scheduleLeaderDoAssignmentRetry(boolean isNewlyElectedLeader) {
     _log.info("Schedule retry for leader assigning tasks");
     _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.HANDLE_LEADER_DO_ASSIGNMENT_NUM_RETRIES, 1);
     _leaderDoAssignmentScheduled.set(true);
     _leaderDoAssignmentScheduledFuture = _scheduledExecutor.schedule(() -> {
-      _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(cleanUpOrphanNodes));
+      _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(isNewlyElectedLeader));
       _leaderDoAssignmentScheduled.set(false);
     }, _config.getRetryIntervalMs(), TimeUnit.MILLISECONDS);
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -34,18 +34,25 @@ public final class CoordinatorConfig {
   public static final String CONFIG_ENABLE_ASSIGNMENT_TOKENS = PREFIX + "enableAssignmentTokens";
 
   // how long should the leader poll the zookeeper to confirm that stopping datastreams have stopped before giving up
-  public static final String CONFIG_STOP_PROPAGATION_TIMEOUT_MS = PREFIX + "stopPropagationTimeout";
+  public static final String CONFIG_STOP_PROPAGATION_TIMEOUT_MS = PREFIX + "stopPropagationTimeoutMs";
   // how long should the coordinator wait for a connector's tasks to stop before giving up
   public static final String CONFIG_TASK_STOP_CHECK_TIMEOUT_MS = PREFIX + "taskStopCheckTimeoutMs";
   // how long should the coordinator wait in between two consecutive calls to check if a connector's tasks have stopped
   public static final String CONFIG_TASK_STOP_CHECK_RETRY_PERIOD_MS = PREFIX + "taskStopCheckRetryPeriodMs";
   // should the coordinator declare a stream stopped if there's no confirmation from at least one follower
   public static final String CONFIG_FORCE_STOP_STREAMS_ON_FAILURE = PREFIX + "forceStopStreamsOnFailure";
+  // how long should the coordinator attempt to mark stopping datastreams stopped before giving up
+  public static final String CONFIG_MARK_DATASTREAMS_STOPPED_TIMEOUT_MS = PREFIX + "markDatastreamsStoppedTimeoutMs";
+  // how long should the coordinator wait between attempts to mark stopping datastreams stopped
+  public static final String CONFIG_MARK_DATASTREAMS_STOPPED_RETRY_PERIOD_MS = PREFIX + "markDatastreamsStoppedRetryPeriodMs";
+
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
-  public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60000;
+  public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
   public static final long DEFAULT_TASK_STOP_CHECK_TIMEOUT_MS = 60 * 1000;
   public static final long DEFAULT_TASK_STOP_CHECK_RETRY_PERIOD_MS = 10 * 1000;
+  public static final int DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS = 60 * 1000;
+  public static final int DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS = 10 * 1000;
 
   private final String _cluster;
   private final String _zkAddress;
@@ -64,10 +71,12 @@ public final class CoordinatorConfig {
   private final boolean _reinitOnNewZkSession;
   private final int _maxAssignmentRetryCount;
   private final boolean _enableAssignmentTokens;
-  private final long _stopPropagationTimeout;
+  private final long _stopPropagationTimeoutMs;
   private final long _taskStopCheckTimeoutMs;
   private final long _taskStopCheckRetryPeriodMs;
   private final boolean _forceStopStreamsOnFailure;
+  private final long _markDatastreamsStoppedTimeoutMs;
+  private final long _markDatastreamsStoppedRetryPeriodMs;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -94,11 +103,16 @@ public final class CoordinatorConfig {
     _reinitOnNewZkSession = _properties.getBoolean(CONFIG_REINIT_ON_NEW_ZK_SESSION, false);
     _maxAssignmentRetryCount = _properties.getInt(CONFIG_MAX_ASSIGNMENT_RETRY_COUNT, DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT);
     _enableAssignmentTokens = _properties.getBoolean(CONFIG_ENABLE_ASSIGNMENT_TOKENS, false);
-    _stopPropagationTimeout = _properties.getLong(CONFIG_STOP_PROPAGATION_TIMEOUT_MS, DEFAULT_STOP_PROPAGATION_TIMEOUT_MS);
+    _stopPropagationTimeoutMs = _properties.getLong(CONFIG_STOP_PROPAGATION_TIMEOUT_MS, DEFAULT_STOP_PROPAGATION_TIMEOUT_MS);
     _taskStopCheckTimeoutMs = _properties.getLong(CONFIG_TASK_STOP_CHECK_TIMEOUT_MS, DEFAULT_TASK_STOP_CHECK_TIMEOUT_MS);
     _taskStopCheckRetryPeriodMs = _properties.getLong(CONFIG_TASK_STOP_CHECK_RETRY_PERIOD_MS,
         DEFAULT_TASK_STOP_CHECK_RETRY_PERIOD_MS);
     _forceStopStreamsOnFailure = _properties.getBoolean(CONFIG_FORCE_STOP_STREAMS_ON_FAILURE, false);
+    _markDatastreamsStoppedTimeoutMs = _properties.getLong(CONFIG_MARK_DATASTREAMS_STOPPED_TIMEOUT_MS,
+        DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS);
+    _markDatastreamsStoppedRetryPeriodMs = _properties.getLong(CONFIG_MARK_DATASTREAMS_STOPPED_RETRY_PERIOD_MS,
+        DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS);
+
   }
 
   public Properties getConfigProperties() {
@@ -161,6 +175,8 @@ public final class CoordinatorConfig {
     return _maxAssignmentRetryCount;
   }
 
+  // Configuration properties for Assignment Tokens Feature
+
   public boolean getEnableAssignmentTokens() {
     return _enableAssignmentTokens;
   }
@@ -173,11 +189,19 @@ public final class CoordinatorConfig {
     return _taskStopCheckRetryPeriodMs;
   }
 
-  public long getStopPropagationTimeout() {
-    return _stopPropagationTimeout;
+  public long getStopPropagationTimeoutMs() {
+    return _stopPropagationTimeoutMs;
   }
 
   public boolean getForceStopStreamsOnFailure() {
     return _forceStopStreamsOnFailure;
+  }
+
+  public long getMarkDatastreamsStoppedTimeoutMs() {
+    return _markDatastreamsStoppedTimeoutMs;
+  }
+
+  public long getMarkDatastreamsStoppedRetryPeriodMs() {
+    return _markDatastreamsStoppedRetryPeriodMs;
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
@@ -44,12 +44,12 @@ public class TestCoordinatorConfig {
   public void testStopPropagationTimeoutConfig() {
     Properties props = new Properties();
     CoordinatorConfig config = createCoordinatorConfig(props);
-    Assert.assertEquals(CoordinatorConfig.DEFAULT_STOP_PROPAGATION_TIMEOUT_MS, config.getStopPropagationTimeout());
+    Assert.assertEquals(CoordinatorConfig.DEFAULT_STOP_PROPAGATION_TIMEOUT_MS, config.getStopPropagationTimeoutMs());
 
     String stopPropagationTimeoutValue = "1000";
     props.put(CoordinatorConfig.CONFIG_STOP_PROPAGATION_TIMEOUT_MS, stopPropagationTimeoutValue);
     CoordinatorConfig config2 = createCoordinatorConfig(props);
-    Assert.assertEquals(config2.getStopPropagationTimeout(), 1000);
+    Assert.assertEquals(config2.getStopPropagationTimeoutMs(), 1000);
   }
 
   @Test


### PR DESCRIPTION
- After issuing a stop stream assignment, the leader polls the zookeeper to confirm that tasks have stopped. Currently that poll happens in the main event thread. 
- There is also a requirement that the coordinator should process all of its events in less than 30 seconds. If this requirement is not met the coordinator won't be able to punch heartbeats.
- If the coordinator is configured to wait for stop propagation for a prolonged time, it will block the event queue for more than 30 seconds.

This change fixes the problem by moving the task to wait for stop request to propagate to a separate thread.