### PR TITLE
BMM Restart Improvements: Bug fixes and logging improvements

### DIFF
--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -445,7 +445,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
     String datastreamName = pathKeys.getAsString(KEY_NAME);
     Datastream datastream = _store.getDatastream(datastreamName);
 
-    LOG.info("Received request to stop datastream {}", datastream);
+    LOG.info("Received request to stop datastream {}, force: {}", datastream, force);
 
     if (datastream == null) {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_404_NOT_FOUND,

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -3136,7 +3136,7 @@ public class TestCoordinator {
     // Wait for the leader to clean tokens
     PollUtils.poll(() -> spyZkAdapter2.getNumUnclaimedTokensForDatastreams(
         Collections.singletonList(datastreamGroup)) == 0, 100, 1000);
-    verify(spyZkAdapter2, atLeast(1)).claimAssignmentTokensForDatastreams(any(), any());
+    verify(spyZkAdapter2, atLeast(1)).claimAssignmentTokensForDatastreams(any(), any(), anyBoolean());
     // Verify that the new leader didn't emit a metric for unclaimed tokens
     long numFailedStopsAfter = numFailedStopsMeter.getCount();
     long countEmitted = numFailedStopsAfter - numFailedStopsBefore;
@@ -3297,11 +3297,11 @@ public class TestCoordinator {
     // (2) For eggBagelStream, since the bagel connector has no tasks in the new assignment (connector stopped case)
     CollectionContainsMatcher<Datastream> deepDishStreamMatcher = new CollectionContainsMatcher<>(pizzaStreams[1]);
     CollectionContainsMatcher<Datastream> eggBagelStreamMatcher = new CollectionContainsMatcher<>(bagelStreams[0]);
-    verify(spyZkAdapter, times(2)).claimAssignmentTokensForDatastreams(any(), any());
+    verify(spyZkAdapter, times(2)).claimAssignmentTokensForDatastreams(any(), any(), anyBoolean());
     verify(spyZkAdapter, times(1)).
-        claimAssignmentTokensForDatastreams(argThat(deepDishStreamMatcher), any());
+        claimAssignmentTokensForDatastreams(argThat(deepDishStreamMatcher), any(), anyBoolean());
     verify(spyZkAdapter, times(1)).
-        claimAssignmentTokensForDatastreams(argThat(eggBagelStreamMatcher), any());
+        claimAssignmentTokensForDatastreams(argThat(eggBagelStreamMatcher), any(), anyBoolean());
 
     zkClient.close();
     coordinator.stop();
@@ -3348,7 +3348,7 @@ public class TestCoordinator {
     // (1) Active tasks are queried from the connector at least once
     // (2) No tokens are claimed for the stream since the task never stops
     verify(mockConnector, Mockito.atLeast(1)).getActiveTasks();
-    verify(spyZkAdapter, times(0)).claimAssignmentTokensForDatastreams(any(), any());
+    verify(spyZkAdapter, times(0)).claimAssignmentTokensForDatastreams(any(), any(), anyBoolean());
   }
 
   @Test

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -855,10 +855,10 @@ public class ZkAdapter {
       String streamName = stream.getName();
       String tokenPath = KeyBuilder.datastreamAssignmentTokenForInstance(_cluster, streamName, instance);
       if (_zkclient.exists(tokenPath)) {
-        if (!revoke) {
-          LOG.info("Claiming assignment token for datastream: {}", streamName);
-        } else {
+        if (revoke) {
           LOG.info("Revoking assignment token for datastream: {}, instance: {}", streamName, instance);
+        } else {
+          LOG.info("Claiming assignment token for datastream: {}", streamName);
         }
         try {
           _zkclient.delete(tokenPath);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -793,7 +793,7 @@ public class ZkAdapter {
         String assignmentTokensPath = KeyBuilder.datastreamAssignmentTokens(_cluster, stoppingStream.getName());
         _zkclient.ensurePath(assignmentTokensPath);
 
-        Set<String> instances = stoppingDgInstances.get(stoppingGroup);
+        Set<String> instances = stoppingDgInstances.getOrDefault(stoppingGroup, Collections.emptySet());
         LOG.info("Issuing assignment tokens for stream {} and {} instance(s)", stoppingStream.getName(), instances.size());
         for (String instance : instances) {
           String assignmentTokenPath = KeyBuilder.datastreamAssignmentTokenForInstance(_cluster,
@@ -850,12 +850,12 @@ public class ZkAdapter {
    * @param datastreams List of datastreams for which tokens are to be claimed
    * @param instance Instance name
    */
-  public void claimAssignmentTokensForDatastreams(List<Datastream> datastreams, String instance) {
+  public void claimAssignmentTokensForDatastreams(List<Datastream> datastreams, String instance, boolean revoke) {
     for (Datastream stream : datastreams) {
       String streamName = stream.getName();
       String tokenPath = KeyBuilder.datastreamAssignmentTokenForInstance(_cluster, streamName, instance);
       if (_zkclient.exists(tokenPath)) {
-        if (instance.equals(_instanceName)) {
+        if (!revoke) {
           LOG.info("Claiming assignment token for datastream: {}", streamName);
         } else {
           LOG.info("Revoking assignment token for datastream: {}, instance: {}", streamName, instance);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -1141,7 +1141,7 @@ public class TestZkAdapter {
     task1.setTaskPrefix(mayoDatastreamGroup.getTaskPrefix());
     task1.setConnectorType(connectorType);
 
-    adapter.claimAssignmentTokensForDatastreams(Collections.singletonList(ketchupStream), adapter.getInstanceName());
+    adapter.claimAssignmentTokensForDatastreams(Collections.singletonList(ketchupStream), adapter.getInstanceName(), false);
 
     // Asserting that ZkAdapter claimed token for the given instance, and given instance only
     List<String> nodes = zkClient.getChildren(

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.2.0-SNAPSHOT"
+  version = "5.2.7"
 }
 
 subprojects {

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.2.7"
+  version = "5.2.7-SNAPSHOT"
 }
 
 subprojects {


### PR DESCRIPTION
This pull request addresses bugs and makes logging improvements in Assignment Tokens Feature (#919 #921 #922 #924)

* Addressed a bug where a stream with no tasks causes the assignment handler to fail.
* Addressed a bug where for tokens assigned to itself, the leader would print "Claiming token" instead of "Revoking token".
* Addressed a bug which was causing a failure in followers' code for inferring stopping streams.
* Added additional log messages for debugging.
