### PR TITLE
Added Support and Handling For Generic Headers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,6 @@ project(':datastream-common') {
     compile "com.linkedin.pegasus:restli-server:$pegasusVersion"
     compile "com.intellij:annotations:$intellijAnnotationsVersion"
     compile "com.google.guava:guava:$guavaVersion"
-    compile "com.linkedin.kafka:kafka-clients:$kafkaVersion"
     compile "com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion"
     compile "com.fasterxml.jackson.core:jackson-core:$jacksonVersion"
     compile "com.fasterxml.jackson.core:jackson-databind:$jacksonVersion"
@@ -172,6 +171,7 @@ project(':datastream-server-api') {
 project(':datastream-utils') {
   dependencies {
     compile project(':datastream-common')
+    compile "com.linkedin.kafka:kafka-clients:$kafkaVersion"
     compile "org.apache.helix:zookeeper-api:$helixZkclientVersion"
     compile "com.linkedin.zookeeper:zookeeper:$zookeeperVersion"
     compile "com.google.guava:guava:$guavaVersion"

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -11,7 +11,6 @@ import java.util.Optional;
 
 import org.apache.avro.reflect.Nullable;
 import org.apache.commons.lang.Validate;
-import org.apache.kafka.common.header.Headers;
 
 
 /**
@@ -30,7 +29,7 @@ public class BrooklinEnvelope {
 
   private Map<String, String> _metadata;
 
-  private Headers _headers;
+  private Object _headers;
 
   /**
    * Construct a BrooklinEnvelope using record key, value, and metadata
@@ -59,11 +58,11 @@ public class BrooklinEnvelope {
    * @param key The record key (e.g. primary key)
    * @param value The new record value
    * @param previousValue The old record value
-   * @param headers Kafka headers to associate with the change event
+   * @param headers Generic headers to associate with the event
    * @param metadata Additional metadata to associate with the change event
    */
   public BrooklinEnvelope(@Nullable Object key, @Nullable Object value, @Nullable Object previousValue,
-      @Nullable Headers headers, Map<String, String> metadata) {
+      @Nullable Object headers, Map<String, String> metadata) {
     Validate.notNull(metadata, "metadata cannot be null");
     setKey(key);
     setValue(value);
@@ -95,14 +94,14 @@ public class BrooklinEnvelope {
   /**
    * Get the Kafka headers
    */
-  public Headers getHeaders() {
+  public Object getHeaders() {
     return _headers;
   }
 
   /**
    * Set the Kafka headers
    */
-  public void setHeaders(Headers headers) {
+  public void setHeaders(Object headers) {
     _headers = headers;
   }
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelope.java
@@ -92,14 +92,14 @@ public class BrooklinEnvelope {
   }
 
   /**
-   * Get the Kafka headers
+   * Get the Generic headers
    */
   public Object getHeaders() {
     return _headers;
   }
 
   /**
-   * Set the Kafka headers
+   * Set the Generic headers
    */
   public void setHeaders(Object headers) {
     _headers = headers;

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTestUtils.java
@@ -16,6 +16,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.header.Headers;
 import org.apache.kafka.common.serialization.ByteArraySerializer;
 import org.testng.Assert;
 
@@ -52,19 +53,23 @@ final class KafkaMirrorMakerConnectorTestUtils {
 
   static void produceEvents(String topic, int destinationPartition, int numEvents,
       DatastreamEmbeddedZookeeperKafkaCluster kafkaCluster) {
-    produceEventsToPartition(topic, destinationPartition, numEvents, kafkaCluster);
+    produceEventsToPartition(topic, destinationPartition, numEvents, kafkaCluster, null);
   }
 
   static void produceEvents(String topic, int numEvents, DatastreamEmbeddedZookeeperKafkaCluster kafkaCluster) {
-    produceEventsToPartition(topic, null, numEvents, kafkaCluster);
+    produceEventsToPartition(topic, null, numEvents, kafkaCluster, null);
+  }
+
+  static void produceEventsWithHeaders(String topic, int numEvents, DatastreamEmbeddedZookeeperKafkaCluster kafkaCluster, Headers headers) {
+    produceEventsToPartition(topic, null, numEvents, kafkaCluster, headers);
   }
 
   static void produceEventsToPartition(String topic, Integer destinationPartition, int numEvents,
-      DatastreamEmbeddedZookeeperKafkaCluster kafkaCluster) {
+      DatastreamEmbeddedZookeeperKafkaCluster kafkaCluster, Headers headers) {
     try (Producer<byte[], byte[]> producer = new KafkaProducer<>(getKafkaProducerProperties(kafkaCluster))) {
       for (int i = 0; i < numEvents; i++) {
         producer.send(new ProducerRecord<>(topic, destinationPartition, ("key-" + i).getBytes(Charsets.UTF_8),
-            ("value-" + i).getBytes(Charsets.UTF_8)), (metadata, exception) -> {
+            ("value-" + i).getBytes(Charsets.UTF_8), headers), (metadata, exception) -> {
           if (exception != null) {
             throw new RuntimeException("Failed to send message.", exception);
           }

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaConsumerOffsets.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaConsumerOffsets.java
@@ -61,7 +61,7 @@ public class TestKafkaConsumerOffsets extends BaseKafkaZkTest {
 
     // produce messages to each topic partition
     topics.forEach(topic -> IntStream.range(0, PARTITION_COUNT).forEach(partition ->
-        KafkaMirrorMakerConnectorTestUtils.produceEventsToPartition(topic, partition, PARTITION_MESSAGE_COUNT, _kafkaCluster)));
+        KafkaMirrorMakerConnectorTestUtils.produceEventsToPartition(topic, partition, PARTITION_MESSAGE_COUNT, _kafkaCluster, null)));
 
     connector.onAssignmentChange(Collections.singletonList(task));
 

--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -5,7 +5,6 @@
  */
 package com.linkedin.datastream.connectors.kafka.mirrormaker;
 
-import java.nio.charset.Charset;
 import java.time.Duration;
 import java.util.Arrays;
 import java.util.Collections;
@@ -24,7 +23,6 @@ import org.apache.commons.io.Charsets;
 import org.apache.commons.lang.StringUtils;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.KafkaException;
 import org.apache.kafka.common.TopicPartition;

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -112,7 +112,14 @@ public class KafkaTransportProvider implements TransportProvider {
     Headers headers = null;
     if (event instanceof BrooklinEnvelope) {
       BrooklinEnvelope envelope = (BrooklinEnvelope) event;
-      headers = envelope.getHeaders() instanceof Headers ? (Headers) envelope.getHeaders() : null;
+      if (envelope.getHeaders() != null) {
+        if (!(envelope.getHeaders() instanceof Headers)) {
+          throw new DatastreamRuntimeException(
+              String.format("Unsupported header encountered %s in kafka transport provider for record %s",
+                  envelope.getHeaders(), record));
+        }
+        headers = (Headers) envelope.getHeaders();
+      }
       if (envelope.key().isPresent() && envelope.key().get() instanceof byte[]) {
         keyValue = (byte[]) envelope.key().get();
       }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProvider.java
@@ -112,7 +112,7 @@ public class KafkaTransportProvider implements TransportProvider {
     Headers headers = null;
     if (event instanceof BrooklinEnvelope) {
       BrooklinEnvelope envelope = (BrooklinEnvelope) event;
-      headers = envelope.getHeaders();
+      headers = envelope.getHeaders() instanceof Headers ? (Headers) envelope.getHeaders() : null;
       if (envelope.key().isPresent() && envelope.key().get() instanceof byte[]) {
         keyValue = (byte[]) envelope.key().get();
       }


### PR DESCRIPTION
## Summary
BrooklinEnvelope supports transporting the source header data to the destination, but is currently bounded to Kafka's header type. This change replaces that with generic header to let any other publisher-subscriber transfer events & headers via brooklin. 

***
## Testing
Added a unit test comparing the source and destination event's headers. 