### PR TITLE
Separated Metrics Handling for Throughput Violating Topics

### DIFF
--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -306,6 +306,9 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           datastreamMap.get(key)
               .getMetadata()
               .put(DatastreamMetadataConstants.THROUGHPUT_VIOLATING_TOPICS, StringUtils.EMPTY);
+          LOG.info(
+              "Feature handling throughput violations disabled. Flushed throughput violating topics for datastream {}",
+              datastreamMap.get(key).getName());
         }
       }
     }
@@ -926,6 +929,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
         if (Objects.requireNonNull(datastream.getMetadata())
             .containsKey(DatastreamMetadataConstants.THROUGHPUT_VIOLATING_TOPICS)) {
           datastream.getMetadata().put(DatastreamMetadataConstants.THROUGHPUT_VIOLATING_TOPICS, StringUtils.EMPTY);
+          LOG.info("Feature handling throughput violations disabled. Flushed throughput violating topics for datastream {}",
+              datastream.getName());
         }
       }
 


### PR DESCRIPTION
The EventProducer of every DatastreamTask reports SLA and latency metrics for every datastream record. But when topics (at least one partition) have higher throughput than the brooklin permissible thresholds, it introduces latency and SLA misses in the mirroring pipeline.

This pull request is the second part of changes to handle the metrics and reporting of throughput-violating topics separately. It introduces the following changes:
1. Separately reporting latency and SLA metrics for these throughput-violating topics within EventProducer.
2. Added per datastream gauge to get insights on the frequency of these throughput violations.

***
Handling Metrics and SLA Reporting for Throughput Violating Topics via Datastream Update API (Part 1 of this work) is merged and [can be referenced here](https://github.com/linkedin/brooklin/pull/928).

