### PR TITLE
Add stop method to TransportProviderAdmin

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProviderAdmin.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/TransportProviderAdmin.java
@@ -71,4 +71,11 @@ public interface TransportProviderAdmin extends MetricsAware {
    * @return retention duration
    */
   Duration getRetention(Datastream datastream);
+
+  /**
+   * Stop the transport provider admin. It should be called only when the coordinator is stopped.
+   */
+  default void stop() {
+
+  }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -383,6 +383,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     for (DatastreamTask task : _assignedDatastreamTasks.values()) {
       ((EventProducer) task.getEventProducer()).shutdown(false);
     }
+
+    //Stop all the Transport provider admins.
+    for (TransportProviderAdmin tpAdmin : _transportProviderAdmins.values()) {
+      tpAdmin.stop();
+    }
+
     _adapter.disconnect();
     _log.info("Coordinator stopped");
   }


### PR DESCRIPTION
Some TransportProviderAdmins create AdminClient for Kafka and the lifecycle of the object is until the coordinator stops. Without a proper stop call for TransportProviderAdmin, the AdminClient loses connection to the other entities and result in failure for other unit-tests.