### PR TITLE
Handling Metrics and SLA Reporting for Throughput Violating Topics Part 1

### DIFF
--- a/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
+++ b/datastream-common/src/main/idl/com.linkedin.datastream.server.dms.datastream.restspec.json
@@ -77,6 +77,14 @@
           "doc" : "StringMap of format &lt;source, comma separated list of partitions or \"*\"&gt;.\n                         <pre>Example: <\"FooTopic\", \"0,13,2\"> or <\"FooTopic\",\"*\"></pre>"
         } ]
       }, {
+        "name" : "reportThroughputViolatingTopics",
+        "doc" : "This endpoint handles the management of throughput violating topics. These topics' metrics and\n SLAs are reported separately as their throughput are not within brooklin's permissible bounds.",
+        "parameters" : [ {
+          "name" : "throughputViolations",
+          "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
+          "doc" : "StringArray of list of topics"
+        } ]
+      }, {
         "name" : "resume",
         "doc" : "Resume a datastream\nService Returns: Result HTTP status",
         "parameters" : [ {

--- a/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
+++ b/datastream-common/src/main/snapshot/com.linkedin.datastream.server.dms.datastream.snapshot.json
@@ -164,6 +164,14 @@
             "doc" : "StringMap of format &lt;source, comma separated list of partitions or \"*\"&gt;.\n                         <pre>Example: <\"FooTopic\", \"0,13,2\"> or <\"FooTopic\",\"*\"></pre>"
           } ]
         }, {
+          "name" : "reportThroughputViolatingTopics",
+          "doc" : "This endpoint handles the management of throughput violating topics. These topics' metrics and\n SLAs are reported separately as their throughput are not within brooklin's permissible bounds.",
+          "parameters" : [ {
+            "name" : "throughputViolations",
+            "type" : "{ \"type\" : \"array\", \"items\" : \"string\" }",
+            "doc" : "StringArray of list of topics"
+          } ]
+        }, {
           "name" : "resume",
           "doc" : "Resume a datastream\nService Returns: Result HTTP status",
           "parameters" : [ {

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamStore.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.datastream.server.dms;
 
+import java.util.Set;
 import java.util.stream.Stream;
 
 import com.linkedin.datastream.common.Datastream;
@@ -72,4 +73,19 @@ public interface DatastreamStore {
    * @param key Name of the datastream whose assignment tokens have to be deleted
    */
   void forceCleanupDatastream(String key);
+
+  /**
+   * Creates or Updates the datastream entry in the persistent store with the latest list of violating topics.
+   * @param key Name of the datastream whose topics have to be handled.
+   * @param throughputViolatingTopics topics, of which at least one partition violates the brooklin's permissible
+   *                                 throughput thresholds.
+   */
+  void createOrUpdateThroughputViolatingDatastreamEntry(String key, Set<String> throughputViolatingTopics) throws DatastreamException;
+
+  /**
+   * Deletes the datastream entry in the persistent store when none of the topics for the datastream
+   * are violating brooklin permissible throughput thresholds.
+   * @param key Name of the datastream whose entry has to be deleted.
+   */
+  void deleteThroughputViolatingDatastreamEntry(String key);
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -45,7 +45,7 @@ public final class CoordinatorConfig {
   public static final String CONFIG_MARK_DATASTREAMS_STOPPED_TIMEOUT_MS = PREFIX + "markDatastreamsStoppedTimeoutMs";
   // how long should the coordinator wait between attempts to mark stopping datastreams stopped
   public static final String CONFIG_MARK_DATASTREAMS_STOPPED_RETRY_PERIOD_MS = PREFIX + "markDatastreamsStoppedRetryPeriodMs";
-
+  public static final String CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING = PREFIX + "enableThroughputViolatingTopicsHandling";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
@@ -77,6 +77,7 @@ public final class CoordinatorConfig {
   private final boolean _forceStopStreamsOnFailure;
   private final long _markDatastreamsStoppedTimeoutMs;
   private final long _markDatastreamsStoppedRetryPeriodMs;
+  private final boolean _enableThroughputViolatingTopicsHandling;
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -112,7 +113,8 @@ public final class CoordinatorConfig {
         DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS);
     _markDatastreamsStoppedRetryPeriodMs = _properties.getLong(CONFIG_MARK_DATASTREAMS_STOPPED_RETRY_PERIOD_MS,
         DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS);
-
+    _enableThroughputViolatingTopicsHandling = _properties.getBoolean(
+        CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, false);
   }
 
   public Properties getConfigProperties() {
@@ -173,6 +175,10 @@ public final class CoordinatorConfig {
 
   public int getMaxAssignmentRetryCount() {
     return _maxAssignmentRetryCount;
+  }
+
+  public boolean getEnableThroughputViolatingTopicsHandling() {
+    return _enableThroughputViolatingTopicsHandling;
   }
 
   // Configuration properties for Assignment Tokens Feature

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -101,6 +101,15 @@ public final class KeyBuilder {
   private static final String DATASTREAM_NUMTASKS = DATASTREAM + "/" + NUM_TASKS;
 
   /**
+   * throughput violating datastreams
+   */
+  private static final String THROUGHPUT_VIOLATIONS = "/%s/throughputViolations";
+
+  /**
+   * throughput violating topics stored for each datastream
+   */
+  private static final String THROUGHPUT_VIOLATIONS_PER_DATASTREAM = "/%s/throughputViolations/%s";
+  /**
    * Get the root level ZooKeeper znode of a Brooklin cluster
    * @param clusterName Brooklin cluster name
    */
@@ -372,5 +381,23 @@ public final class KeyBuilder {
    */
   public static String getTargetAssignmentBase(String cluster, String connectorType) {
     return String.format(TARGET_ASSIGNMENT_BASE, cluster, connectorType).replaceAll("//", "/'");
+  }
+
+  /**
+   * Get all the throughput violating datastreams
+   * @param cluster Brooklin cluster name
+   * @return throughput violating datastreams
+   */
+  public static String throughputViolations(String cluster) {
+    return String.format(THROUGHPUT_VIOLATIONS, cluster);
+  }
+
+  /**
+   * Get all the throughput violating topics per datastream
+   * @param cluster Brooklin cluster name
+   * @return throughput violating topics per datastream
+   */
+  public static String throughputViolationsPerDatastream(String cluster, String datastream) {
+    return String.format(THROUGHPUT_VIOLATIONS_PER_DATASTREAM, cluster, datastream);
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -8,6 +8,7 @@ package com.linkedin.datastream.server;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -71,7 +72,7 @@ public class TestEventProducer {
     };
 
     EventProducer eventProducer = new EventProducer(task, transport,
-        new NoOpCheckpointProvider(), new Properties(), false);
+        new NoOpCheckpointProvider(), new Properties(), false, (t) -> new HashSet<>());
 
     int eventCount = 5;
     for (int i = 0; i < eventCount; i++) {
@@ -122,7 +123,7 @@ public class TestEventProducer {
     };
 
     EventProducer eventProducer = new EventProducer(task, transport,
-        new NoOpCheckpointProvider(), new Properties(), false);
+        new NoOpCheckpointProvider(), new Properties(), false, (t) -> new HashSet<>());
 
     int eventCount = 5;
     for (int i = 0; i < eventCount; i++) {
@@ -142,7 +143,8 @@ public class TestEventProducer {
 
     Properties props = new Properties();
     props.put(EventProducer.CONFIG_ENABLE_PER_TOPIC_METRICS, Boolean.FALSE.toString());
-    EventProducer eventProducer = new EventProducer(task, transport, new NoOpCheckpointProvider(), props, false);
+    EventProducer eventProducer =
+        new EventProducer(task, transport, new NoOpCheckpointProvider(), props, false, (t) -> new HashSet<>());
 
     eventProducer.send(createDatastreamProducerRecord(), (m, e) -> {
     });


### PR DESCRIPTION
The EventProducer of every DatastreamTask reports SLA and latency metrics for every datastream record. But when topics (at least one partition) have higher throughput than the thresholds, it introduces latency and SLA misses in the mirroring pipeline.

This pull request is the first part of changes to handle the metrics and SLA reporting of throughput-violating topics. It introduces the following changes:

1. A newer API endpoint shall simultaneously accept a datastream and a list of throughput-violating topics. The ZkAdapter would persist this information in the DatastreamStore.
2. The violations would be persisted in a newer path within the DatastreamStore under **_/violations/\<datastream\>/_**. Every child under this path is a datastream entry (with the topics stored as data for every entry). All the server hosts would be watching this path for child changes (handler added in ZkAdapter).
3. A new callback for the eventProducer to fetch the latest list of offending topics from the ZkAdapter. We ensure that the correct set of topics is excluded from reporting the metrics and SLAs for every record.

***
Part 2 of this series would take care of:
1. Excluding the reporting of metrics for these throughput-violating topics within EventProducer.
2. Introducing separate metrics for throughput-violating topics.

***
Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
