### PR TITLE
Increased the size of token claims thread pool

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -174,7 +174,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private static final long STOP_PROPAGATION_RETRY_MS = 5000L;
   // how many threads will the token claims executor use for assignment tokens feature. There's a risk that this will get
   // exhausted when there are more concurrent stop requests than threads in the thread pool
-  private static final int TOKEN_CLAIM_THREAD_POOL_SIZE = 8;
+  private static final int TOKEN_CLAIM_THREAD_POOL_SIZE = 16;
 
   private static final Duration ASSIGNMENT_TIMEOUT = Duration.ofSeconds(90);
 


### PR DESCRIPTION
We ran into cases when BMM clusters are running into "restart storms". Lots of restart requests in a short time window. This leads to the token claims thread pool getting exhausted and not claiming tokens properly. While the underlying issue needs to be investigated and addressed, we need to mitigate the exhaustion of the token claims executor.

This change increases the token claims executor thread pool size to 16.