### PR TITLE
Fixing Flaky Test testLeaderDoAssignmentForNewlyElectedLeaderFailurePathVariation

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4062,6 +4062,8 @@ public class TestCoordinator {
     Datastream testDatastream =
         DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, streamName)[0];
 
+    // Blocking until we have performed atleast 5 retries of LeaderDoAssignmentEvent with a newly elected leader.
+    PollUtils.poll(() -> shadowListWithPreviousAndNewHeadPairsAtNewLeaderDoAssignmentEvent.size() > 5, 50, 2000);
     coordinator.stop();
     zkClient.close();
     coordinator.getDatastreamCache().getZkclient().close();


### PR DESCRIPTION
## Summary
- Waiting off until we have completed 5 retries, to ensure that we do not encounter an index out of bounds error in the event that the coordinator stops operations prior to completing the necessary retries.
- Saw a similar error on this Circle CI attempt: https://app.circleci.com/pipelines/github/linkedin/brooklin/902/workflows/59a34317-9b59-4386-89f2-c70aa76340bf/jobs/3243 
___
Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
