### PR TITLE
Fixing Deadlock Bug Between ZK Callback & Event Thread On Acquiring Coordinator Object

### DIFF
--- a/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorUtils.java
+++ b/datastream-kafka-connector/src/test/java/com/linkedin/datastream/connectors/kafka/TestKafkaConnectorUtils.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.datastream.connectors.kafka;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import com.linkedin.datastream.common.zk.ZkClient;
@@ -41,6 +42,9 @@ public class TestKafkaConnectorUtils {
     props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, zkAddr);
     props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
+    if (!props.containsKey(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS)) {
+      props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
+    }
     props.putAll(override);
     ZkClient client = new ZkClient(zkAddr);
     CachedDatastreamReader cachedDatastreamReader = new CachedDatastreamReader(client, cluster);

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -155,6 +155,9 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, zkAddr);
     props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
+    if (!props.containsKey(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS)) {
+      props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
+    }
     props.putAll(override);
     ZkClient client = new ZkClient(zkAddr);
     _cachedDatastreamReader = new CachedDatastreamReader(client, cluster);
@@ -178,6 +181,9 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, zkAddr);
     props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
+    if (!props.containsKey(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS)) {
+      props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
+    }
     props.putAll(override);
     ZkClient client = new ZkClient(zkAddr);
     _cachedDatastreamReader = new CachedDatastreamReader(client, cluster);
@@ -2986,6 +2992,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, _zkConnectionString);
     props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);
@@ -3098,6 +3105,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ENABLE_ASSIGNMENT_TOKENS, String.valueOf(true));
     props.put(CoordinatorConfig.CONFIG_STOP_PROPAGATION_TIMEOUT_MS, String.valueOf(1000));
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);
@@ -3185,6 +3193,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_REINIT_ON_NEW_ZK_SESSION, String.valueOf(handleNewSession));
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);
@@ -3275,6 +3284,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, _zkConnectionString);
     props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);
@@ -3341,6 +3351,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_TASK_STOP_CHECK_TIMEOUT_MS, "100");
     props.put(CoordinatorConfig.CONFIG_TASK_STOP_CHECK_RETRY_PERIOD_MS, "10");
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);
@@ -3419,6 +3430,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ENABLE_ASSIGNMENT_TOKENS, String.valueOf(false));
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);
@@ -3452,6 +3464,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ENABLE_ASSIGNMENT_TOKENS, String.valueOf(true));
     props.put(CoordinatorConfig.CONFIG_STOP_PROPAGATION_TIMEOUT_MS, String.valueOf(6000));
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);
@@ -3503,6 +3516,7 @@ public class TestCoordinator {
     props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
     props.put(CoordinatorConfig.CONFIG_ENABLE_ASSIGNMENT_TOKENS, String.valueOf(true));
     props.put(CoordinatorConfig.CONFIG_STOP_PROPAGATION_TIMEOUT_MS, String.valueOf(6000));
+    props.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     _cachedDatastreamReader = new CachedDatastreamReader(zkClient, testCluster);

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4088,13 +4088,13 @@ public class TestCoordinator {
     // custom heartbeat period of 2 second.
     properties.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(testHeartbeatPeriod));
 
-    final Coordinator.CoordinatorEventProcessor[] _testCoordinatorEventProcessor = {null};
+    final Coordinator.CoordinatorEventProcessor[] testCoordinatorEventProcessor = {null};
     Coordinator coordinator =
         createCoordinator(_zkConnectionString, testCluster, properties, new DummyTransportProviderAdminFactory(),
             (cachedDatastreamReader, props) -> new Coordinator(cachedDatastreamReader, props) {
               @Override
               protected synchronized void createEventThread() {
-                _testCoordinatorEventProcessor[0] = new CoordinatorEventProcessor() {
+                testCoordinatorEventProcessor[0] = new CoordinatorEventProcessor() {
                   // Mimicking the coordinator's event thread's runnable method.
                   // 1. Sleeping before calling handleEvent to let zk session expiry
                   //    thread acquire coordinator object before event thread enters
@@ -4133,12 +4133,12 @@ public class TestCoordinator {
                     super.notifyThreadsWaitingForCoordinatorObjectSynchronization();
                   }
                 };
-                _testCoordinatorEventProcessor[0].setDaemon(true);
+                testCoordinatorEventProcessor[0].setDaemon(true);
               }
 
               @Override
               CoordinatorEventProcessor getEventThread() {
-                return _testCoordinatorEventProcessor[0];
+                return testCoordinatorEventProcessor[0];
               }
             });
 
@@ -4166,13 +4166,13 @@ public class TestCoordinator {
     // custom heartbeat period of 2 second.
     properties.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(testHeartbeatPeriod));
 
-    final Coordinator.CoordinatorEventProcessor[] _testCoordinatorEventProcessor = {null};
+    final Coordinator.CoordinatorEventProcessor[] testCoordinatorEventProcessor = {null};
     Coordinator coordinator =
         createCoordinator(_zkConnectionString, testCluster, properties, new DummyTransportProviderAdminFactory(),
             (cachedDatastreamReader, props) -> new Coordinator(cachedDatastreamReader, props) {
               @Override
               protected synchronized void createEventThread() {
-                _testCoordinatorEventProcessor[0] = new CoordinatorEventProcessor() {
+                testCoordinatorEventProcessor[0] = new CoordinatorEventProcessor() {
                   // Mimicking the coordinator's event thread's runnable method.
                   // 1. Handling a No-Op Event.
                   // 2. Sleeping after calling handleEvent to let zk session expiry
@@ -4211,12 +4211,12 @@ public class TestCoordinator {
                     super.notifyThreadsWaitingForCoordinatorObjectSynchronization();
                   }
                 };
-                _testCoordinatorEventProcessor[0].setDaemon(true);
+                testCoordinatorEventProcessor[0].setDaemon(true);
               }
 
               @Override
               CoordinatorEventProcessor getEventThread() {
-                return _testCoordinatorEventProcessor[0];
+                return testCoordinatorEventProcessor[0];
               }
             });
 

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4127,11 +4127,6 @@ public class TestCoordinator {
                       }
                     }
                   }
-
-                  @Override
-                  protected void notifyThreadsWaitingForCoordinatorObjectSynchronization() {
-                    super.notifyThreadsWaitingForCoordinatorObjectSynchronization();
-                  }
                 };
                 testCoordinatorEventProcessor[0].setDaemon(true);
               }
