### PR TITLE
Add metrics for CoordinatorEvent queue

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -257,7 +257,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _heartbeatPeriod = Duration.ofMillis(config.getHeartbeatPeriodMs());
 
     _adapter = createZkAdapter();
-    _eventQueue = new CoordinatorEventBlockingQueue();
+    _eventQueue = new CoordinatorEventBlockingQueue(Coordinator.class.getSimpleName());
     createEventThread();
 
     VerifiableProperties coordinatorProperties = new VerifiableProperties(_config.getConfigProperties());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -39,7 +39,8 @@ public class CoordinatorEventBlockingQueue implements MetricsAware {
 
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorEventBlockingQueue.class.getName());
   private static final String SIMPLE_NAME = CoordinatorEventBlockingQueue.class.getSimpleName();
-  private static final Set<BrooklinMetricInfo> _metricInfos = ConcurrentHashMap.newKeySet();
+  private static final Set<BrooklinMetricInfo> METRIC_INFOS = ConcurrentHashMap.newKeySet();
+
   static final String COUNTER_KEY = "duplicateEvents";
   static final String GAUGE_KEY = "queuedEvents";
 
@@ -78,7 +79,7 @@ public class CoordinatorEventBlockingQueue implements MetricsAware {
 
     BrooklinCounterInfo counterInfo = new BrooklinCounterInfo(MetricRegistry.name(prefix, COUNTER_KEY));
     BrooklinGaugeInfo gaugeInfo = new BrooklinGaugeInfo(MetricRegistry.name(prefix, GAUGE_KEY));
-    _metricInfos.addAll(Arrays.asList(counterInfo, gaugeInfo));
+    METRIC_INFOS.addAll(Arrays.asList(counterInfo, gaugeInfo));
   }
 
 
