### PR TITLE
Replacing Coordinator Queue With Deque & Fixing Usage Of toMap Util

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/CallableCoordinatorForTest.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/CallableCoordinatorForTest.java
@@ -1,0 +1,20 @@
+/**
+ *  Copyright 2023 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server;
+
+import java.util.Properties;
+
+/**
+ * Callable Coordinator is used for overriding coordinator behaviors for tests
+ */
+public interface CallableCoordinatorForTest {
+  /**
+   * invoking constructor of coordinator with params,
+   * - datastreamCache to maintain all the datastreams in the cluster.
+   * - properties to use while creating coordinator.
+   * */
+  Coordinator invoke(CachedDatastreamReader cachedDatastreamReader, Properties properties);
+}

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.lang.reflect.Method;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.AbstractMap;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,6 +36,7 @@ import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.Validate;
 import org.apache.zookeeper.CreateMode;
@@ -4007,6 +4009,69 @@ public class TestCoordinator {
 
     // As we expect the reattempt event to be added to the front, the front of the queue should now be the same.
     Assert.assertEquals(shadowCoordinatorQueue.poll(), leaderDoAssignmentForNewlyElectedLeader);
+  }
+
+  @Test
+  public void testLeaderDoAssignmentForNewlyElectedLeaderFailurePathVariation() throws Exception {
+    String testCluster = "testLeaderDoAssignmentForNewlyElectedLeaderFailurePathVariation";
+    String connectorType = "connectorType";
+    String streamName = "testLeaderDoAssignmentForNewlyElectedLeaderFailurePathVariation";
+
+    // This is the event which should be added to the front of the queue once the handler exits on an exception.
+    CoordinatorEvent leaderDoAssignmentForNewlyElectedLeader =
+        new CoordinatorEvent(CoordinatorEvent.EventType.LEADER_DO_ASSIGNMENT, true);
+
+    List<Map.Entry<CoordinatorEvent, CoordinatorEvent>>
+        shadowListWithPreviousAndNewHeadPairsAtNewLeaderDoAssignmentEvent = new ArrayList<>();
+
+    Properties properties = new Properties();
+    Coordinator coordinator =
+        createCoordinator(_zkConnectionString, testCluster, properties, new DummyTransportProviderAdminFactory(),
+            (cachedDatastreamReader, props) -> new Coordinator(cachedDatastreamReader, props) {
+
+              // This override generates an exception while the newly elected leader performs pre assignment cleanup.
+              // The exception causes the handleLeaderDoAssignment handler to exit, along with inserting the same event
+              // in the queue for a reattempt.
+              @Override
+              protected void performPreAssignmentCleanup(List<DatastreamGroup> datastreamGroups) {
+                throw new RuntimeException("testing exception path in assignment cleanup routine");
+              }
+
+              // This override collects the coordinator queue events in a shadow queue for test purposes.
+              @Override
+              protected synchronized void handleEvent(CoordinatorEvent event) {
+                CoordinatorEvent previousHead = peekCoordinatorEventBlockingQueue();
+                super.handleEvent(event);
+                CoordinatorEvent nextHead = peekCoordinatorEventBlockingQueue();
+
+                // recording previous and new heads of the CoordinatorEventBlockingQueue
+                if (event.equals(leaderDoAssignmentForNewlyElectedLeader)) {
+                  shadowListWithPreviousAndNewHeadPairsAtNewLeaderDoAssignmentEvent.add(
+                      new AbstractMap.SimpleEntry<>(previousHead, nextHead));
+                }
+              }
+            });
+    TestHookConnector dummyConnector = new TestHookConnector("dummyConnector", connectorType);
+    coordinator.addConnector(connectorType, dummyConnector, new BroadcastStrategy(Optional.empty()), false,
+        new SourceBasedDeduper(), null);
+    coordinator.start();
+
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+
+    Datastream testDatastream =
+        DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, streamName)[0];
+
+    coordinator.stop();
+    zkClient.close();
+    coordinator.getDatastreamCache().getZkclient().close();
+
+    // Comparing the previous and new head values when the NewLeaderDoAssignmentEvent fails.
+    IntStream.range(0, 3).forEach(index -> {
+      Assert.assertNotEquals(shadowListWithPreviousAndNewHeadPairsAtNewLeaderDoAssignmentEvent.get(index).getKey(),
+          leaderDoAssignmentForNewlyElectedLeader);
+      Assert.assertEquals(shadowListWithPreviousAndNewHeadPairsAtNewLeaderDoAssignmentEvent.get(index).getValue(),
+          leaderDoAssignmentForNewlyElectedLeader);
+    });
   }
 
   // This helper function helps compare the requesting topics with the topics reflected in the server.

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4042,6 +4042,7 @@ public class TestCoordinator {
               protected synchronized void handleEvent(CoordinatorEvent event) {
                 CoordinatorEvent previousHead = peekCoordinatorEventBlockingQueue();
                 super.handleEvent(event);
+                PollUtils.poll(() -> peekCoordinatorEventBlockingQueue() != null, 50, 1000);
                 CoordinatorEvent nextHead = peekCoordinatorEventBlockingQueue();
 
                 // recording previous and new heads of the CoordinatorEventBlockingQueue

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4002,7 +4002,10 @@ public class TestCoordinator {
       shadowCoordinatorQueue.poll();
     }
 
-    // As we expect the reattempt event to added to the front of the queue, the front of the queue should be the same.
+    // Take out the initial leaderDoAssignmentForNewlyElectedLeader
+    shadowCoordinatorQueue.poll();
+
+    // As we expect the reattempt event to be added to the front, the front of the queue should now be the same.
     Assert.assertEquals(shadowCoordinatorQueue.poll(), leaderDoAssignmentForNewlyElectedLeader);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1527,7 +1527,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _leaderDoAssignmentScheduled.set(true);
     // scheduling LEADER_DO_ASSIGNMENT event instantly to prevent any other event being handled before the reattempt.
     _leaderDoAssignmentScheduledFuture = _scheduledExecutor.schedule(() -> {
-      _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(isNewlyElectedLeader), false);
+      _eventQueue.putFirst(CoordinatorEvent.createLeaderDoAssignmentEvent(isNewlyElectedLeader));
       _leaderDoAssignmentScheduled.set(false);
     }, 0, TimeUnit.MILLISECONDS);
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2328,6 +2328,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   }
 
   @VisibleForTesting
