### PR TITLE
EventQueue metrics are not exported

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2439,6 +2439,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // CheckpointProvider metrics
       addMetricInfos(_coordinator._cpProvider);
 
+      // CoordinatorEventBlockingQueue metrics
+      addMetricInfos(_coordinator._eventQueue);
+
       // EventProducer metrics
       _metricInfos.addAll(EventProducer.getMetricInfos());
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -38,7 +38,7 @@ import com.linkedin.datastream.metrics.MetricsAware;
 class CoordinatorEventBlockingQueue implements MetricsAware {
 
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorEventBlockingQueue.class.getName());
-  private final Set<BrooklinMetricInfo> METRIC_INFOS = ConcurrentHashMap.newKeySet();
+  private final Set<BrooklinMetricInfo> _metricInfos = ConcurrentHashMap.newKeySet();
 
   static final String COUNTER_KEY = "duplicateEvents";
   static final String GAUGE_KEY = "queuedEvents";
@@ -68,7 +68,7 @@ class CoordinatorEventBlockingQueue implements MetricsAware {
 
     BrooklinCounterInfo counterInfo = new BrooklinCounterInfo(MetricRegistry.name(prefix, COUNTER_KEY));
     BrooklinGaugeInfo gaugeInfo = new BrooklinGaugeInfo(MetricRegistry.name(prefix, GAUGE_KEY));
-    METRIC_INFOS.addAll(Arrays.asList(counterInfo, gaugeInfo));
+    _metricInfos.addAll(Arrays.asList(counterInfo, gaugeInfo));
   }
 
 
@@ -161,6 +161,6 @@ class CoordinatorEventBlockingQueue implements MetricsAware {
 
   @Override
   public List<BrooklinMetricInfo> getMetricInfos() {
-    return new ArrayList<>(METRIC_INFOS);
+    return new ArrayList<>(_metricInfos);
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -38,7 +38,7 @@ import com.linkedin.datastream.metrics.MetricsAware;
 class CoordinatorEventBlockingQueue implements MetricsAware {
 
   private static final Logger LOG = LoggerFactory.getLogger(CoordinatorEventBlockingQueue.class.getName());
-  private static final Set<BrooklinMetricInfo> METRIC_INFOS = ConcurrentHashMap.newKeySet();
+  private final Set<BrooklinMetricInfo> METRIC_INFOS = ConcurrentHashMap.newKeySet();
 
   static final String COUNTER_KEY = "duplicateEvents";
   static final String GAUGE_KEY = "queuedEvents";


### PR DESCRIPTION
Here "export" means InGraphs.

`CoordinatorEventBlockingQueue` metrics are created but not exported/registered in healthcheck Sensors. This adds them to the metrics registered (and exported) for the `Coordinator` - see [DatastreamServer.initializeMetrics](https://github.com/linkedin/brooklin/blob/c317f12b5106c8d78da8affb16dbc7bcf0d1c03d/datastream-server-restli/src/main/java/com/linkedin/datastream/server/DatastreamServer.java#L353). 