@@ -4204,11 +4199,6 @@ public class TestCoordinator {
                         break;
                       }
                     }
-                  }
-
-                  @Override
-                  protected void notifyThreadsWaitingForCoordinatorObjectSynchronization() {
-                    super.notifyThreadsWaitingForCoordinatorObjectSynchronization();
                   }
                 };
                 testCoordinatorEventProcessor[0].setDaemon(true);

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4077,6 +4077,163 @@ public class TestCoordinator {
     });
   }
 
+  @Test
+  public void testSessionExpiryCallbackThreadAttemptingToAcquireCoordinatorObjectBeforeHandlingEvent() throws Exception {
+    String testCluster = "dummyCluster";
+    long testHeartbeatPeriod = Duration.ofSeconds(2).toMillis();
+
+    Properties properties = new Properties();
+    properties.put(CoordinatorConfig.CONFIG_CLUSTER, testCluster);
+    properties.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, _zkConnectionString);
+    // custom heartbeat period of 2 second.
+    properties.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(testHeartbeatPeriod));
+
+    final Coordinator.CoordinatorEventProcessor[] _testCoordinatorEventProcessor = {null};
+    Coordinator coordinator =
+        createCoordinator(_zkConnectionString, testCluster, properties, new DummyTransportProviderAdminFactory(),
+            (cachedDatastreamReader, props) -> new Coordinator(cachedDatastreamReader, props) {
+              @Override
+              protected synchronized void createEventThread() {
+                _testCoordinatorEventProcessor[0] = new CoordinatorEventProcessor() {
+                  // Mimicking the coordinator's event thread's runnable method.
+                  // 1. Sleeping before calling handleEvent to let zk session expiry
+                  //    thread acquire coordinator object before event thread enters
+                  //    handleEvent.
+                  // 2. Handling a No-Op Event.
+                  // 3. Notifying the zk session expiry threads to attempt acquiring the
+                  //    coordinator object.
+                  @Override
+                  public void run() {
+                    // This flag will be enabled when an interrupt was called
+                    // on the event thread while the event thread was sleeping.
+                    boolean isInterruptedInSleep = false;
+                    while (!isInterrupted()) {
+                      try {
+                        // Step 1
+                        // Making sure we sleep for more than heartbeat period to
+                        // mock the scenario where the zk session expiry thread
+                        // acquires the coordinator object before the event thread does.
+                        Thread.sleep(testHeartbeatPeriod + Duration.ofMillis(500).toMillis());
+                      } catch (InterruptedException e) {
+                        isInterruptedInSleep = true;
+                      }
+                      // Step 2
+                      // Handling an event requires acquiring the coordinator's object.
+                      handleEvent(new CoordinatorEvent(CoordinatorEvent.EventType.NO_OP, null));
+                      // Step 3
+                      notifyThreadsWaitingForCoordinatorObjectSynchronization();
+                      if (isInterruptedInSleep) {
+                        break;
+                      }
+                    }
+                  }
+
+                  @Override
+                  protected void notifyThreadsWaitingForCoordinatorObjectSynchronization() {
+                    super.notifyThreadsWaitingForCoordinatorObjectSynchronization();
+                  }
+                };
+                _testCoordinatorEventProcessor[0].setDaemon(true);
+              }
+
+              @Override
+              CoordinatorEventProcessor getEventThread() {
+                return _testCoordinatorEventProcessor[0];
+              }
+            });
+
+    coordinator.start();
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+
+    coordinator.onSessionExpired();
+    Assert.assertTrue(PollUtils.poll(coordinator::isZkSessionExpired, 100, testHeartbeatPeriod));
+    // Making sure we don't run into a deadlock scenario.
+    Assert.assertTrue(PollUtils.poll(() -> !coordinator.getEventThread().isAlive(), 100, testHeartbeatPeriod));
+
+    coordinator.stop();
+    zkClient.close();
+    coordinator.getDatastreamCache().getZkclient().close();
+  }
+
+  @Test
+  public void testSessionExpiryCallbackThreadAttemptingToAcquireCoordinatorObjectAfterHandlingEvent() throws Exception {
+    String testCluster = "dummyCluster";
+    long testHeartbeatPeriod = Duration.ofSeconds(2).toMillis();
+
+    Properties properties = new Properties();
+    properties.put(CoordinatorConfig.CONFIG_CLUSTER, testCluster);
+    properties.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, _zkConnectionString);
+    // custom heartbeat period of 2 second.
+    properties.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(testHeartbeatPeriod));
+
+    final Coordinator.CoordinatorEventProcessor[] _testCoordinatorEventProcessor = {null};
+    Coordinator coordinator =
+        createCoordinator(_zkConnectionString, testCluster, properties, new DummyTransportProviderAdminFactory(),
+            (cachedDatastreamReader, props) -> new Coordinator(cachedDatastreamReader, props) {
+              @Override
+              protected synchronized void createEventThread() {
+                _testCoordinatorEventProcessor[0] = new CoordinatorEventProcessor() {
+                  // Mimicking the coordinator's event thread's runnable method.
+                  // 1. Handling a No-Op Event.
+                  // 2. Sleeping after calling handleEvent to let zk session expiry
+                  //    thread wait for notification from event thread to access coordinator
+                  //    object.
+                  // 3. Notifying the zk session expiry threads to attempt acquiring the
+                  //    coordinator object.
+                  @Override
+                  public void run() {
+                    // This flag will be enabled when an interrupt was called
+                    // on the event thread while the event thread was sleeping.
+                    boolean isInterruptedInSleep = false;
+                    // Step 1
+                    // Handling an event requires acquiring the coordinator's object.
+                    handleEvent(new CoordinatorEvent(CoordinatorEvent.EventType.NO_OP, null));
+                    while (!isInterrupted()) {
+                      try {
+                        // Step 2
+                        // Making sure we sleep for less than heartbeat period to
+                        // mock the scenario where the zk session expiry thread
+                        // is waiting for notification from the event thread.
+                        Thread.sleep(testHeartbeatPeriod - Duration.ofMillis(500).toMillis());
+                      } catch (InterruptedException e) {
+                        isInterruptedInSleep = true;
+                      }
+                      // Step 3
+                      notifyThreadsWaitingForCoordinatorObjectSynchronization();
+                      if (isInterruptedInSleep) {
+                        break;
+                      }
+                    }
+                  }
+
+                  @Override
+                  protected void notifyThreadsWaitingForCoordinatorObjectSynchronization() {
+                    super.notifyThreadsWaitingForCoordinatorObjectSynchronization();
+                  }
+                };
+                _testCoordinatorEventProcessor[0].setDaemon(true);
+              }
+
+              @Override
+              CoordinatorEventProcessor getEventThread() {
+                return _testCoordinatorEventProcessor[0];
+              }
+            });
+
+
+    coordinator.start();
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+
+    coordinator.onSessionExpired();
+    Assert.assertTrue(PollUtils.poll(coordinator::isZkSessionExpired, 100, testHeartbeatPeriod));
+    // Making sure we don't run into a deadlock scenario.
+    Assert.assertTrue(PollUtils.poll(() -> !coordinator.getEventThread().isAlive(), 100, testHeartbeatPeriod));
+
+    coordinator.stop();
+    zkClient.close();
+    coordinator.getDatastreamCache().getZkclient().close();
+  }
+
   // This helper function helps compare the requesting topics with the topics reflected in the server.
   private BooleanSupplier validateIfViolatingTopicsAreReflectedInServer(Datastream testStream, Coordinator coordinator,
       Set<String> requestedThroughputViolatingTopics) {

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -6,6 +6,7 @@
 package com.linkedin.datastream.server;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -140,6 +141,7 @@ public class EmbeddedDatastreamCluster {
       Map<String, Properties> connectorProperties, Properties override, KafkaCluster kafkaCluster) {
     String connectorTypes = String.join(",", connectorProperties.keySet());
     Properties properties = new Properties();
+    properties.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(Duration.ofSeconds(1).toMillis()));
     properties.put(DatastreamServerConfigurationConstants.CONFIG_CLUSTER_NAME, "DatastreamCluster");
     properties.put(DatastreamServerConfigurationConstants.CONFIG_ZK_ADDRESS, zkConnectionString);
     properties.put(DatastreamServerConfigurationConstants.CONFIG_HTTP_PORT, String.valueOf(httpPort));

--- a/findbugs/excludeFilter.xml
+++ b/findbugs/excludeFilter.xml
@@ -29,4 +29,11 @@
     <Class name="com.linkedin.datastream.common.zk.ZkClient" />
     <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" />
   </Match>
+
+  <!-- Suppress warning about naked notify on the synchronized coordinator object -->
+  <!-- The threads are to be waiting and notifying on the synchronized coordinator object only -->
+  <Match>
+    <Class name="com.linkedin.datastream.server.Coordinator" />
+    <Bug pattern="NN_NAKED_NOTIFY" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
# Summary
## Bug In Detail
- In a rare situation, the runnable of the Coordinator event thread (aka event thread) and the callback thread of the ZK session expiry could become deadlocked when the callback thread attempts to interrupt the event thread by acquiring the lock of the Coordinator object. The event thread on the other side cannot be interrupted because it is blocked on acquiring the Coordinator object's lock to handle an event before breaking out of the runnable loop.

- The code snippets shown below are pseudocode examples of the actual implementation, used to explain the deadlock scenario. **Essentially, if the callback thread of the ZK client enters the `stopEventThread()` method (and acquires the Coordinator object's lock) at the same time that the event thread is about to enter the `handleEvent()` method, a deadlock scenario will occur.**

  - The Coordinator event thread remains blocked until the lock of the Coordinator's object is released. [code link](https://github.com/linkedin/brooklin/blob/master/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java#L2301)
  - The Session expiry callback thread will not release the Coordinator object's lock until the event thread is interrupted. [code link](https://github.com/linkedin/brooklin/blob/master/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java#L335)

```
// Coordinator event thread's runnable

private boolean run() {
  while (isNotIterrupted()) {
    handleEvent(); // this method needs to acquire lock on the Coordinator object.
  }
}
```

```
// ZK client's callback thread on session expiry
// "synchronized" method of the Coordinator class.

private synchronized boolean stopEventThread() {
  while (eventThread.isAlive()) {
    eventThread.interrupt(); // continuously attempts to interrupt the event thread.
  }
}
``` 
## BugFix In Detail
- An intrinsic Conditional Variable is used to halt threads (such as ZK callback threads and the main server thread) to release the lock on the Coordinator object and before attempting to re-acquire the Coordinator object. 
- In the `stopEventThread()` method, the calling thread (such as zk callback threads and the main server thread) waits for a maximum of the `_heartbeat` period to acquire the Coordinator object. This time-bound waiting prevents the calling thread from waiting indefinitely if the event thread has already been shut down.
- Similarly, in the `waitForEventThreadToJoin()` method, the calling thread (in this case, the main server thread) must wait for a maximum of the `_heartbeat` period.
- This conditional variable is not used to explicitly halt the Coordinator event thread.
- The Coordinator event thread will use this intrinsic conditional variable to notify other threads that may be waiting to acquire access to the Coordinator object after it releases the lock on the object and before it loops and attempts to reacquire it.

### Pseudocode examples of the proposed implementation.
```
// Coordinator event thread's runnable

private boolean run() {
  while (isNotIterrupted()) {
    handleEvent(); // this method needs to acquire lock on the Coordinator object.
    notifyThreadsWaitingForCoordinatorObjectSynchronization();
  }
}
```
```
// ZK client's callback thread on session expiry

private synchronized boolean stopEventThread() {
  while (eventThread.isAlive()) {
    wait(heartbeatPeriod); // released the lock on coordinator object for heartbeat period and re-acquires it. 
    eventThread.interrupt(); // continuously attempts to interrupt the event thread.
  }
}
``` 

## Tests
1. Testing the scenario when the session expiry callback thread is attempting to acquire the Coordinator object's lock before the event thread calls for handling an event.
2. Testing the scenario when the session expiry callback thread is attempting to acquire the Coordinator object's lock after the event thread calls for handling an event.
___
Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