+  CoordinatorEvent peekCoordinatorEventBlockingQueue() {
+    return _eventQueue.peek();
+  }
+
+  @VisibleForTesting
   static String getNumThroughputViolatingTopicsMetricName() {
     return CoordinatorMetrics.NUM_THROUGHPUT_VIOLATING_TOPICS_PER_DATASTREAM;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -834,7 +834,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _assignedDatastreamTasks.putAll(currentAssignment.values()
         .stream()
         .flatMap(Collection::stream)
-        .collect(Collectors.toMap(DatastreamTask::getDatastreamTaskName, Function.identity())));
+        .collect(Collectors.toMap(DatastreamTask::getDatastreamTaskName, Function.identity(),
+            (existingTask, duplicateTask) -> existingTask)));
     List<DatastreamTask> newAssignment = new ArrayList<>(_assignedDatastreamTasks.values());
 
     if ((totalTasks - submittedTasks) > 0) {
@@ -1524,10 +1525,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _log.info("Schedule retry for leader assigning tasks");
     _metrics.updateKeyedMeter(CoordinatorMetrics.KeyedMeter.HANDLE_LEADER_DO_ASSIGNMENT_NUM_RETRIES, 1);
     _leaderDoAssignmentScheduled.set(true);
+    // scheduling LEADER_DO_ASSIGNMENT event instantly to prevent any other event being handled before the reattempt.
     _leaderDoAssignmentScheduledFuture = _scheduledExecutor.schedule(() -> {
-      _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(isNewlyElectedLeader));
+      _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(isNewlyElectedLeader), false);
       _leaderDoAssignmentScheduled.set(false);
-    }, _config.getRetryIntervalMs(), TimeUnit.MILLISECONDS);
+    }, 0, TimeUnit.MILLISECONDS);
   }
 
   @VisibleForTesting
