### PR TITLE
Handling Metrics and SLA Reporting for Throughput Violating Topics via Datastream Update API Part 1

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -130,4 +130,10 @@ public class DatastreamMetadataConstants {
    * Datastream metadata that represents number of tasks
    */
   public static final String NUM_TASKS = "numTasks";
+
+  /**
+   * Datastream metadata that represents the throughput violating topics. The topics; of
+   * which at least one partition violates the brooklin's permissible throughput bounds.
+   */
+  public static final String THROUGHPUT_VIOLATING_TOPICS = "throughputViolatingTopics";
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -46,6 +46,7 @@ public final class CoordinatorConfig {
   // how long should the coordinator wait between attempts to mark stopping datastreams stopped
   public static final String CONFIG_MARK_DATASTREAMS_STOPPED_RETRY_PERIOD_MS = PREFIX + "markDatastreamsStoppedRetryPeriodMs";
 
+  public static final String CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING = PREFIX + "enableThroughputViolatingTopicsHandling";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
@@ -77,6 +78,8 @@ public final class CoordinatorConfig {
   private final boolean _forceStopStreamsOnFailure;
   private final long _markDatastreamsStoppedTimeoutMs;
   private final long _markDatastreamsStoppedRetryPeriodMs;
+  private final boolean _enableThroughputViolatingTopicsHandling;
+
 
   /**
    * Construct an instance of CoordinatorConfig
@@ -112,7 +115,8 @@ public final class CoordinatorConfig {
         DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS);
     _markDatastreamsStoppedRetryPeriodMs = _properties.getLong(CONFIG_MARK_DATASTREAMS_STOPPED_RETRY_PERIOD_MS,
         DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS);
-
+    _enableThroughputViolatingTopicsHandling = _properties.getBoolean(
+        CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, false);
   }
 
   public Properties getConfigProperties() {
@@ -173,6 +177,10 @@ public final class CoordinatorConfig {
 
   public int getMaxAssignmentRetryCount() {
     return _maxAssignmentRetryCount;
+  }
+
+  public boolean getEnableThroughputViolatingTopicsHandling() {
+    return _enableThroughputViolatingTopicsHandling;
   }
 
   // Configuration properties for Assignment Tokens Feature

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -14,8 +14,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.kafka.common.TopicPartition;
@@ -105,6 +107,7 @@ public class EventProducer implements DatastreamEventProducer {
   private final boolean _enablePerTopicMetrics;
   private final boolean _enablePerTopicEventLatencyMetrics;
   private final Duration _flushInterval;
+  private final Function<DatastreamTask, Set<String>> _throughputViolatingTopicsProvider;
 
   private Instant _lastFlushTime = Instant.now();
   private long _lastEventsOutsideAltSlaLogTimeMs = System.currentTimeMillis();
@@ -120,7 +123,8 @@ public class EventProducer implements DatastreamEventProducer {
    *                            provided checkpointing.
    */
   public EventProducer(DatastreamTask task, TransportProvider transportProvider, CheckpointProvider checkpointProvider,
-      Properties config, boolean customCheckpointing) {
+      Properties config, boolean customCheckpointing,
+      Function<DatastreamTask, Set<String>> throughputViolatingTopicsProvider) {
     Validate.notNull(transportProvider, "null transport provider");
     Validate.notNull(checkpointProvider, "null checkpoint provider");
     Validate.notNull(config, "null config");
@@ -129,6 +133,7 @@ public class EventProducer implements DatastreamEventProducer {
     _transportProvider = transportProvider;
     _producerId = PRODUCER_ID_SEED.getAndIncrement();
     _logger = LoggerFactory.getLogger(String.format("%s:%d", MODULE, _producerId));
+    _throughputViolatingTopicsProvider = throughputViolatingTopicsProvider;
 
     if (customCheckpointing) {
       _checkpointProvider = new NoOpCheckpointProvider();
@@ -342,6 +347,11 @@ public class EventProducer implements DatastreamEventProducer {
   private void reportMetrics(DatastreamRecordMetadata metadata, long eventsSourceTimestamp, long eventsSendTimestamp) {
     // If per-topic metrics are enabled, use topic as key for metrics; else, use datastream name as the key
     String datastreamName = getDatastreamName();
+
+    if (_throughputViolatingTopicsProvider.apply(_datastreamTask).contains(metadata.getTopic())) {
+      // TODO (Shrinand): Handle metrics reporting for throughput violating topics.
+    }
+
     String topicOrDatastreamName = _enablePerTopicMetrics ? metadata.getTopic() : datastreamName;
     // Treat all events within this record equally (assume same timestamp)
     if (eventsSourceTimestamp > 0) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -8,6 +8,7 @@ package com.linkedin.datastream.server;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -71,7 +72,7 @@ public class TestEventProducer {
     };
 
     EventProducer eventProducer = new EventProducer(task, transport,
-        new NoOpCheckpointProvider(), new Properties(), false);
+        new NoOpCheckpointProvider(), new Properties(), false, (t) -> new HashSet<>());
 
     int eventCount = 5;
     for (int i = 0; i < eventCount; i++) {
@@ -122,7 +123,7 @@ public class TestEventProducer {
     };
 
     EventProducer eventProducer = new EventProducer(task, transport,
-        new NoOpCheckpointProvider(), new Properties(), false);
+        new NoOpCheckpointProvider(), new Properties(), false, (t) -> new HashSet<>());
 
     int eventCount = 5;
     for (int i = 0; i < eventCount; i++) {
@@ -142,7 +143,8 @@ public class TestEventProducer {
 
     Properties props = new Properties();
     props.put(EventProducer.CONFIG_ENABLE_PER_TOPIC_METRICS, Boolean.FALSE.toString());
-    EventProducer eventProducer = new EventProducer(task, transport, new NoOpCheckpointProvider(), props, false);
+    EventProducer eventProducer =
+        new EventProducer(task, transport, new NoOpCheckpointProvider(), props, false, (t) -> new HashSet<>());
 
     eventProducer.send(createDatastreamProducerRecord(), (m, e) -> {
     });

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/zk/ZkClient.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.datastream.common.zk;
 
+import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Random;
@@ -31,6 +32,7 @@ public class ZkClient extends org.apache.helix.zookeeper.impl.client.ZkClient {
   public static final int DEFAULT_CONNECTION_TIMEOUT = 60 * 1000;
   public static final int DEFAULT_SESSION_TIMEOUT = 30 * 1000;
   public static final int DEFAULT_OPERATION_RETRY_TIMEOUT = -1;
+  public static final Charset ZK_STRING_SERIALIZER_CHARSET = StandardCharsets.UTF_8;
 
   private static final Logger LOG = LoggerFactory.getLogger(ZkClient.class);
 
@@ -218,7 +220,7 @@ public class ZkClient extends org.apache.helix.zookeeper.impl.client.ZkClient {
     @Override
     public byte[] serialize(Object data) throws ZkMarshallingError {
       byte[] ret = null;
-      ret = ((String) data).getBytes(StandardCharsets.UTF_8);
+      ret = ((String) data).getBytes(ZK_STRING_SERIALIZER_CHARSET);
       return ret;
     }
 
@@ -226,7 +228,7 @@ public class ZkClient extends org.apache.helix.zookeeper.impl.client.ZkClient {
     public Object deserialize(byte[] bytes) throws ZkMarshallingError {
       String data = null;
       if (bytes != null) {
-        data = new String(bytes, StandardCharsets.UTF_8);
+        data = new String(bytes, ZK_STRING_SERIALIZER_CHARSET);
       }
       return data;
     }


### PR DESCRIPTION
The EventProducer of every DatastreamTask reports SLA and latency metrics for every datastream record. But when topics (at least one partition) have higher throughput than the thresholds, it introduces latency and SLA misses in the mirroring pipeline.

This pull request is the first part of changes to handle the metrics and SLA reporting of throughput-violating topics via the datastream update API. It introduces the following changes:

1. The datastream update endpoint shall simultaneously accept a datastream and a list of throughput-violating topics via its datastream metadata. The ZkAdapter would persist this information in the DatastreamStore.
2. The update API touches every server host in its normal code path, and in that code path, every host (Coordinator) maintains a shared cache (Datastream -> Violating Topics Map) with the latest violations for every datastream.
3. A new callback for the eventProducer to fetch the latest list of offending topics from the Coordinator. We ensure that the correct set of topics is excluded from reporting the metrics and SLAs for every record.

***
Part 2 of this series would take care of:
1. Excluding the reporting of metrics for these throughput-violating topics within EventProducer.
2. Introducing separate metrics for throughput-violating topics.

***


Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