@@ -171,6 +172,6 @@ public class CoordinatorEventBlockingQueue implements MetricsAware {
 
   @Override
   public List<BrooklinMetricInfo> getMetricInfos() {
-    return new ArrayList<>(_metricInfos);
+    return new ArrayList<>(METRIC_INFOS);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -52,16 +52,6 @@ public class CoordinatorEventBlockingQueue implements MetricsAware {
   /**
    * Construct a blocking event queue for all types of events in {@link CoordinatorEvent.EventType}
    *
-   * @deprecated Use of this constructor should be replaced with the single parameter variant.
-   */
-  @Deprecated
-  public CoordinatorEventBlockingQueue() {
-    this("legacy");
-  }
-
-  /**
-   * Construct a blocking event queue for all types of events in {@link CoordinatorEvent.EventType}
-   *
    * @param key String used to register CoordinatorEventBlockQueue metrics. The metrics
    *            will be registered to {@code CoordinatorEventBlockingQueue.<key>.<metric>}.
    *            Where {@code <metric>} is either {@link CoordinatorEventBlockingQueue#COUNTER_KEY}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -38,7 +38,6 @@ import com.linkedin.datastream.metrics.MetricsAware;
 public class CoordinatorEventBlockingQueue implements MetricsAware {
 
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorEventBlockingQueue.class.getName());
-  private static final String SIMPLE_NAME = CoordinatorEventBlockingQueue.class.getSimpleName();
   private static final Set<BrooklinMetricInfo> METRIC_INFOS = ConcurrentHashMap.newKeySet();
 
   static final String COUNTER_KEY = "duplicateEvents";

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -35,7 +35,7 @@ import com.linkedin.datastream.metrics.MetricsAware;
  *
  * @see CoordinatorEvent.EventType
  */
-public class CoordinatorEventBlockingQueue implements MetricsAware {
+class CoordinatorEventBlockingQueue implements MetricsAware {
 
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorEventBlockingQueue.class.getName());
   private static final Set<BrooklinMetricInfo> METRIC_INFOS = ConcurrentHashMap.newKeySet();
@@ -57,7 +57,7 @@ public class CoordinatorEventBlockingQueue implements MetricsAware {
    *            Where {@code <metric>} is either {@link CoordinatorEventBlockingQueue#COUNTER_KEY}
    *            or {@link CoordinatorEventBlockingQueue#GAUGE_KEY}.
    */
-  public CoordinatorEventBlockingQueue(String key) {
+  CoordinatorEventBlockingQueue(String key) {
     _eventSet = new HashSet<>();
     _eventQueue = new LinkedBlockingQueue<>();
     _dynamicMetricsManager = DynamicMetricsManager.getInstance();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -106,7 +106,7 @@ public class TestCoordinatorEventBlockingQueue {
     queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
     queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
     queue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
-    Assert.assertEquals((int) gauge.getValue(), 3 );
+    Assert.assertEquals((int) gauge.getValue(), 3);
     queue.clear();
     Assert.assertEquals(counter.getCount(), random, "clear() should not alter counter.");
     Assert.assertEquals((int) gauge.getValue(), 0, "clear() should reset gauge.");

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -18,7 +18,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.testutil.MetricsTestUtils;
 
-import static com.linkedin.datastream.server.CoordinatorEventBlockingQueue.*;
+import static com.linkedin.datastream.server.CoordinatorEventBlockingQueue.COUNTER_KEY;
+import static com.linkedin.datastream.server.CoordinatorEventBlockingQueue.GAUGE_KEY;
 
 
 /**

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -8,10 +8,23 @@ package com.linkedin.datastream.server;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.testutil.MetricsTestUtils;
+
+import static com.linkedin.datastream.server.CoordinatorEventBlockingQueue.*;
+
+
 /**
  * Tests for {@link CoordinatorEventBlockingQueue}
  */
 public class TestCoordinatorEventBlockingQueue {
+
+  static {
+    DynamicMetricsManager.createInstance(new MetricRegistry(), TestCoordinatorEventBlockingQueue.class.getSimpleName());
+  }
 
   @Test
   public void testHappyPath() throws Exception {
@@ -32,5 +45,93 @@ public class TestCoordinatorEventBlockingQueue {
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderPartitionAssignmentEvent("test2"));
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+  }
+
+  /**
+   * Verify metric registration.
+   */
+  @Test
+  public void testRegistersMetricsCorrectly() {
+    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue();
+    MetricsTestUtils.verifyMetrics(queue, DynamicMetricsManager.getInstance());
+  }
+
+  /**
+   * Verify gauge matches operations: {@code put()}, {@code peek()}, {@code take()},
+   * and {@code clear()}.
+   */
+  @Test(timeOut = 100)
+  public void testGaugeOperations() throws InterruptedException {
+    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue();
+    String metricName = queue.buildMetricName(METRIC_KEY);
+    Gauge<Integer> gauge = DynamicMetricsManager.getInstance().getMetric(metricName);
+    Assert.assertNotNull(gauge, "Gauge was not found. Test setup failed.");
+    Assert.assertEquals((int) gauge.getValue(), 0, "Initial size should be 0.");
+
+    queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    Assert.assertEquals((int) gauge.getValue(), 1, "put() should increment gauge.");
+
+    CoordinatorEvent event0 = queue.peek();
+    Assert.assertNotNull(event0, "Event was not queued.");
+    Assert.assertEquals((int) gauge.getValue(), 1, "peek() should affect gauge.");
+
+    CoordinatorEvent event1 = queue.take();
+    Assert.assertNotNull(event0, "Event was not queued.");
+    Assert.assertEquals((int) gauge.getValue(), 0, "remove() should decrement gauge.");
+
+    queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
+    queue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
+    Assert.assertEquals((int) gauge.getValue(), 3 );
+    queue.clear();
+    Assert.assertEquals((int) gauge.getValue(), 0, "clear() should reset gauge.");
+  }
+
+  /**
+   * Verify gauge follows de-duplication. Adding duplicate events should not
+   * change gauge value.
+   *
+   * 2-step assertion:
+   *   1. queue.size() == value            => verify test construction
+   *   2. gauge.getValue() == queue.size() => verify implementation
+   */
+  @Test(timeOut = 100)
+  public void testGaugeDedupe() throws InterruptedException {
+    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue();
+    String metricName = queue.buildMetricName(METRIC_KEY);
+    Gauge<Integer> gauge = DynamicMetricsManager.getInstance().getMetric(metricName);
+    Assert.assertNotNull(gauge, "Gauge was not found. Test setup failed.");
+    Assert.assertEquals((int) gauge.getValue(), 0, "Initial size should be 0.");
+
+    queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    Assert.assertEquals(queue.size(), 1);
+    Assert.assertEquals((int) gauge.getValue(), 1, "Add should increment gauge.");
+
+    queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    Assert.assertEquals(queue.size(), 1);
+    Assert.assertEquals((int) gauge.getValue(), queue.size(), "Duplicate event should not change gauge.");
+
+    queue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
+    Assert.assertEquals(queue.size(), 2);
+    Assert.assertEquals((int) gauge.getValue(), queue.size(), "Add should increment gauge.");
+
+    queue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    Assert.assertEquals(queue.size(), 2);
+    Assert.assertEquals((int) gauge.getValue(), queue.size(), "Duplicate event should not change gauge.");
+
+    CoordinatorEvent event0 = queue.take();
+    Assert.assertNotNull(event0, "Event was not queued.");
+    Assert.assertEquals(queue.size(), 1);
+    Assert.assertEquals((int) gauge.getValue(), queue.size(), "Remove should decrement gauge.");
+
+    CoordinatorEvent event1 = queue.take();
+    Assert.assertNotNull(event1, "Event was not queued.");
+    Assert.assertEquals(queue.size(), 0);
+    Assert.assertEquals((int) gauge.getValue(), queue.size(), "Remove should decrement gauge.");
+
+    CoordinatorEvent event2 = queue.peek();
+    Assert.assertNull(event2, "Event queue was expected to be empty.");
+    Assert.assertEquals(queue.size(), 0);
+    Assert.assertEquals((int) gauge.getValue(), queue.size(), "Value is never less than zero.");
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -26,6 +26,12 @@ import static com.linkedin.datastream.server.CoordinatorEventBlockingQueue.*;
  */
 public class TestCoordinatorEventBlockingQueue {
 
+  private static final String SIMPLE_NAME = TestCoordinatorEventBlockingQueue.class.getSimpleName();
+  private static final String COUNTER_NAME =
+      MetricRegistry.name(CoordinatorEventBlockingQueue.class.getSimpleName(), SIMPLE_NAME, COUNTER_KEY);
+  private static final String GAUGE_NAME =
+      MetricRegistry.name(CoordinatorEventBlockingQueue.class.getSimpleName(), SIMPLE_NAME, GAUGE_KEY);
+
   @BeforeMethod(alwaysRun = true)
   public void resetMetrics() {
     DynamicMetricsManager.createInstance(new MetricRegistry(), TestCoordinatorEventBlockingQueue.class.getName());
@@ -33,7 +39,7 @@ public class TestCoordinatorEventBlockingQueue {
 
   @Test
   public void testHappyPath() throws Exception {
-    CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue();
+    CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue(SIMPLE_NAME);
     eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
     eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
     eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
@@ -57,7 +63,7 @@ public class TestCoordinatorEventBlockingQueue {
    */
   @Test
   public void testRegistersMetricsCorrectly() {
-    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue();
+    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue(SIMPLE_NAME);
     MetricsTestUtils.verifyMetrics(queue, DynamicMetricsManager.getInstance());
   }
 
@@ -67,9 +73,9 @@ public class TestCoordinatorEventBlockingQueue {
    */
   @Test(timeOut = 500)
   public void testMetricOperations() throws InterruptedException {
-    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue();
-    Counter counter = DynamicMetricsManager.getInstance().getMetric(queue.buildMetricName(COUNTER_KEY));
-    Gauge<Integer> gauge = DynamicMetricsManager.getInstance().getMetric(queue.buildMetricName(GAUGE_KEY));
+    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue(SIMPLE_NAME);
+    Counter counter = DynamicMetricsManager.getInstance().getMetric(COUNTER_NAME);
+    Gauge<Integer> gauge = DynamicMetricsManager.getInstance().getMetric(GAUGE_NAME);
 
     Assert.assertNotNull(counter, "Counter was not found. Test setup failed.");
     Assert.assertEquals(counter.getCount(), 0, "Initial value should be 0.");
@@ -115,9 +121,9 @@ public class TestCoordinatorEventBlockingQueue {
    */
   @Test(timeOut = 500)
   public void testGaugeDedupe() throws InterruptedException {
-    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue();
-    Counter counter = DynamicMetricsManager.getInstance().getMetric(queue.buildMetricName(COUNTER_KEY));
-    Gauge<Integer> gauge = DynamicMetricsManager.getInstance().getMetric(queue.buildMetricName(GAUGE_KEY));
+    CoordinatorEventBlockingQueue queue = new CoordinatorEventBlockingQueue(SIMPLE_NAME);
+    Counter counter = DynamicMetricsManager.getInstance().getMetric(COUNTER_NAME);
+    Gauge<Integer> gauge = DynamicMetricsManager.getInstance().getMetric(GAUGE_NAME);
 
     Assert.assertNotNull(counter, "Counter was not found. Test setup failed.");
     Assert.assertEquals(counter.getCount(), 0, "Initial value should be 0.");

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
@@ -53,7 +53,7 @@ public class MetricsTestUtils {
    * names start with the provided {@code metricsAware}'s simple class name.
    */
   public static void verifyMetrics(MetricsAware metricsAware, DynamicMetricsManager metricsManager) {
-    verifyMetrics(metricsAware, metricsManager, s -> s.startsWith(metricsAware.getClass().getSimpleName()));
+    verifyMetrics(metricsAware, metricsManager, s -> s.matches(metricsAware.getClass().getSimpleName()));
   }
 
   /**


### PR DESCRIPTION
Adds a `Gauge` and `Counter` to `CoordinatorEventBlockingQueue`. The `Gauge` tracks the current size of the underlying queue; and the `Counter` increments when a duplicate event is `put()`. The class implements `MetricsAware` and registers the underlying metrics to the simple class name + constructor parameter `key`. The existing parameterless constructor is marked deprecated. It registers metrics to the key "CoordinatorEventBlockingQueue.legacy".

The change to `MetricTestUtils` was required to avoid collisions with `TestCoordinator`. The `startsWith` predicate was changed to `match` to ensure that the entire name was used to filter. The same metric verification registration test was added to the `CoordinatorEventBlockingQueue`.