### PR TITLE
Upgrade Pre Assignment Clean Up To Remove Dependency Tasks Across Hosts

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -490,9 +490,8 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
         .collect(Collectors.toMap(DatastreamTask::getDatastreamTaskName, Function.identity(),
             (existingTask, duplicateTask) -> existingTask));
 
-    Set<DatastreamTask> allDependencyTasksInCurrentAssignment = currentAssignment.keySet()
+    Set<DatastreamTask> allDependencyTasksInCurrentAssignment = currentAssignment.values()
         .stream()
-        .map(currentAssignment::get)
         .flatMap(Collection::stream)
         .map(task -> ((DatastreamTaskImpl) task).getDependencies())
         .flatMap(Collection::stream)

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -490,15 +490,22 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
         .collect(Collectors.toMap(DatastreamTask::getDatastreamTaskName, Function.identity(),
             (existingTask, duplicateTask) -> existingTask));
 
+    Set<DatastreamTask> allDependencyTasksInCurrentAssignment = currentAssignment.keySet()
+        .stream()
+        .map(currentAssignment::get)
+        .flatMap(Collection::stream)
+        .map(task -> ((DatastreamTaskImpl) task).getDependencies())
+        .flatMap(Collection::stream)
+        .map(assignmentsMap::get)
+        .filter(Objects::nonNull)
+        .collect(Collectors.toSet());
+
     for (String instance : currentAssignment.keySet()) {
       // find the dependency tasks which also exist in the assignmentsMap.
       List<DatastreamTask> dependencyTasksPerInstance = currentAssignment.get(instance)
           .stream()
           .filter(t -> datastreamGroupsSet.contains(t.getTaskPrefix()))
-          .map(task -> ((DatastreamTaskImpl) task).getDependencies())
-          .flatMap(Collection::stream)
-          .map(assignmentsMap::get)
-          .filter(Objects::nonNull)
+          .filter(allDependencyTasksInCurrentAssignment::contains)
           .collect(Collectors.toList());
 
       if (!dependencyTasksPerInstance.isEmpty()) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignmentStrategy.java
@@ -9,6 +9,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -16,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.jetbrains.annotations.NotNull;
 import org.testng.Assert;
@@ -184,6 +186,42 @@ public class TestStickyPartitionAssignmentStrategy {
       taskToCleanup.forEach((instance, taskList1) -> Assert.assertEquals(taskList1.size(), 3));
       Assert.assertEquals(new HashSet<>(taskToCleanup.get("instance0")), new HashSet<>(assignment.get("instance0")));
     });
+  }
+
+  @Test
+  public void testTaskCleanupAcrossMultipleInstances() {
+    StickyPartitionAssignmentStrategy strategy =
+        createStickyPartitionAssignmentStrategy(3, 90, true, getZkClient(true), _clusterName);
+    List<DatastreamGroup> datastreams = generateDatastreams("testTasksCleanUpWithDuplicatesAcrossInstances", 1, 3);
+
+    Map<String, Set<DatastreamTask>> assignment = generateEmptyAssignment(datastreams, 2, 3, true);
+    assignment.put("instance1", new HashSet<>());
+
+    DatastreamGroupPartitionsMetadata partitionsMetadata =
+        new DatastreamGroupPartitionsMetadata(datastreams.get(0), ImmutableList.of("t-0", "t-1", "t1-0"));
+
+    assignment = strategy.assignPartitions(assignment, partitionsMetadata);
+
+    DatastreamGroupPartitionsMetadata newPartitionsMetadata = new DatastreamGroupPartitionsMetadata(datastreams.get(0),
+        ImmutableList.of("t-0", "t-1", "t1-0", "t2-0", "t2-1", "t2-2"));
+
+    Map<String, Set<DatastreamTask>> newAssignment = strategy.assignPartitions(assignment, newPartitionsMetadata);
+
+    // Adding the dependency task as well in the assignment list to simulate the scenario where
+    // the dependency task nodes are not deleted and the leader gets interrupted, OOM, hit session expiry or
+    // in some bad assignment state.
+    // The next leader should be able to identify and cleanup.
+    Map<String, Set<DatastreamTask>> finalAssignment = assignment;
+
+    // The dependency tasks went to other host as well due to bad assignment, and the next leader should
+    // handle this as well.
+    newAssignment.forEach((instance, taskSet1) -> taskSet1.addAll(
+        finalAssignment.values().stream().flatMap(Collection::stream).collect(Collectors.toList())));
+
+    Map<String, List<DatastreamTask>> taskToCleanup = strategy.getTasksToCleanUp(datastreams, newAssignment);
+    Assert.assertEquals(taskToCleanup.size(), 2);
+    taskToCleanup.forEach((instance, taskList1) -> Assert.assertEquals(taskList1.size(), 3));
+    Assert.assertEquals(new HashSet<>(taskToCleanup.get("instance0")), new HashSet<>(assignment.get("instance0")));
   }
 
   @Test

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestStickyPartitionAssignmentStrategy.java
@@ -189,10 +189,10 @@ public class TestStickyPartitionAssignmentStrategy {
   }
 
   @Test
-  public void testTaskCleanupAcrossMultipleInstances() {
+  public void testTaskCleanUpAcrossMultipleInstances() {
     StickyPartitionAssignmentStrategy strategy =
         createStickyPartitionAssignmentStrategy(3, 90, true, getZkClient(true), _clusterName);
-    List<DatastreamGroup> datastreams = generateDatastreams("testTasksCleanUpWithDuplicatesAcrossInstances", 1, 3);
+    List<DatastreamGroup> datastreams = generateDatastreams("testTaskCleanUpAcrossMultipleInstances", 1, 3);
 
     Map<String, Set<DatastreamTask>> assignment = generateEmptyAssignment(datastreams, 2, 3, true);
     assignment.put("instance1", new HashSet<>());


### PR DESCRIPTION
## Summary
- When a newly elected leader receives an instance-task assignment from ZK, it is expected that the leader will perform a cleanup routine on the assignment. Failure to do so may lead to inconsistencies in task assignment across instances.
- At present, the pre-assignment cleanup only checks for dependency tasks in the current host's assignment and cleans them up accordingly. This process does not extend to other hosts, meaning that if the same task (a dependency list task) is assigned to another host, due to any unforeseen circumstances, it will not be cleaned up.
- This is not a bug, rather it is a safety measure to restore the assignments in the event of a new leader being elected following a bad task assignment.

___

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
