### PR TITLE
Fix Metric Registration Issue for Throughput Violations Reporting

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -3617,7 +3617,7 @@ public class TestCoordinator {
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
-    String numThroughputViolatingTopicsMetric = String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
+    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
         streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
@@ -3731,7 +3731,7 @@ public class TestCoordinator {
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
-    String numThroughputViolatingTopicsMetric = String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
+    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
         streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
@@ -3778,10 +3778,10 @@ public class TestCoordinator {
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
     String numThroughputViolatingTopicsMetricForFirstDatastream =
-        String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
+        getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
             streamName1, coordinator.getNumThroughputViolatingTopicsMetricName());
     String numThroughputViolatingTopicsMetricForSecondDatastream =
-        String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
+        getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
             streamName2, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
@@ -3903,7 +3903,7 @@ public class TestCoordinator {
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
-    String numThroughputViolatingTopicsMetric = String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
+    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
         streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
@@ -3949,6 +3949,11 @@ public class TestCoordinator {
     // Comparing the reported topics information with the cached for the second datastream.
     return () -> requestedThroughputViolatingTopics.size() == fetchedViolatingTopicsFromStore.size()
         && requestedThroughputViolatingTopics.containsAll(fetchedViolatingTopicsFromStore);
+  }
+
+  // Formats the numThroughputViolatingTopics Metric String
+  private String getNumThroughputViolatingTopicsMetric(String className, String key, String metricName) {
+    return String.format("%s.%s.%s", className, key, metricName);
   }
 
   // helper method: assert that within a timeout value, the connector are assigned the specific

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -3618,7 +3618,7 @@ public class TestCoordinator {
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
     String numThroughputViolatingTopicsMetric = String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
-        coordinator.getNumThroughputViolatingTopicsMetricName(), streamName);
+        streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
@@ -3732,7 +3732,7 @@ public class TestCoordinator {
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
     String numThroughputViolatingTopicsMetric = String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
-        coordinator.getNumThroughputViolatingTopicsMetricName(), streamName);
+        streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
@@ -3779,10 +3779,10 @@ public class TestCoordinator {
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
     String numThroughputViolatingTopicsMetricForFirstDatastream =
         String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
-            coordinator.getNumThroughputViolatingTopicsMetricName(), streamName1);
+            streamName1, coordinator.getNumThroughputViolatingTopicsMetricName());
     String numThroughputViolatingTopicsMetricForSecondDatastream =
         String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
-            coordinator.getNumThroughputViolatingTopicsMetricName(), streamName2);
+            streamName2, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
@@ -3904,7 +3904,7 @@ public class TestCoordinator {
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
     String numThroughputViolatingTopicsMetric = String.format("%s.%s.%s", Coordinator.class.getSimpleName(),
-        coordinator.getNumThroughputViolatingTopicsMetricName(), streamName);
+        streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -3617,8 +3617,7 @@ public class TestCoordinator {
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
-    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
-        streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
+    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(streamName);
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
@@ -3731,8 +3730,7 @@ public class TestCoordinator {
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
-    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
-        streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
+    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(streamName);
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
@@ -3778,11 +3776,9 @@ public class TestCoordinator {
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
     String numThroughputViolatingTopicsMetricForFirstDatastream =
-        getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
-            streamName1, coordinator.getNumThroughputViolatingTopicsMetricName());
+        getNumThroughputViolatingTopicsMetric(streamName1);
     String numThroughputViolatingTopicsMetricForSecondDatastream =
-        getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
-            streamName2, coordinator.getNumThroughputViolatingTopicsMetricName());
+        getNumThroughputViolatingTopicsMetric(streamName2);
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
@@ -3903,8 +3899,7 @@ public class TestCoordinator {
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, Boolean.TRUE.toString());
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, properties);
-    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(Coordinator.class.getSimpleName(),
-        streamName, coordinator.getNumThroughputViolatingTopicsMetricName());
+    String numThroughputViolatingTopicsMetric = getNumThroughputViolatingTopicsMetric(streamName);
     TestHookConnector connector1 = new TestHookConnector("connector1", connectorType);
     coordinator.addConnector(connectorType, connector1, new BroadcastStrategy(Optional.empty()), false,
         new SourceBasedDeduper(), null);
@@ -3952,8 +3947,9 @@ public class TestCoordinator {
   }
 
   // Formats the numThroughputViolatingTopics Metric String
-  private String getNumThroughputViolatingTopicsMetric(String className, String key, String metricName) {
-    return String.format("%s.%s.%s", className, key, metricName);
+  private String getNumThroughputViolatingTopicsMetric(String key) {
+    return String.format("%s.%s.%s", Coordinator.class.getSimpleName(), key,
+        Coordinator.getNumThroughputViolatingTopicsMetricName());
   }
 
   // helper method: assert that within a timeout value, the connector are assigned the specific

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2320,7 +2320,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   }
 
   @VisibleForTesting
-  String getNumThroughputViolatingTopicsMetricName() {
+  static String getNumThroughputViolatingTopicsMetricName() {
     return CoordinatorMetrics.NUM_THROUGHPUT_VIOLATING_TOPICS_PER_DATASTREAM;
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -619,6 +619,10 @@ public class EventProducer implements DatastreamEventProducer {
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
             BrooklinHistogramInfo.PERCENTILE_999))));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_SEND_LATENCY_MS_STRING));
+    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + THROUGHPUT_VIOLATING_EVENTS_LATENCY_MS_STRING, Optional.of(
+        Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
+            BrooklinHistogramInfo.PERCENTILE_999))));
+    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + THROUGHPUT_VIOLATING_EVENTS_SEND_LATENCY_MS_STRING));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + FLUSH_LATENCY_MS_STRING));
 
     return Collections.unmodifiableList(metrics);

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.3.2-SNAPSHOT"
+  version = "5.3.5-SNAPSHOT"
 }
 
 subprojects {


### PR DESCRIPTION
Changes in this PR:

- Registering the Event Producer's metrics to be reported for throughput-violating topics at initialization. 
- Fixed the Gauge metric's registration as well via regex-based prefix, which reports the number of throughput-violating topics. 


