### PR TITLE
Replaced deprecated Kafka client poll with the recommended one

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -508,7 +508,7 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   }
 
   protected ConsumerRecords<?, ?> consumerPoll(long pollInterval) {
-    return _consumer.poll(pollInterval);
+    return _consumer.poll(Duration.ofMillis(pollInterval));
   }
 
   /**

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -424,7 +424,7 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
       // Kafka rejects a poll if there is empty assignment
       return ConsumerRecords.EMPTY;
     } else {
-      return _consumer.poll(pollInterval);
+      return _consumer.poll(Duration.ofMillis(pollInterval));
     }
   }
 


### PR DESCRIPTION
Kafka poll currently used by Brooklin is prone to indefinitely blocking the client thread in certain scenarios (such as fetching metadata updates). This behavior is described in [KIP-266](https://cwiki.apache.org/confluence/display/KAFKA/KIP-266%3A+Fix+consumer+indefinite+blocking+behavior).

The current change fixes this by using the recommended API.