### PR TITLE
Log existing datastream for update and delete call

### DIFF
--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -245,6 +245,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           throw new DatastreamValidationException(String.format("Failed to update %s. Can't update numTasks."
               + " old: %s new: %s", key, oldDatastream, datastream));
         }
+
+        LOG.info("[UPDATE] old datastream: {}, new datastream: {}", oldDatastream, datastream);
       } catch (DatastreamValidationException e) {
         _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, CALL_ERROR, 1);
         _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_400_BAD_REQUEST, e.getMessage());
@@ -766,7 +768,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
     }
 
     try {
-      LOG.info("Delete datastream called for datastream " + datastreamName);
+      LOG.info("Delete datastream called for datastream {}: {}", datastreamName, datastream);
 
       _dynamicMetricsManager.createOrUpdateMeter(CLASS_NAME, DELETE_CALL, 1);
       Instant startTime = Instant.now();


### PR DESCRIPTION
Existing datastream object needs to be logged to check the states and rollback based on logs if necessary.