@@ -1614,7 +1616,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
   }
 
-  private void performPreAssignmentCleanup(List<DatastreamGroup> datastreamGroups) {
+  protected void performPreAssignmentCleanup(List<DatastreamGroup> datastreamGroups) {
 
     // Map between instance to tasks assigned to the instance.
     Map<String, Set<DatastreamTask>> previousAssignmentByInstance = _adapter.getAllAssignedDatastreamTasks();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEvent.java
@@ -52,7 +52,7 @@ public class CoordinatorEvent {
     _eventMetadata = null;
   }
 
-  private CoordinatorEvent(EventType eventType, Object eventMetadata) {
+  protected CoordinatorEvent(EventType eventType, Object eventMetadata) {
     _eventType = eventType;
     _eventMetadata = eventMetadata;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -85,6 +85,15 @@ class CoordinatorEventBlockingQueue implements MetricsAware {
    * @param event CoordinatorEvent event to add to the queue
    */
   public synchronized void putFirst(CoordinatorEvent event) {
+    // If the requested event is already in the CoordinatorEventBlockingQueue, it will be removed to prioritize the
+    // event to be putFirst.
+    if (_eventSet.contains(event)) {
+      LOG.info("Prioritizing the event to be putFirst by removing the existing CoordinatorEvent " + event);
+      // Since the distinct content of the CoordinatorEventBlockingQueue is not anticipated to be extensive, the
+      // linear complexity removal operation deemed acceptable.
+      _eventQueue.remove(event);
+      _eventSet.remove(event);
+    }
     put(event, false);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorEventBlockingQueue.java
@@ -81,11 +81,19 @@ class CoordinatorEventBlockingQueue implements MetricsAware {
   }
 
   /**
+   * Add a single event to the queue. Adds the event to the front of the queue.
+   * @param event CoordinatorEvent event to add to the queue
+   */
+  public synchronized void putFirst(CoordinatorEvent event) {
+    put(event, false);
+  }
+
+  /**
    * Add a single event to the queue, de-duping events with the same name and same metadata.
    * @param event CoordinatorEvent event to add to the queue
    * @param insertInTheEnd if true, indicates to add the event to the end of the queue and front, otherwise.
    */
-  public synchronized void put(CoordinatorEvent event, boolean insertInTheEnd) {
+  private synchronized void put(CoordinatorEvent event, boolean insertInTheEnd) {
     LOG.info("Queuing event {} at the " + (insertInTheEnd ? "end" : "front") + " of the event queue", event.getType());
     if (_eventSet.contains(event)) {
       _counter.inc(); // count duplicate event

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -487,7 +487,8 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
     Map<String, DatastreamTask> assignmentsMap = currentAssignment.values()
         .stream()
         .flatMap(Collection::stream)
-        .collect(Collectors.toMap(DatastreamTask::getDatastreamTaskName, Function.identity()));
+        .collect(Collectors.toMap(DatastreamTask::getDatastreamTaskName, Function.identity(),
+            (existingTask, duplicateTask) -> existingTask));
 
     for (String instance : currentAssignment.keySet()) {
       // find the dependency tasks which also exist in the assignmentsMap.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -759,10 +759,11 @@ public class ZkAdapter {
   private Map<DatastreamGroup, Set<String>> getStoppingDatastreamGroupInstances(
       List<DatastreamGroup> stoppingDatastreamGroups) {
     Map<String, Set<DatastreamTask>> currentAssignment = getAllAssignedDatastreamTasks();
-    Set<String> stoppingDatastreamTaskPrefixes = stoppingDatastreamGroups.stream().
-        map(DatastreamGroup::getTaskPrefix).collect(toSet());
-    Map<String, DatastreamGroup> taskPrefixDatastreamGroups = stoppingDatastreamGroups.stream().
-        collect(Collectors.toMap(DatastreamGroup::getTaskPrefix, Function.identity()));
+    Set<String> stoppingDatastreamTaskPrefixes =
+        stoppingDatastreamGroups.stream().map(DatastreamGroup::getTaskPrefix).collect(toSet());
+    Map<String, DatastreamGroup> taskPrefixDatastreamGroups = stoppingDatastreamGroups.stream()
+        .collect(Collectors.toMap(DatastreamGroup::getTaskPrefix, Function.identity(),
+            (existingDatastreamGroup, duplicateDatastreamGroup) -> existingDatastreamGroup));
 
     Map<DatastreamGroup, Set<String>> stoppingDgInstances = new HashMap<>();
     currentAssignment.keySet()

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -42,20 +42,20 @@ public class TestCoordinatorEventBlockingQueue {
   public void testHappyPath() throws Exception {
     CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue(SIMPLE_NAME);
     eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true), false);
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false), true);
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true), false);
     eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
     eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test2"));
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test2"), false);
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
     Assert.assertEquals(eventBlockingQueue.size(), 5);
-    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderDoAssignmentEvent(false));
-    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderDoAssignmentEvent(true));
-    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderPartitionAssignmentEvent("test2"));
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderDoAssignmentEvent(true));
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -42,12 +42,12 @@ public class TestCoordinatorEventBlockingQueue {
   public void testHappyPath() throws Exception {
     CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue(SIMPLE_NAME);
     eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true), false);
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false), true);
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(true), false);
+    eventBlockingQueue.putFirst(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    eventBlockingQueue.putFirst(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
     eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
     eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
-    eventBlockingQueue.put(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test2"), false);
+    eventBlockingQueue.putFirst(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test2"));
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
     eventBlockingQueue.put(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorEventBlockingQueue.java
@@ -59,6 +59,21 @@ public class TestCoordinatorEventBlockingQueue {
     Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
   }
 
+  @Test
+  public void testHappyPathWithDuplicatedPutFirstEventRequests() throws Exception {
+    CoordinatorEventBlockingQueue eventBlockingQueue = new CoordinatorEventBlockingQueue(SIMPLE_NAME);
+    eventBlockingQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+    eventBlockingQueue.putFirst(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
+    eventBlockingQueue.putFirst(CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
+    eventBlockingQueue.putFirst(CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    eventBlockingQueue.putFirst(CoordinatorEvent.createLeaderDoAssignmentEvent(true));
+    Assert.assertEquals(eventBlockingQueue.size(), 4);
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderDoAssignmentEvent(true));
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.HANDLE_ASSIGNMENT_CHANGE_EVENT);
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderPartitionAssignmentEvent("test1"));
+    Assert.assertEquals(eventBlockingQueue.take(), CoordinatorEvent.createLeaderDoAssignmentEvent(false));
+  }
+
   /**
    * Verify metric registration.
    */


### PR DESCRIPTION
## Summary
**Deque Coordinator Queue**
- When a newly elected leader receives an instance-task assignment from ZK, it is expected that the leader will perform a cleanup routine on the assignment. Failure to do so may lead to inconsistencies in task assignment across instances.
- In the event that the cleanup routine encounters an exception, the "LEADER_DO_ASSIGNMENT" event with the "isNewlyElectedLeader" flag enabled must be reinserted at the front of the coordinator queue to ensure that no other events are processed before re-handling the event.

**Bug Fixing toMap() Usage**
- Replace the use of **Collectors.toMap(keyMapper, valueMapper)** in cases where duplicate values may be encountered, with **Collectors.toMap(keyMapper, valueMapper, mergeFunction)**. 

---
Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
