### PR TITLE
Test Circle CI build errors

### DIFF
--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -16,5 +16,6 @@ dependencies {
     classpath 'com.linkedin.pegasus:gradle-plugins:29.2.3'
     // TODO Remove this dependency
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+    classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.32.0"
 }

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -15,7 +15,9 @@ dependencies {
     classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
     classpath 'com.linkedin.pegasus:gradle-plugins:29.2.3'
     // TODO Remove this dependency
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
+    classpath('com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5') {
+      exclude group: 'org.codehaus.groovy.modules.http-builder', module: 'http-builder'
+    }
     classpath 'org.codehaus.groovy.modules.http-builder:http-builder:0.7.2'
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.32.0"
 }

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -16,5 +16,5 @@ dependencies {
     classpath 'com.linkedin.pegasus:gradle-plugins:29.2.3'
     // TODO Remove this dependency
     classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
-    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0"
+    classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.32.0"
 }

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -15,6 +15,6 @@ dependencies {
     classpath 'gradle.plugin.nl.javadude.gradle.plugins:license-gradle-plugin:0.14.0'
     classpath 'com.linkedin.pegasus:gradle-plugins:29.2.3'
     // TODO Remove this dependency
-    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4'
+    classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.5'
     classpath "org.jfrog.buildinfo:build-info-extractor-gradle:4.32.0"
 }


### PR DESCRIPTION
Investigating CI error.


```
FAILURE: Build failed with an exception.

* What went wrong:
A problem occurred configuring root project 'brooklin'.
> Could not resolve all artifacts for configuration ':classpath'.
   > Could not find org.codehaus.groovy.modules.http-builder:http-builder:0.7.2.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/codehaus/groovy/modules/http-builder/http-builder/0.7.2/http-builder-0.7.2.pom
       - https://repo.maven.apache.org/maven2/org/codehaus/groovy/modules/http-builder/http-builder/0.7.2/http-builder-0.7.2.jar
       - https://plugins.gradle.org/m2/org/codehaus/groovy/modules/http-builder/http-builder/0.7.2/http-builder-0.7.2.pom
       - https://plugins.gradle.org/m2/org/codehaus/groovy/modules/http-builder/http-builder/0.7.2/http-builder-0.7.2.jar
       - https://linkedin.jfrog.io/artifactory/open-source/org/codehaus/groovy/modules/http-builder/http-builder/0.7.2/http-builder-0.7.2.pom
       - https://linkedin.jfrog.io/artifactory/open-source/org/codehaus/groovy/modules/http-builder/http-builder/0.7.2/http-builder-0.7.2.jar
     Required by:
         project : > com.jfrog.bintray.gradle:gradle-bintray-plugin:1.8.4
   > Could not find org.jfrog.buildinfo:build-info-extractor:2.23.0.
     Searched in the following locations:
       - https://repo.maven.apache.org/maven2/org/jfrog/buildinfo/build-info-extractor/2.23.0/build-info-extractor-2.23.0.pom
       - https://repo.maven.apache.org/maven2/org/jfrog/buildinfo/build-info-extractor/2.23.0/build-info-extractor-2.23.0.jar
       - https://plugins.gradle.org/m2/org/jfrog/buildinfo/build-info-extractor/2.23.0/build-info-extractor-2.23.0.pom
       - https://plugins.gradle.org/m2/org/jfrog/buildinfo/build-info-extractor/2.23.0/build-info-extractor-2.23.0.jar
       - https://linkedin.jfrog.io/artifactory/open-source/org/jfrog/buildinfo/build-info-extractor/2.23.0/build-info-extractor-2.23.0.pom
       - https://linkedin.jfrog.io/artifactory/open-source/org/jfrog/buildinfo/build-info-extractor/2.23.0/build-info-extractor-2.23.0.jar
     Required by:
         project : > org.jfrog.buildinfo:build-info-extractor-gradle:4.21.0

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org/

BUILD FAILED in 6s

Exited with code exit status 1
```