### PR TITLE
Quick Optimization For Partition Assignors

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
@@ -91,7 +91,7 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
         tasks.forEach(task -> {
           if (task.getTaskPrefix().equals(datastreamGroupName)) {
             Set<String> retainedPartitions = new HashSet<>(task.getPartitionsV2());
-            retainedPartitions.retainAll(partitionMetadata.getPartitions());
+            retainedPartitions.retainAll(new HashSet<>(partitionMetadata.getPartitions()));
             newPartitionAssignmentMap.put(task.getId(), retainedPartitions);
             if (retainedPartitions.size() != task.getPartitionsV2().size()) {
               tasksWithChangedPartition.add(task.getId());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -262,7 +262,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
           return task;
         } else {
           Set<String> newPartitions = new HashSet<>(task.getPartitionsV2());
-          newPartitions.retainAll(datastreamPartitions.getPartitions());
+          newPartitions.retainAll(new HashSet<>(datastreamPartitions.getPartitions()));
 
           //We need to create new task if the partition is changed
           boolean partitionChanged = newPartitions.size() != task.getPartitionsV2().size();
@@ -332,7 +332,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
 
     Set<String> allToReassignPartitions = new HashSet<>();
     targetAssignment.values().forEach(allToReassignPartitions::addAll);
-    allToReassignPartitions.retainAll(partitionsMetadata.getPartitions());
+    allToReassignPartitions.retainAll(new HashSet<>(partitionsMetadata.getPartitions()));
 
     // construct a map to store the tasks and if it contain the partitions that can be released
     // map: <source taskName, partitions that need to be released>


### PR DESCRIPTION
## Summary
- The coordinator thread should be able to finish any event in less than the configured heartbeat period (default 1 minute). Lately it has been observed that all the partition assignment events are taking more than approximately 1.5 minutes to complete for every request for large clusters with around ~500K partitions per datastream.

- The issue seems to be related to [this code](https://github.com/linkedin/brooklin/blob/a67108bcff9e3c8f5c22dbc44e04f91f200cc1cc/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java#L93) where the thread is stuck in the retainAll call, where one of the collections is a list. This may result in higher CPU usage.

- This has been confirmed with thread dumps and logs in an internal RC document. 
___

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
