### PR TITLE
Added new class to help log assignments

### DIFF
--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/mirrormaker/TestKafkaMirrorMakerConnectorTask.java
@@ -96,6 +96,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
 
   private static final long CONNECTOR_AWAIT_STOP_TIMEOUT_MS = 30000;
   private static final long DEBOUNCE_TIMER_MS = 1000;
+  private static final double LOG_SIZE_LIMIT_IN_BYTES = 1024;
   private static final Logger LOG = LoggerFactory.getLogger(TestKafkaMirrorMakerConnectorTask.class);
 
   @Test
@@ -1084,7 +1085,7 @@ public class TestKafkaMirrorMakerConnectorTask extends BaseKafkaZkTest {
   private void createAndConnectZkAdapter(DatastreamTaskImpl task) {
     ZkAdapter zkAdapter =
         new ZkAdapter(_kafkaCluster.getZkConnection(), "testCluster", null, ZkClient.DEFAULT_SESSION_TIMEOUT,
-            ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, null);
+            ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, LOG_SIZE_LIMIT_IN_BYTES, null);
     task.setZkAdapter(zkAdapter);
     zkAdapter.connect();
   }

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2971,7 +2971,7 @@ public class TestCoordinator {
     ZkAdapter createZkAdapter() {
       return spy(new ZkAdapter(getConfig().getZkAddress(), getConfig().getCluster(),
           getConfig().getDefaultTransportProviderName(), getConfig().getZkSessionTimeout(),
-          getConfig().getZkConnectionTimeout(), 1000, this));
+          getConfig().getZkConnectionTimeout(), 1000, 1024 * 1024, this));
     }
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -18,14 +18,15 @@ import static com.linkedin.datastream.common.LogUtils.logStringsUnderSizeLimit;
  */
 public class AssignmentTaskMapLogger {
   private final Logger _log;
-  public static final double SIZE_LIMIT_BYTES = 1024 * 1024;
+  private double _sizeLimit;
 
   /**
    * Constructor
    * @param logger logger to be used for logging
    */
-  public AssignmentTaskMapLogger(Logger logger) {
+  public AssignmentTaskMapLogger(Logger logger, double logSizeLimitInBytes) {
     _log = logger;
+    _sizeLimit = logSizeLimitInBytes;
   }
 
   /**
@@ -35,7 +36,7 @@ public class AssignmentTaskMapLogger {
     for (String host: taskMap.keySet()) {
       for (DatastreamTask task: taskMap.get(host)) {
         String logContext = String.format("Host=%s: Live task", host);
-        logStringsUnderSizeLimit(_log, task.toString(), logContext, 1, SIZE_LIMIT_BYTES);
+        logStringsUnderSizeLimit(_log, task.toString(), logContext, 1, _sizeLimit);
       }
     }
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -5,13 +5,12 @@
  */
 package com.linkedin.datastream.server;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
-
-import com.linkedin.datastream.common.zk.ZkClient;
 
 
 /**
@@ -66,7 +65,7 @@ public class AssignmentTaskMapLogger {
    */
   private double getBlobSizeInBytes(String task) {
     if (Objects.nonNull(task) && !task.isEmpty()) {
-      return (task.getBytes(ZkClient.ZK_STRING_SERIALIZER_CHARSET).length);
+      return (task.getBytes(StandardCharsets.UTF_8).length);
     }
     return 0;
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -19,10 +19,9 @@ import com.linkedin.datastream.common.zk.ZkClient;
  */
 public class AssignmentTaskMapLogger {
   private final Logger _log;
-  private static final double ONE_MEBIBYTE = 1024 * 1024;
-  private static final double ONE_MB = 1.0;
-  private static final double BUFFER_1KB =  1.0 / 1024.0;
-  private static final int BUFFER_ADJUSTED_1MB = 1024 * 1020;
+  public static final double SIZE_LIMIT_BYTES = 1024 * 1024;
+  private static final double BUFFER_1KB =  1024;
+  private static final int BUFFER_ADJUSTED_LIMIT = (int) (SIZE_LIMIT_BYTES - BUFFER_1KB);
 
   /**
    * Constructor
@@ -44,41 +43,41 @@ public class AssignmentTaskMapLogger {
   }
 
   /**
-   * prints one log line for each task less than 1MB in size
+   * prints one log line for each task smaller than size limit
    * @param task
    */
   private void logTask(String task, String host, int part) {
-    if (isLessThan1MB(task)) {
+    if (isLessThanSizeLimit(task)) {
       if (part == 1) {
         _log.info("Host={}: Live task={}", host, task);
       } else {
         _log.info("Host={}: Live task (part {})={}", host, part, task);
       }
     } else {
-      _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, BUFFER_ADJUSTED_1MB));
-      logTask(task.substring(BUFFER_ADJUSTED_1MB), host, part + 1);
+      _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, BUFFER_ADJUSTED_LIMIT));
+      logTask(task.substring(BUFFER_ADJUSTED_LIMIT), host, part + 1);
     }
   }
 
   /**
-   * helper function to get the size of a task in string form (default charset UTF) in MBs
+   * helper function to get the size of a task in string form (default charset UTF) in bytes
    * @param task string form of task to measure
-   * @return size of task in MBS
+   * @return size of task in bytes
    */
-  private double getBlobSizeInMBs(String task) {
+  private double getBlobSizeInBytes(String task) {
     if (Objects.nonNull(task) && !task.isEmpty()) {
-      return ((double) task.getBytes(ZkClient.ZK_STRING_SERIALIZER_CHARSET).length) / ONE_MEBIBYTE;
+      return (task.getBytes(ZkClient.ZK_STRING_SERIALIZER_CHARSET).length);
     }
     return 0;
   }
 
   /**
-   * helper function to check if an object is less than 1 MB in size
+   * helper function to check if task size is less than size limit
    * @param task task to check size of
-   * @return true if object is less than 1MB in size
+   * @return true if object is less than size limit
    */
-  private boolean isLessThan1MB(String task) {
-    double sizeInMB = getBlobSizeInMBs(task);
-    return sizeInMB + BUFFER_1KB < ONE_MB;
+  private boolean isLessThanSizeLimit(String task) {
+    double sizeInMB = getBlobSizeInBytes(task);
+    return sizeInMB + BUFFER_1KB < SIZE_LIMIT_BYTES;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -23,6 +23,7 @@ public class AssignmentTaskMapLogger {
   /**
    * Constructor
    * @param logger logger to be used for logging
+   * @param logSizeLimitInBytes size limit for each log line in bytes
    */
   public AssignmentTaskMapLogger(Logger logger, double logSizeLimitInBytes) {
     _log = logger;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -5,12 +5,13 @@
  */
 package com.linkedin.datastream.server;
 
-import com.linkedin.datastream.common.zk.ZkClient;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
+
+import com.linkedin.datastream.common.zk.ZkClient;
 
 
 /**

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -5,22 +5,20 @@
  */
 package com.linkedin.datastream.server;
 
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
 
+import static com.linkedin.datastream.common.LogUtils.logStringsUnderSizeLimit;
+
 
 /**
- * Class that logs assignments one task at a time, keeping each log line under 1 MB in size
+ * Class that logs assignments one task at a time, keeping each log line under a size limit
  */
 public class AssignmentTaskMapLogger {
   private final Logger _log;
   public static final double SIZE_LIMIT_BYTES = 1024 * 1024;
-  private static final double BUFFER_1KB =  1024;
-  private static final int BUFFER_ADJUSTED_LIMIT = (int) (SIZE_LIMIT_BYTES - BUFFER_1KB);
 
   /**
    * Constructor
@@ -36,47 +34,9 @@ public class AssignmentTaskMapLogger {
   public void logAssignment(Map<String, Set<DatastreamTask>> taskMap) {
     for (String host: taskMap.keySet()) {
       for (DatastreamTask task: taskMap.get(host)) {
-        logTask(task.toString(), host, 1);
+        String logContext = String.format("Host=%s: Live task", host);
+        logStringsUnderSizeLimit(_log, task.toString(), logContext, 1, SIZE_LIMIT_BYTES);
       }
     }
-  }
-
-  /**
-   * prints one log line for each task smaller than size limit
-   * @param task
-   */
-  private void logTask(String task, String host, int part) {
-    if (isLessThanSizeLimit(task)) {
-      if (part == 1) {
-        _log.info("Host={}: Live task={}", host, task);
-      } else {
-        _log.info("Host={}: Live task (part {})={}", host, part, task);
-      }
-    } else {
-      _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, BUFFER_ADJUSTED_LIMIT));
-      logTask(task.substring(BUFFER_ADJUSTED_LIMIT), host, part + 1);
-    }
-  }
-
-  /**
-   * helper function to get the size of a task in string form (default charset UTF) in bytes
-   * @param task string form of task to measure
-   * @return size of task in bytes
-   */
-  private double getBlobSizeInBytes(String task) {
-    if (Objects.nonNull(task) && !task.isEmpty()) {
-      return (task.getBytes(StandardCharsets.UTF_8).length);
-    }
-    return 0;
-  }
-
-  /**
-   * helper function to check if task size is less than size limit
-   * @param task task to check size of
-   * @return true if object is less than size limit
-   */
-  private boolean isLessThanSizeLimit(String task) {
-    double sizeInMB = getBlobSizeInBytes(task);
-    return sizeInMB + BUFFER_1KB < SIZE_LIMIT_BYTES;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -5,9 +5,9 @@
  */
 package com.linkedin.datastream.server;
 
-import java.io.ByteArrayOutputStream;
-import java.io.ObjectOutputStream;
+import com.linkedin.datastream.common.zk.ZkClient;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -17,27 +17,26 @@ import org.slf4j.Logger;
  * Class that logs assignments one task at a time, keeping each log line under 1 MB in size
  */
 public class AssignmentTaskMapLogger {
-  private final Map<String, Set<DatastreamTask>> _taskMap;
   private final Logger _log;
+  private static final double ONE_MEBIBYTE = 1024 * 1024;
+  private static final double ONE_MB = 1.0;
   private static final double BUFFER_1KB =  1.0 / 1024.0;
-  private static final int NUM_OF_CHAR_IN_1MB = 1024 * 1024 / 2;
+  private static final int BUFFER_ADJUSTED_1MB = 1024 * 1020;
 
   /**
    * Constructor
-   * @param taskMap assignment to be logged
    * @param logger logger to be used for logging
    */
-  public AssignmentTaskMapLogger(Map<String, Set<DatastreamTask>> taskMap, Logger logger) {
-    _taskMap = taskMap;
+  public AssignmentTaskMapLogger(Logger logger) {
     _log = logger;
   }
 
   /**
    * logs assigned tasks for each host
    */
-  public void logAssignment() {
-    for (String host: _taskMap.keySet()) {
-      for (DatastreamTask task: _taskMap.get(host)) {
+  public void logAssignment(Map<String, Set<DatastreamTask>> taskMap) {
+    for (String host: taskMap.keySet()) {
+      for (DatastreamTask task: taskMap.get(host)) {
         logTask(task.toString(), host, 1);
       }
     }
@@ -47,46 +46,38 @@ public class AssignmentTaskMapLogger {
    * prints one log line for each task less than 1MB in size
    * @param task
    */
-  public void logTask(String task, String host, int part) {
-    try {
-      if (isLessThan1MB(task)) {
-        if (part == 1) {
-          _log.info("Host={}: Live task={}", host, part, task);
-        } else {
-          _log.info("Host={}: Live task (part {})={}", host, part, task);
-        }
+  private void logTask(String task, String host, int part) {
+    if (isLessThan1MB(task)) {
+      if (part == 1) {
+        _log.info("Host={}: Live task={}", host, task);
       } else {
-        _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, NUM_OF_CHAR_IN_1MB));
-        logTask(task.substring(NUM_OF_CHAR_IN_1MB), host, part + 1);
+        _log.info("Host={}: Live task (part {})={}", host, part, task);
       }
-    } catch (Exception e) {
-      throw new RuntimeException(e);
+    } else {
+      _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, BUFFER_ADJUSTED_1MB));
+      logTask(task.substring(BUFFER_ADJUSTED_1MB), host, part + 1);
     }
   }
 
   /**
-   * helper function to serialize object for size measurement
-   * @param obj object to serialize
-   * @return serialized byte array of object
-   * @throws Exception
+   * helper function to get the size of a task in string form (default charset UTF) in MBs
+   * @param task string form of task to measure
+   * @return size of task in MBS
    */
-  public byte[] serializeObject(Object obj) throws Exception {
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    ObjectOutputStream out = new ObjectOutputStream(bos);
-    out.writeObject(obj);
-    out.flush();
-    return bos.toByteArray();
+  private double getBlobSizeInMBs(String task) {
+    if (Objects.nonNull(task) && !task.isEmpty()) {
+      return ((double) task.getBytes(ZkClient.ZK_STRING_SERIALIZER_CHARSET).length) / ONE_MEBIBYTE;
+    }
+    return 0;
   }
 
   /**
    * helper function to check if an object is less than 1 MB in size
-   * @param obj object to check size of
+   * @param task task to check size of
    * @return true if object is less than 1MB in size
-   * @throws Exception
    */
-  public boolean isLessThan1MB(Object obj) throws Exception {
-    byte[] serializedData = serializeObject(obj);
-    double sizeInMB = serializedData.length / 1024.0 / 1024.0;
-    return sizeInMB + BUFFER_1KB < 1.0;
+  private boolean isLessThan1MB(String task) {
+    double sizeInMB = getBlobSizeInMBs(task);
+    return sizeInMB + BUFFER_1KB < ONE_MB;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -1,0 +1,90 @@
+/**
+ *  Copyright 2023 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server;
+
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectOutputStream;
+import java.util.Map;
+import java.util.Set;
+
+import org.slf4j.Logger;
+
+
+/**
+ * Class that logs assignments one task at a time, keeping each log line under 1 MB in size
+ */
+public class AssignmentTaskMapLogger {
+  private final Map<String, Set<DatastreamTask>> _taskMap;
+  private final Logger _log;
+
+  /**
+   * Constructor
+   * @param taskMap assignment to be logged
+   * @param logger logger to be used for logging
+   */
+  public AssignmentTaskMapLogger(Map<String, Set<DatastreamTask>> taskMap, Logger logger) {
+    _taskMap = taskMap;
+    _log = logger;
+  }
+
+  /**
+   * logs assigned tasks for each host
+   */
+  public void logAssignment() {
+    for (String host: _taskMap.keySet()) {
+      for (DatastreamTask task: _taskMap.get(host)) {
+        logTask(task.toString(), host, 1);
+      }
+    }
+  }
+
+  /**
+   * prints one log line for each task less than 1MB in size
+   * @param task
+   */
+  public void logTask(String task, String host, int part) {
+    try {
+      if (isLessThan1MB(task)) {
+        if (part == 1) {
+          _log.info("Host={}: Live task={}", host, part, task);
+        } else {
+          _log.info("Host={}: Live task (part {})={}", host, part, task);
+        }
+      } else {
+        _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, 1024 * 1024));
+        logTask(task.substring(1024 * 1024), host, part + 1);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * helper function to serialize object for size measurement
+   * @param obj object to serialize
+   * @return serialized byte array of object
+   * @throws Exception
+   */
+  public byte[] serializeObject(Object obj) throws Exception {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    ObjectOutputStream out = new ObjectOutputStream(bos);
+    out.writeObject(obj);
+    out.flush();
+    return bos.toByteArray();
+  }
+
+  /**
+   * helper function to check if an object is less than 1 MB in size
+   * @param obj object to check size of
+   * @return true if object is less than 1MB in size
+   * @throws Exception
+   */
+  public boolean isLessThan1MB(Object obj) throws Exception {
+    byte[] serializedData = serializeObject(obj);
+    double sizeInMB = serializedData.length / 1024.0 / 1024.0;
+    return sizeInMB < 1.0;
+  }
+}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -36,7 +36,7 @@ public class AssignmentTaskMapLogger {
     for (String host: taskMap.keySet()) {
       for (DatastreamTask task: taskMap.get(host)) {
         String logContext = String.format("Host=%s: Live task", host);
-        logStringsUnderSizeLimit(_log, task.toString(), logContext, 1, _sizeLimit);
+        logStringsUnderSizeLimit(_log, task.toString(), logContext, _sizeLimit);
       }
     }
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/AssignmentTaskMapLogger.java
@@ -19,6 +19,8 @@ import org.slf4j.Logger;
 public class AssignmentTaskMapLogger {
   private final Map<String, Set<DatastreamTask>> _taskMap;
   private final Logger _log;
+  private static final double BUFFER_1KB =  1.0 / 1024.0;
+  private static final int NUM_OF_CHAR_IN_1MB = 1024 * 1024 / 2;
 
   /**
    * Constructor
@@ -54,8 +56,8 @@ public class AssignmentTaskMapLogger {
           _log.info("Host={}: Live task (part {})={}", host, part, task);
         }
       } else {
-        _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, 1024 * 1024));
-        logTask(task.substring(1024 * 1024), host, part + 1);
+        _log.info("Host={}: Live task (part {})={}", host, part, task.substring(0, NUM_OF_CHAR_IN_1MB));
+        logTask(task.substring(NUM_OF_CHAR_IN_1MB), host, part + 1);
       }
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -85,6 +87,6 @@ public class AssignmentTaskMapLogger {
   public boolean isLessThan1MB(Object obj) throws Exception {
     byte[] serializedData = serializeObject(obj);
     double sizeInMB = serializedData.length / 1024.0 / 1024.0;
-    return sizeInMB < 1.0;
+    return sizeInMB + BUFFER_1KB < 1.0;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1696,8 +1696,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         newAssignmentsByInstance.put(key, new ArrayList<>(assignmentByInstance.get(key)));
       }
       _adapter.updateAllAssignments(newAssignmentsByInstance);
-      _log.info("Partition assignment completed: datastreamGroup {}, assignment {} ", datastreamGroupName,
-          assignmentByInstance);
+      _log.info("Partition assignment completed for datastreamGroup {}, logging assignment...", datastreamGroupName);
+      AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(assignmentByInstance, _log);
+      assignmentLogger.logAssignment();
       succeeded = true;
     } catch (Exception ex) {
       _log.warn("Partition assignment failed, Exception: ", ex);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -275,7 +275,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   @VisibleForTesting
   ZkAdapter createZkAdapter() {
     return new ZkAdapter(_config.getZkAddress(), _clusterName, _config.getDefaultTransportProviderName(),
-        _config.getZkSessionTimeout(), _config.getZkConnectionTimeout(), _config.getDebounceTimerMs(), this);
+        _config.getZkSessionTimeout(), _config.getZkConnectionTimeout(), _config.getDebounceTimerMs(),
+        _config.getLogSizeLimitInBytes(), this);
   }
 
   /**
@@ -1697,7 +1698,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       }
       _adapter.updateAllAssignments(newAssignmentsByInstance);
       _log.info("Partition assignment completed for datastreamGroup {}, logging assignment...", datastreamGroupName);
-      AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(_log);
+      AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(_log, _config.getLogSizeLimitInBytes());
       assignmentLogger.logAssignment(assignmentByInstance);
       succeeded = true;
     } catch (Exception ex) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1697,8 +1697,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       }
       _adapter.updateAllAssignments(newAssignmentsByInstance);
       _log.info("Partition assignment completed for datastreamGroup {}, logging assignment...", datastreamGroupName);
-      AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(assignmentByInstance, _log);
-      assignmentLogger.logAssignment();
+      AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(_log);
+      assignmentLogger.logAssignment(assignmentByInstance);
       succeeded = true;
     } catch (Exception ex) {
       _log.warn("Partition assignment failed, Exception: ", ex);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -47,6 +47,7 @@ public final class CoordinatorConfig {
   public static final String CONFIG_MARK_DATASTREAMS_STOPPED_RETRY_PERIOD_MS = PREFIX + "markDatastreamsStoppedRetryPeriodMs";
 
   public static final String CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING = PREFIX + "enableThroughputViolatingTopicsHandling";
+  public static final String CONFIG_LOG_SIZE_LIMIT_IN_BYTES = PREFIX + "logSizeLimitInBytes";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
@@ -54,6 +55,7 @@ public final class CoordinatorConfig {
   public static final long DEFAULT_TASK_STOP_CHECK_RETRY_PERIOD_MS = 10 * 1000;
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS = 60 * 1000;
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS = 10 * 1000;
+  public static final int DEFAULT_LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
 
   private final String _cluster;
   private final String _zkAddress;
@@ -79,6 +81,7 @@ public final class CoordinatorConfig {
   private final long _markDatastreamsStoppedTimeoutMs;
   private final long _markDatastreamsStoppedRetryPeriodMs;
   private final boolean _enableThroughputViolatingTopicsHandling;
+  private final double _logSizeLimitInBytes;
 
 
   /**
@@ -117,6 +120,7 @@ public final class CoordinatorConfig {
         DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS);
     _enableThroughputViolatingTopicsHandling = _properties.getBoolean(
         CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, false);
+    _logSizeLimitInBytes = _properties.getDouble(CONFIG_LOG_SIZE_LIMIT_IN_BYTES, DEFAULT_LOG_SIZE_LIMIT_IN_BYTES);
   }
 
   public Properties getConfigProperties() {
@@ -211,5 +215,9 @@ public final class CoordinatorConfig {
 
   public long getMarkDatastreamsStoppedRetryPeriodMs() {
     return _markDatastreamsStoppedRetryPeriodMs;
+  }
+
+  public double getLogSizeLimitInBytes() {
+    return _logSizeLimitInBytes;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -27,6 +27,7 @@ import com.linkedin.datastream.common.zk.ZkClient;
 import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
+import com.linkedin.datastream.server.AssignmentTaskMapLogger;
 import com.linkedin.datastream.server.ClusterThroughputInfo;
 import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamGroupPartitionsMetadata;
@@ -111,7 +112,9 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
         currentAssignment, datastreamGroupName);
     List<String> assignedPartitions = assignedPartitionsAndTaskCount.getKey();
     int taskCount = assignedPartitionsAndTaskCount.getValue();
-    LOG.info("Old partition assignment info, assignment: {}", currentAssignment);
+    LOG.info("Logging old partition assignment info...");
+    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(currentAssignment, LOG);
+    assignmentLogger.logAssignment();
     Validate.isTrue(taskCount > 0, String.format("No tasks found for datastream group %s", datastreamGroup));
     Validate.isTrue(currentAssignment.size() > 0,
         "Zero tasks assigned. Retry leader partition assignment");

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -113,8 +113,8 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     List<String> assignedPartitions = assignedPartitionsAndTaskCount.getKey();
     int taskCount = assignedPartitionsAndTaskCount.getValue();
     LOG.info("Logging old partition assignment info...");
-    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(currentAssignment, LOG);
-    assignmentLogger.logAssignment();
+    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(LOG);
+    assignmentLogger.logAssignment(currentAssignment);
     Validate.isTrue(taskCount > 0, String.format("No tasks found for datastream group %s", datastreamGroup));
     Validate.isTrue(currentAssignment.size() > 0,
         "Zero tasks assigned. Retry leader partition assignment");

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategyConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategyConfig.java
@@ -23,6 +23,7 @@ public class LoadBasedPartitionAssignmentStrategyConfig extends PartitionAssignm
   public static final String CFG_ENABLE_PARTITION_NUM_BASED_TASK_COUNT_ESTIMATION = "enablePartitionNumBasedTaskCountEstimation";
   public static final String CFG_DEFAULT_PARTITION_BYTES_IN_KB_RATE = "defaultPartitionBytesInKBRate";
   public static final String CFG_DEFAULT_PARTITION_MSGS_IN_RATE = "defaultPartitionMsgsInRate";
+  public static final String CFG_LOG_SIZE_LIMIT_IN_BYTES = "logSizeLimitInBytes";
 
   private static final int DEFAULT_THROUGHPUT_INFO_FETCH_TIMEOUT_MS = (int) Duration.ofSeconds(10).toMillis();
   private static final int DEFAULT_THROUGHPUT_INFO_FETCH_RETRY_PERIOD_MS = (int) Duration.ofSeconds(1).toMillis();
@@ -32,6 +33,7 @@ public class LoadBasedPartitionAssignmentStrategyConfig extends PartitionAssignm
   private static final boolean DEFAULT_ENABLE_PARTITION_NUM_BASED_TASK_COUNT_ESTIMATION = false;
   private static final int DEFAULT_PARTITION_BYTES_IN_KB_RATE = 5;
   private static final int DEFAULT_PARTITION_MSGS_IN_RATE = 5;
+  private static final double DEFAULT_LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
 
 
   private final int _taskCapacityMBps;
@@ -42,6 +44,7 @@ public class LoadBasedPartitionAssignmentStrategyConfig extends PartitionAssignm
   private final boolean _enablePartitionNumBasedTaskCountEstimation;
   private final int _defaultPartitionBytesInKBRate;
   private final int _defaultPartitionMsgsInRate;
+  private final double _logSizeLimitInBytes;
 
   /**
    * Creates an instance of {@link LoadBasedPartitionAssignmentStrategyConfig}
@@ -60,6 +63,7 @@ public class LoadBasedPartitionAssignmentStrategyConfig extends PartitionAssignm
         DEFAULT_ENABLE_PARTITION_NUM_BASED_TASK_COUNT_ESTIMATION);
     _defaultPartitionBytesInKBRate = props.getInt(CFG_DEFAULT_PARTITION_BYTES_IN_KB_RATE, DEFAULT_PARTITION_BYTES_IN_KB_RATE);
     _defaultPartitionMsgsInRate = props.getInt(CFG_DEFAULT_PARTITION_MSGS_IN_RATE, DEFAULT_PARTITION_MSGS_IN_RATE);
+    _logSizeLimitInBytes = props.getDouble(CFG_LOG_SIZE_LIMIT_IN_BYTES, DEFAULT_LOG_SIZE_LIMIT_IN_BYTES);
   }
 
   /**
@@ -116,5 +120,9 @@ public class LoadBasedPartitionAssignmentStrategyConfig extends PartitionAssignm
 
   public int getDefaultPartitionMsgsInRate() {
     return _defaultPartitionMsgsInRate;
+  }
+
+  public double getLogSizeLimitInBytes() {
+    return _logSizeLimitInBytes;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategyFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategyFactory.java
@@ -45,7 +45,7 @@ public class LoadBasedPartitionAssignmentStrategyFactory extends StickyPartition
         config.getTaskCapacityUtilizationPct(), config.getThroughputInfoFetchTimeoutMs(),
         config.getThroughputInfoFetchRetryPeriodMs(), zkClient, _config.getCluster(),
         config.isEnableThroughputBasedPartitionAssignment(), config.isEnablePartitionNumBasedTaskCountEstimation(),
-        config.getDefaultPartitionBytesInKBRate(), config.getDefaultPartitionMsgsInRate());
+        config.getDefaultPartitionBytesInKBRate(), config.getDefaultPartitionMsgsInRate(), config.getLogSizeLimitInBytes());
   }
 
   protected PartitionThroughputProvider constructPartitionThroughputProvider() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -202,6 +202,7 @@ public class ZkAdapter {
    * @param defaultTransportProviderName Default transport provider to use for a newly created task
    * @param sessionTimeoutMs Session timeout to use for the connection with the ZooKeeper server
    * @param connectionTimeoutMs Connection timeout to use for the connection with the ZooKeeper server
+   * @param logSizeLimitInBytes size limit for each log line in bytes
    * @param listener ZKAdapterListener implementation to receive callbacks based on various znode changes
    */
   @VisibleForTesting

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -612,8 +612,8 @@ public class ZkAdapter {
    */
   public Map<String, Set<DatastreamTask>> getAllAssignedDatastreamTasks() {
     LOG.info("Logging all live tasks...");
-    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(_liveTaskMap, LOG);
-    assignmentLogger.logAssignment();
+    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(LOG);
+    assignmentLogger.logAssignment(_liveTaskMap);
     return new HashMap<>(_liveTaskMap);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -133,6 +133,7 @@ public class ZkAdapter {
   private final int _connectionTimeoutMs;
   private final int _operationRetryTimeoutMs;
   private final long _debounceTimerMs;
+  private final double _logSizeLimitInBytes;
 
   private ZkClient _zkclient;
   private String _instanceName;
@@ -177,16 +178,19 @@ public class ZkAdapter {
    * @param operationRetryTimeoutMs Timeout to use for retrying failed retriable operations. A value lesser than 0 is
    *                         considered as retry forever until a connection has been reestablished.
    * @param debounceTimerMs debounce timer to be used to delay the lock clean up.
+   * @param logSizeLimitInBytes size limit of log messages in bytes
    * @param listener ZKAdapterListener implementation to receive callbacks based on various znode changes
    */
   public ZkAdapter(String zkServers, String cluster, String defaultTransportProviderName, int sessionTimeoutMs,
-      int connectionTimeoutMs, int operationRetryTimeoutMs, long debounceTimerMs, ZkAdapterListener listener) {
+      int connectionTimeoutMs, int operationRetryTimeoutMs, long debounceTimerMs, double logSizeLimitInBytes,
+      ZkAdapterListener listener) {
     _zkServers = zkServers;
     _cluster = cluster;
     _sessionTimeoutMs = sessionTimeoutMs;
     _connectionTimeoutMs = connectionTimeoutMs;
     _operationRetryTimeoutMs = operationRetryTimeoutMs;
     _debounceTimerMs = debounceTimerMs;
+    _logSizeLimitInBytes = logSizeLimitInBytes;
     _listener = listener;
     _defaultTransportProviderName = defaultTransportProviderName;
   }
@@ -202,9 +206,9 @@ public class ZkAdapter {
    */
   @VisibleForTesting
   public ZkAdapter(String zkServers, String cluster, String defaultTransportProviderName, int sessionTimeoutMs,
-      int connectionTimeoutMs, long debounceTimerMs, ZkAdapterListener listener) {
+      int connectionTimeoutMs, long debounceTimerMs, double logSizeLimitInBytes, ZkAdapterListener listener) {
     this(zkServers, cluster, defaultTransportProviderName, sessionTimeoutMs, connectionTimeoutMs, -1,
-        debounceTimerMs, listener);
+        debounceTimerMs, logSizeLimitInBytes, listener);
   }
 
   /**
@@ -612,7 +616,7 @@ public class ZkAdapter {
    */
   public Map<String, Set<DatastreamTask>> getAllAssignedDatastreamTasks() {
     LOG.info("Logging all live tasks...");
-    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(LOG);
+    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(LOG, _logSizeLimitInBytes);
     assignmentLogger.logAssignment(_liveTaskMap);
     return new HashMap<>(_liveTaskMap);
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -49,6 +49,7 @@ import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamUtils;
 import com.linkedin.datastream.common.ErrorLogger;
 import com.linkedin.datastream.common.zk.ZkClient;
+import com.linkedin.datastream.server.AssignmentTaskMapLogger;
 import com.linkedin.datastream.server.AssignmentToken;
 import com.linkedin.datastream.server.DatastreamGroup;
 import com.linkedin.datastream.server.DatastreamTask;
@@ -610,7 +611,9 @@ public class ZkAdapter {
    * have been cleaned up after each task reassignment.
    */
   public Map<String, Set<DatastreamTask>> getAllAssignedDatastreamTasks() {
-    LOG.info("All live tasks: " + _liveTaskMap);
+    LOG.info("Logging all live tasks...");
+    AssignmentTaskMapLogger assignmentLogger = new AssignmentTaskMapLogger(_liveTaskMap, LOG);
+    assignmentLogger.logAssignment();
     return new HashMap<>(_liveTaskMap);
   }
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -16,7 +16,6 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-import static com.linkedin.datastream.server.AssignmentTaskMapLogger.SIZE_LIMIT_BYTES;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.eq;
@@ -33,6 +32,7 @@ public class TestAssignmentTaskMapLogger {
   private static final DatastreamTask MOCK_TASK = mock(DatastreamTask.class);
   private static final DatastreamTask MOCK_TASK_2 = mock(DatastreamTask.class);
   private static final DatastreamTask MOCK_LARGE_TASK = Mockito.spy(new DatastreamTaskImpl());
+  private static final double SIZE_LIMIT_BYTES = 1024 * 1024;
 
   @Test
   public void testTasksLessThanSizeLimit() {
@@ -41,7 +41,7 @@ public class TestAssignmentTaskMapLogger {
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
     taskMap.put("host2", ImmutableSet.of(MOCK_TASK, MOCK_TASK_2));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log, SIZE_LIMIT_BYTES);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();
@@ -62,7 +62,7 @@ public class TestAssignmentTaskMapLogger {
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
     taskMap.put("host2", ImmutableSet.of(MOCK_LARGE_TASK));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log, SIZE_LIMIT_BYTES);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();
@@ -89,7 +89,7 @@ public class TestAssignmentTaskMapLogger {
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
     taskMap.put("host2", ImmutableSet.of(MOCK_LARGE_TASK));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log, SIZE_LIMIT_BYTES);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();
@@ -116,7 +116,7 @@ public class TestAssignmentTaskMapLogger {
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
     taskMap.put("host2", ImmutableSet.of(MOCK_LARGE_TASK));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log, SIZE_LIMIT_BYTES);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -10,12 +10,13 @@ import java.util.Map;
 import java.util.Set;
 
 import org.mockito.Mockito;
+
 import org.slf4j.Logger;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
-import static com.linkedin.datastream.server.AssignmentTaskMapLogger.*;
+import static com.linkedin.datastream.server.AssignmentTaskMapLogger.SIZE_LIMIT_BYTES;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.eq;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -1,0 +1,130 @@
+package com.linkedin.datastream.server;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+
+
+/**
+ * Tests for {@link AssignmentTaskMapLogger}
+ */
+public class TestAssignmentTaskMapLogger {
+
+  private static final Logger LOG = mock(Logger.class);
+  private static final DatastreamTask mockTask = mock(DatastreamTask.class);
+  private static final DatastreamTask mockTask2 = mock(DatastreamTask.class);
+  private static final DatastreamTask largeTaskMock = Mockito.spy(new DatastreamTaskImpl());
+
+  @Test
+  public void testTasksLessThan1MB() {
+    Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
+    taskMap.put("host1", ImmutableSet.of(mockTask));
+    taskMap.put("host2", ImmutableSet.of(mockTask, mockTask2));
+
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    long startTime = System.currentTimeMillis();
+    logger.logAssignment(taskMap);
+    long endTime = System.currentTimeMillis();
+    long duration = endTime - startTime;
+    System.out.println("Log assignment duration: " + duration + " ms");
+
+    verify(LOG, times(3)).info(eq("Host={}: Live task={}"), contains("host"), anyString());
+
+    verifyNoMoreInteractions(LOG);
+  }
+
+  @Test
+  public void testTaskWithSize1MB() {
+    Mockito.doReturn(createCustomSizeString(1024 * 1024)).when(largeTaskMock).toString();
+
+    Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
+    taskMap.put("host1", ImmutableSet.of(mockTask));
+    taskMap.put("host2", ImmutableSet.of(largeTaskMock));
+
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    long startTime = System.currentTimeMillis();
+    logger.logAssignment(taskMap);
+    long endTime = System.currentTimeMillis();
+    long duration = endTime - startTime;
+    System.out.println("Log assignment duration: " + duration + " ms");
+
+    verify(LOG, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
+    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
+    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+
+    verifyNoMoreInteractions(LOG);
+  }
+
+  /**
+   * this test expects the large task to be split even though it is slightly less than 1 MB due to size buffers
+   * (it's better to round up than down when determining if it's necessary to split)
+   */
+  @Test
+  public void testTasksSlightlyLessThan1MB() {
+    Mockito.doReturn(createCustomSizeString(1024 * 1023)).when(largeTaskMock).toString();
+
+    Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
+    taskMap.put("host1", ImmutableSet.of(mockTask));
+    taskMap.put("host2", ImmutableSet.of(largeTaskMock));
+
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    long startTime = System.currentTimeMillis();
+    logger.logAssignment(taskMap);
+    long endTime = System.currentTimeMillis();
+    long duration = endTime - startTime;
+    System.out.println("Log assignment duration: " + duration + " ms");
+
+    verify(LOG, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
+    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
+    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+
+    verifyNoMoreInteractions(LOG);
+  }
+
+  /**
+   * this test expects the large task to be split into 3 parts even though it is 2MB due to size buffers
+   * (it's better to round up than down when determining if it's necessary to split)
+   */
+  @Test
+  public void testTaskWithSize2MB() {
+    Mockito.doReturn(createCustomSizeString(1024 * 1024 * 2)).when(largeTaskMock).toString();
+
+    Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
+    taskMap.put("host1", ImmutableSet.of(mockTask));
+    taskMap.put("host2", ImmutableSet.of(largeTaskMock));
+
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    long startTime = System.currentTimeMillis();
+    logger.logAssignment(taskMap);
+    long endTime = System.currentTimeMillis();
+    long duration = endTime - startTime;
+    System.out.println("Log assignment duration: " + duration + " ms");
+
+    verify(LOG, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
+    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
+    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(3), anyString());
+
+    verifyNoMoreInteractions(LOG);
+  }
+
+  /**
+   * helper function to create string of any size
+   * @param size size of string wanted
+   * @return string with size number of characters
+   */
+  private String createCustomSizeString(int size) {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < size; i++) {
+      sb.append('A');
+    }
+    return sb.toString();
+  }
+
+}

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -48,7 +48,7 @@ public class TestAssignmentTaskMapLogger {
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(log, times(3)).info(eq("Host={}: Live task={}"), contains("host"), anyString());
+    verify(log, times(3)).info(eq("{}={}"), contains("Live task"), anyString());
 
     verifyNoMoreInteractions(log);
   }
@@ -69,15 +69,15 @@ public class TestAssignmentTaskMapLogger {
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(log, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
-    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
-    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+    verify(log, times(1)).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
+    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
+    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
 
     verifyNoMoreInteractions(log);
   }
 
   /**
-   * this test expects the large task to be split even though it is slightly less than 1 MB due to size buffers
+   * this test expects the large task to be split even though it is slightly less than the size limit due to size buffers
    * (it's better to round up than down when determining if it's necessary to split)
    */
   @Test
@@ -96,15 +96,15 @@ public class TestAssignmentTaskMapLogger {
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(log, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
-    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
-    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+    verify(log, times(1)).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
+    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
+    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
 
     verifyNoMoreInteractions(log);
   }
 
   /**
-   * this test expects the large task to be split into 3 parts even though it is 2MB due to size buffers
+   * this test expects the large task to be split into 3 parts even though it is 2x the size limit due to size buffers
    * (it's better to round up than down when determining if it's necessary to split)
    */
   @Test
@@ -123,10 +123,10 @@ public class TestAssignmentTaskMapLogger {
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(log, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
-    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
-    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
-    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(3), anyString());
+    verify(log, times(1)).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
+    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
+    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
+    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(3), anyString());
 
     verifyNoMoreInteractions(log);
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -69,9 +69,9 @@ public class TestAssignmentTaskMapLogger {
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(log, times(1)).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
-    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
-    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
+    verify(log).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
+    verify(log).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
+    verify(log).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
 
     verifyNoMoreInteractions(log);
   }
@@ -96,9 +96,9 @@ public class TestAssignmentTaskMapLogger {
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(log, times(1)).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
-    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
-    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
+    verify(log).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
+    verify(log).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
+    verify(log).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
 
     verifyNoMoreInteractions(log);
   }
@@ -123,10 +123,10 @@ public class TestAssignmentTaskMapLogger {
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(log, times(1)).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
-    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
-    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
-    verify(log, times(1)).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(3), anyString());
+    verify(log).info(eq("{}={}"), eq("Host=host1: Live task"), anyString());
+    verify(log).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(1), anyString());
+    verify(log).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(2), anyString());
+    verify(log).info(eq("{} (part {})={}"), eq("Host=host2: Live task"), eq(3), anyString());
 
     verifyNoMoreInteractions(log);
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -15,6 +15,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.ImmutableSet;
 
+import static com.linkedin.datastream.server.AssignmentTaskMapLogger.*;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.contains;
 import static org.mockito.Mockito.eq;
@@ -33,7 +34,7 @@ public class TestAssignmentTaskMapLogger {
   private static final DatastreamTask MOCK_LARGE_TASK = Mockito.spy(new DatastreamTaskImpl());
 
   @Test
-  public void testTasksLessThan1MB() {
+  public void testTasksLessThanSizeLimit() {
     final Logger log = mock(Logger.class);
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
@@ -52,9 +53,9 @@ public class TestAssignmentTaskMapLogger {
   }
 
   @Test
-  public void testTaskWithSize1MB() {
+  public void testTaskWithSizeExactlySizeLimit() {
     final Logger log = mock(Logger.class);
-    Mockito.doReturn(createCustomSizeString(1024 * 1024)).when(MOCK_LARGE_TASK).toString();
+    Mockito.doReturn(createCustomSizeString(SIZE_LIMIT_BYTES)).when(MOCK_LARGE_TASK).toString();
 
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
@@ -79,9 +80,9 @@ public class TestAssignmentTaskMapLogger {
    * (it's better to round up than down when determining if it's necessary to split)
    */
   @Test
-  public void testTasksSlightlyLessThan1MB() {
+  public void testTasksSlightlyLessThanSizeLimit() {
     final Logger log = mock(Logger.class);
-    Mockito.doReturn(createCustomSizeString(1024 * 1023)).when(MOCK_LARGE_TASK).toString();
+    Mockito.doReturn(createCustomSizeString(SIZE_LIMIT_BYTES - 1024)).when(MOCK_LARGE_TASK).toString();
 
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
@@ -108,7 +109,7 @@ public class TestAssignmentTaskMapLogger {
   @Test
   public void testTaskWithSize2MB() {
     final Logger log = mock(Logger.class);
-    Mockito.doReturn(createCustomSizeString(1024 * 1024 * 2)).when(MOCK_LARGE_TASK).toString();
+    Mockito.doReturn(createCustomSizeString(SIZE_LIMIT_BYTES * 2)).when(MOCK_LARGE_TASK).toString();
 
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
@@ -134,7 +135,7 @@ public class TestAssignmentTaskMapLogger {
    * @param size size of string wanted
    * @return string with size number of characters
    */
-  private String createCustomSizeString(int size) {
+  private String createCustomSizeString(double size) {
     StringBuilder sb = new StringBuilder();
     for (int i = 0; i < size; i++) {
       sb.append('A');

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -1,64 +1,77 @@
+/**
+ *  Copyright 2023 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
 package com.linkedin.datastream.server;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.*;
+import com.google.common.collect.ImmutableSet;
+
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.contains;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 
 /**
  * Tests for {@link AssignmentTaskMapLogger}
  */
 public class TestAssignmentTaskMapLogger {
-
-  private static final Logger LOG = mock(Logger.class);
-  private static final DatastreamTask mockTask = mock(DatastreamTask.class);
-  private static final DatastreamTask mockTask2 = mock(DatastreamTask.class);
-  private static final DatastreamTask largeTaskMock = Mockito.spy(new DatastreamTaskImpl());
+  private static final DatastreamTask MOCK_TASK = mock(DatastreamTask.class);
+  private static final DatastreamTask MOCK_TASK_2 = mock(DatastreamTask.class);
+  private static final DatastreamTask MOCK_LARGE_TASK = Mockito.spy(new DatastreamTaskImpl());
 
   @Test
   public void testTasksLessThan1MB() {
+    final Logger log = mock(Logger.class);
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
-    taskMap.put("host1", ImmutableSet.of(mockTask));
-    taskMap.put("host2", ImmutableSet.of(mockTask, mockTask2));
+    taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
+    taskMap.put("host2", ImmutableSet.of(MOCK_TASK, MOCK_TASK_2));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(LOG, times(3)).info(eq("Host={}: Live task={}"), contains("host"), anyString());
+    verify(log, times(3)).info(eq("Host={}: Live task={}"), contains("host"), anyString());
 
-    verifyNoMoreInteractions(LOG);
+    verifyNoMoreInteractions(log);
   }
 
   @Test
   public void testTaskWithSize1MB() {
-    Mockito.doReturn(createCustomSizeString(1024 * 1024)).when(largeTaskMock).toString();
+    final Logger log = mock(Logger.class);
+    Mockito.doReturn(createCustomSizeString(1024 * 1024)).when(MOCK_LARGE_TASK).toString();
 
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
-    taskMap.put("host1", ImmutableSet.of(mockTask));
-    taskMap.put("host2", ImmutableSet.of(largeTaskMock));
+    taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
+    taskMap.put("host2", ImmutableSet.of(MOCK_LARGE_TASK));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(LOG, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
-    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
-    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
 
-    verifyNoMoreInteractions(LOG);
+    verifyNoMoreInteractions(log);
   }
 
   /**
@@ -67,24 +80,25 @@ public class TestAssignmentTaskMapLogger {
    */
   @Test
   public void testTasksSlightlyLessThan1MB() {
-    Mockito.doReturn(createCustomSizeString(1024 * 1023)).when(largeTaskMock).toString();
+    final Logger log = mock(Logger.class);
+    Mockito.doReturn(createCustomSizeString(1024 * 1023)).when(MOCK_LARGE_TASK).toString();
 
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
-    taskMap.put("host1", ImmutableSet.of(mockTask));
-    taskMap.put("host2", ImmutableSet.of(largeTaskMock));
+    taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
+    taskMap.put("host2", ImmutableSet.of(MOCK_LARGE_TASK));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(LOG, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
-    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
-    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
 
-    verifyNoMoreInteractions(LOG);
+    verifyNoMoreInteractions(log);
   }
 
   /**
@@ -93,25 +107,26 @@ public class TestAssignmentTaskMapLogger {
    */
   @Test
   public void testTaskWithSize2MB() {
-    Mockito.doReturn(createCustomSizeString(1024 * 1024 * 2)).when(largeTaskMock).toString();
+    final Logger log = mock(Logger.class);
+    Mockito.doReturn(createCustomSizeString(1024 * 1024 * 2)).when(MOCK_LARGE_TASK).toString();
 
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
-    taskMap.put("host1", ImmutableSet.of(mockTask));
-    taskMap.put("host2", ImmutableSet.of(largeTaskMock));
+    taskMap.put("host1", ImmutableSet.of(MOCK_TASK));
+    taskMap.put("host2", ImmutableSet.of(MOCK_LARGE_TASK));
 
-    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(LOG);
+    AssignmentTaskMapLogger logger = new AssignmentTaskMapLogger(log);
     long startTime = System.currentTimeMillis();
     logger.logAssignment(taskMap);
     long endTime = System.currentTimeMillis();
     long duration = endTime - startTime;
     System.out.println("Log assignment duration: " + duration + " ms");
 
-    verify(LOG, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
-    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
-    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
-    verify(LOG, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(3), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task={}"), eq("host1"), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(1), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(2), anyString());
+    verify(log, times(1)).info(eq("Host={}: Live task (part {})={}"), eq("host2"), eq(3), anyString());
 
-    verifyNoMoreInteractions(LOG);
+    verifyNoMoreInteractions(log);
   }
 
   /**

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -32,7 +32,7 @@ public class TestAssignmentTaskMapLogger {
   private static final DatastreamTask MOCK_TASK = mock(DatastreamTask.class);
   private static final DatastreamTask MOCK_TASK_2 = mock(DatastreamTask.class);
   private static final DatastreamTask MOCK_LARGE_TASK = Mockito.spy(new DatastreamTaskImpl());
-  private static final double SIZE_LIMIT_BYTES = 1024 * 1024;
+  private static final double SIZE_LIMIT_BYTES = 1024 * 4;
 
   @Test
   public void testTasksLessThanSizeLimit() {
@@ -83,7 +83,7 @@ public class TestAssignmentTaskMapLogger {
   @Test
   public void testTasksSlightlyLessThanSizeLimit() {
     final Logger log = mock(Logger.class);
-    Mockito.doReturn(createCustomSizeString(SIZE_LIMIT_BYTES - 1024)).when(MOCK_LARGE_TASK).toString();
+    Mockito.doReturn(createCustomSizeString(SIZE_LIMIT_BYTES - 100)).when(MOCK_LARGE_TASK).toString();
 
     Map<String, Set<DatastreamTask>> taskMap = new HashMap<>();
     taskMap.put("host1", ImmutableSet.of(MOCK_TASK));

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssignmentStrategy.java
@@ -86,13 +86,14 @@ public class TestLoadBasedPartitionAssignmentStrategy {
     int throughputInfoFetchRetryPeriodMs = 200;
     int defaultPartitionBytesInKBRate = 10;
     int defaultPartitionMsgInRate = 20;
+    double logSizeLimitInBytes = 1024 * 1024;
     ZkClient zkClient = null;
 
     LoadBasedPartitionAssignmentStrategy strategy = new LoadBasedPartitionAssignmentStrategy(mockProvider,
         maxTasks, imbalanceThreshold, maxPartitionPerTask, enableElasticTaskAssignment, partitionsPerTask,
         partitionFullnessFactorPct, taskCapacityMBps, taskCapacityUtilizationPct, throughputInfoFetchTimeoutMs,
         throughputInfoFetchRetryPeriodMs, zkClient, _clusterName, true, true,
-        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate);
+        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate, logSizeLimitInBytes);
 
     testFallbackToBaseClassWhenElasticTaskCountIsDisabled(mockProvider, strategy);
   }
@@ -113,12 +114,13 @@ public class TestLoadBasedPartitionAssignmentStrategy {
     ZkClient zkClient = _zkClient;
     int defaultPartitionBytesInKBRate = 10;
     int defaultPartitionMsgInRate = 20;
+    double logSizeLimitInBytes = 1024 * 1024;
 
     LoadBasedPartitionAssignmentStrategy strategy = new LoadBasedPartitionAssignmentStrategy(mockProvider,
         maxTasks, imbalanceThreshold, maxPartitionPerTask, enableElasticTaskAssignment, partitionsPerTask,
         partitionFullnessFactorPct, taskCapacityMBps, taskCapacityUtilizationPct, throughputInfoFetchTimeoutMs,
         throughputInfoFetchRetryPeriodMs, zkClient, _clusterName, false, true,
-        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate);
+        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate, logSizeLimitInBytes);
 
     testFallbackToBaseClassWhenElasticTaskCountIsDisabled(mockProvider, strategy);
   }
@@ -160,12 +162,13 @@ public class TestLoadBasedPartitionAssignmentStrategy {
     ZkClient zkClient = _zkClient;
     int defaultPartitionBytesInKBRate = 10;
     int defaultPartitionMsgInRate = 20;
+    double logSizeLimitInBytes = 1024 * 1024;
 
     LoadBasedPartitionAssignmentStrategy strategy = Mockito.spy(new LoadBasedPartitionAssignmentStrategy(mockProvider,
         maxTasks, imbalanceThreshold, maxPartitionPerTask, enableElasticTaskAssignment, partitionsPerTask,
         partitionFullnessFactorPct, taskCapacityMBps, taskCapacityUtilizationPct, throughputInfoFetchTimeoutMs,
         throughputInfoFetchRetryPeriodMs, zkClient, _clusterName, true, true,
-        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate));
+        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate, logSizeLimitInBytes));
 
     Datastream ds1 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1")[0];
     ds1.getSource().setPartitions(0);
@@ -207,12 +210,13 @@ public class TestLoadBasedPartitionAssignmentStrategy {
     ZkClient zkClient = _zkClient;
     int defaultPartitionBytesInKBRate = 10;
     int defaultPartitionMsgInRate = 20;
+    double logSizeLimitInBytes = 1024 * 1024;
 
     LoadBasedPartitionAssignmentStrategy strategy = new LoadBasedPartitionAssignmentStrategy(mockProvider,
         maxTasks, imbalanceThreshold, maxPartitionPerTask, enableElasticTaskAssignment, partitionsPerTask,
         partitionFullnessFactorPct, taskCapacityMBps, taskCapacityUtilizationPct, throughputInfoFetchTimeoutMs,
         throughputInfoFetchRetryPeriodMs, zkClient, _clusterName, true, true,
-        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate);
+        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate, logSizeLimitInBytes);
 
     Datastream ds1 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1")[0];
     ds1.getSource().setPartitions(0);
@@ -253,12 +257,13 @@ public class TestLoadBasedPartitionAssignmentStrategy {
     ZkClient zkClient = _zkClient;
     int defaultPartitionBytesInKBRate = 10;
     int defaultPartitionMsgInRate = 20;
+    double logSizeLimitInBytes = 1024 * 1024;
 
     LoadBasedPartitionAssignmentStrategy strategy = new LoadBasedPartitionAssignmentStrategy(mockProvider,
         maxTasks, imbalanceThreshold, maxPartitionPerTask, enableElasticTaskAssignment, partitionsPerTask,
         partitionFullnessFactorPct, taskCapacityMBps, taskCapacityUtilizationPct, throughputInfoFetchTimeoutMs,
         throughputInfoFetchRetryPeriodMs, zkClient, _clusterName, true, true,
-        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate);
+        defaultPartitionBytesInKBRate, defaultPartitionMsgInRate, logSizeLimitInBytes);
 
     Datastream ds1 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1")[0];
     ds1.getMetadata().put(StickyPartitionAssignmentStrategy.CFG_MIN_TASKS, String.valueOf(10));
@@ -330,13 +335,14 @@ public class TestLoadBasedPartitionAssignmentStrategy {
     ZkClient zkClient = _zkClient;
     int defaultPartitionBytesInKBRate = 10;
     int defaultPartitionMsgInRate = 20;
+    double logSizeLimitInBytes = 2000;
 
     LoadBasedPartitionAssignmentStrategy strategy = Mockito.spy(
         new LoadBasedPartitionAssignmentStrategy(mockProvider, maxTasks, imbalanceThreshold, maxPartitionPerTask,
             enableElasticTaskAssignment, partitionsPerTask, partitionFullnessFactorPct, taskCapacityMBps,
             taskCapacityUtilizationPct, throughputInfoFetchTimeoutMs, throughputInfoFetchRetryPeriodMs, zkClient,
             _clusterName, true, enablePartitionCountBasedEstimation,
-            defaultPartitionBytesInKBRate, defaultPartitionMsgInRate));
+            defaultPartitionBytesInKBRate, defaultPartitionMsgInRate, logSizeLimitInBytes));
 
     Datastream ds1 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1")[0];
     ds1.getMetadata().put(StickyPartitionAssignmentStrategy.CFG_MIN_TASKS, String.valueOf(1));

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/providers/TestZookeeperCheckpointProvider.java
@@ -42,6 +42,7 @@ public class TestZookeeperCheckpointProvider {
 
   private final String defaultTransportProviderName = "test";
   private static final long DEBOUNCE_TIMER_MS = 1000;
+  private static final long LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
 
   @BeforeMethod
   public void setup(Method method) throws IOException {
@@ -60,7 +61,7 @@ public class TestZookeeperCheckpointProvider {
   @Test
   public void testUnassign() {
     ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster", defaultTransportProviderName, ZkClient.DEFAULT_SESSION_TIMEOUT,
-        ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, null);
+        ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, LOG_SIZE_LIMIT_IN_BYTES, null);
     adapter.connect();
     ZookeeperCheckpointProvider checkpointProvider = new ZookeeperCheckpointProvider(adapter);
     Datastream ds1 = generateDatastream(1);
@@ -92,7 +93,7 @@ public class TestZookeeperCheckpointProvider {
   @Test
   public void testCommitAndReadCheckpoints() {
     ZkAdapter adapter = new ZkAdapter(_zookeeper.getConnection(), "testcluster", defaultTransportProviderName, ZkClient.DEFAULT_SESSION_TIMEOUT,
-        ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, null);
+        ZkClient.DEFAULT_CONNECTION_TIMEOUT, DEBOUNCE_TIMER_MS, LOG_SIZE_LIMIT_IN_BYTES, null);
     adapter.connect();
     ZookeeperCheckpointProvider checkpointProvider = new ZookeeperCheckpointProvider(adapter);
     DatastreamTaskImpl datastreamTask1 = new DatastreamTaskImpl(Collections.singletonList(generateDatastream(1)));

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -56,6 +56,7 @@ public class TestZkAdapter {
   private static final Logger LOG = LoggerFactory.getLogger(com.linkedin.datastream.server.zk.TestZkAdapter.class);
   private static final int ZK_WAIT_IN_MS = 500;
   private static final long ZK_DEBOUNCE_TIMER_MS = 1000;
+  private static final double LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
 
   private final String defaultTransportProviderName = "test";
   private EmbeddedZookeeper _embeddedZookeeper;
@@ -106,7 +107,8 @@ public class TestZkAdapter {
 
   private ZkAdapter createZkAdapter(String testCluster) {
     return new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
-        ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, ZK_DEBOUNCE_TIMER_MS, null);
+        ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT, ZK_DEBOUNCE_TIMER_MS,
+        LOG_SIZE_LIMIT_IN_BYTES, null);
   }
 
   @Test
@@ -140,11 +142,11 @@ public class TestZkAdapter {
     // start two ZkAdapters, which is corresponding to two Coordinator instances
     //
     ZkAdapter adapter1 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
-        1000, 15000, ZK_DEBOUNCE_TIMER_MS, null);
+        1000, 15000, ZK_DEBOUNCE_TIMER_MS, LOG_SIZE_LIMIT_IN_BYTES, null);
     adapter1.connect();
 
     ZkAdapter adapter2 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
-        1000, 15000, ZK_DEBOUNCE_TIMER_MS, null);
+        1000, 15000, ZK_DEBOUNCE_TIMER_MS, LOG_SIZE_LIMIT_IN_BYTES, null);
     adapter2.connect();
 
     //
@@ -170,7 +172,7 @@ public class TestZkAdapter {
     adapter2.disconnect();
     // now a new client goes online
     ZkAdapter adapter3 = new ZkAdapter(_zkConnectionString, testCluster, defaultTransportProviderName,
-        1000, 15000, ZK_DEBOUNCE_TIMER_MS, null);
+        1000, 15000, ZK_DEBOUNCE_TIMER_MS, LOG_SIZE_LIMIT_IN_BYTES, null);
     adapter3.connect();
 
     //
@@ -723,7 +725,7 @@ public class TestZkAdapter {
     public ZkClientInterceptingAdapter(String zkConnectionString, String testCluster, String defaultTransportProviderName,
         int defaultSessionTimeoutMs, int defaultConnectionTimeoutMs, long debounceTimerMs, ZkAdapterListener listener) {
       super(zkConnectionString, testCluster, defaultTransportProviderName, defaultSessionTimeoutMs,
-          defaultConnectionTimeoutMs, debounceTimerMs, listener);
+          defaultConnectionTimeoutMs, debounceTimerMs, LOG_SIZE_LIMIT_IN_BYTES, listener);
       _sleepMs = defaultSessionTimeoutMs;
     }
 

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
@@ -107,11 +107,11 @@ public class LogUtils {
   public static void logStringsUnderSizeLimit(Logger log, String message, String contextPrefix, double sizeLimit) {
     if (sizeLimit <= BUFFER_1KB) {
       throw new IllegalArgumentException("Log size limit cannot be set to less than or equal to 1KB");
-    } else if (isLessThanSizeLimit(contextPrefix, BUFFER_1KB)) {
+    } else if (!isLessThanSizeLimit(contextPrefix, BUFFER_1KB)) {
       throw new IllegalArgumentException("Context prefix cannot be longer than 1KB in size");
     } else {
       int bufferAdjustedSizeLimit = (int) (sizeLimit - BUFFER_1KB);
-      logStringsUnderSizeLimit(log, message, contextPrefix, 1, sizeLimit, bufferAdjustedSizeLimit);
+      logStringsUnderSizeLimit(log, message, contextPrefix, 1, bufferAdjustedSizeLimit);
     }
   }
 
@@ -121,12 +121,11 @@ public class LogUtils {
    * @param message string to be logged
    * @param contextPrefix string that provides context for what is being logged
    * @param part printed in the log message to keep track of how many parts a larger message has been split into
-   * @param sizeLimit size limit of each log line
    * @param adjustedSizeLimit buffer adjusted size limit to account for extra bytes in the log line (e.g. timestamp, avro wrapping)
    */
   private static void logStringsUnderSizeLimit(Logger log, String message, String contextPrefix, int part,
-      double sizeLimit, int adjustedSizeLimit) {
-    if (isLessThanSizeLimit(message, sizeLimit)) {
+      int adjustedSizeLimit) {
+    if (isLessThanSizeLimit(message, adjustedSizeLimit)) {
       if (part == 1) {
         log.info("{}={}", contextPrefix,  message);
       } else {
@@ -134,7 +133,7 @@ public class LogUtils {
       }
     } else {
       log.info("{} (part {})={}", contextPrefix, part, message.substring(0, adjustedSizeLimit));
-      logStringsUnderSizeLimit(log, message.substring(adjustedSizeLimit), contextPrefix, part + 1, sizeLimit, adjustedSizeLimit);
+      logStringsUnderSizeLimit(log, message.substring(adjustedSizeLimit), contextPrefix, part + 1, adjustedSizeLimit);
     }
   }
 
@@ -145,7 +144,7 @@ public class LogUtils {
    */
   private static boolean isLessThanSizeLimit(String message, double sizeLimit) {
     double sizeInMB = getStringSizeInBytes(message);
-    return sizeInMB + BUFFER_1KB < sizeLimit;
+    return sizeInMB < sizeLimit;
   }
 
   /**

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
@@ -97,11 +97,35 @@ public class LogUtils {
   }
 
   /**
-   * prints one log line for each string smaller than size limit
-   * @param  message
+   * prints one log line for each string smaller than a given size limit, splitting longer messages into multiple part
+   * @param log logger to use for logging
+   * @param message string to be logged
+   * @param contextPrefix string that provides context for what is being logged, which will be added right before the
+   *                      actual message being logged (e.g. contextPrefix="Live task: ", Log line="Live task: message")
+   * @param sizeLimit size limit of each log line
    */
-  public static void logStringsUnderSizeLimit(Logger log, String message, String contextPrefix, int part, double sizeLimit) {
-    int bufferAdjustedSizeLimit = (int) (sizeLimit - BUFFER_1KB);
+  public static void logStringsUnderSizeLimit(Logger log, String message, String contextPrefix, double sizeLimit) {
+    if (sizeLimit <= BUFFER_1KB) {
+      throw new IllegalArgumentException("Log size limit cannot be set to less than or equal to 1KB");
+    } else if (isLessThanSizeLimit(contextPrefix, BUFFER_1KB)) {
+      throw new IllegalArgumentException("Context prefix cannot be longer than 1KB in size");
+    } else {
+      int bufferAdjustedSizeLimit = (int) (sizeLimit - BUFFER_1KB);
+      logStringsUnderSizeLimit(log, message, contextPrefix, 1, sizeLimit, bufferAdjustedSizeLimit);
+    }
+  }
+
+  /**
+   * helper function to print and keep log lines under a certain size limit
+   * @param log logger to use for logging
+   * @param message string to be logged
+   * @param contextPrefix string that provides context for what is being logged
+   * @param part printed in the log message to keep track of how many parts a larger message has been split into
+   * @param sizeLimit size limit of each log line
+   * @param adjustedSizeLimit buffer adjusted size limit to account for extra bytes in the log line (e.g. timestamp, avro wrapping)
+   */
+  private static void logStringsUnderSizeLimit(Logger log, String message, String contextPrefix, int part,
+      double sizeLimit, int adjustedSizeLimit) {
     if (isLessThanSizeLimit(message, sizeLimit)) {
       if (part == 1) {
         log.info("{}={}", contextPrefix,  message);
@@ -109,8 +133,8 @@ public class LogUtils {
         log.info("{} (part {})={}", contextPrefix, part,  message);
       }
     } else {
-      log.info("{} (part {})={}", contextPrefix, part, message.substring(0, bufferAdjustedSizeLimit));
-      logStringsUnderSizeLimit(log, message.substring(bufferAdjustedSizeLimit), contextPrefix, part + 1, sizeLimit);
+      log.info("{} (part {})={}", contextPrefix, part, message.substring(0, adjustedSizeLimit));
+      logStringsUnderSizeLimit(log, message.substring(adjustedSizeLimit), contextPrefix, part + 1, sizeLimit, adjustedSizeLimit);
     }
   }
 


### PR DESCRIPTION
### Summary ###
Added class `AssignmentTaskMapLogger` to log assignments one task per log line so that logs stay under 1MB in size. Includes logic for checking if a task is greater than 1MB. If it is, that task will be split and logged in multiple parts.

BUG=[DATAPIPES-27351](https://jira01.corp.linkedin.com:8443/browse/DATAPIPES-27351)

### Testing Done ###
./gradlew build

In unit tests, the time it took to do logAssignment was always <50ms.