### PR TITLE
Fixing the CPU Intensive RemoveAll with Lists in Sticky & Load Based Partition Assignment Strategies

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
@@ -79,7 +79,7 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
    */
   public Map<String, Set<DatastreamTask>> assignPartitions(
       ClusterThroughputInfo throughputInfo, Map<String, Set<DatastreamTask>> currentAssignment,
-      List<String> unassignedPartitions, DatastreamGroupPartitionsMetadata partitionMetadata, int maxPartitionsPerTask) {
+      Set<String> unassignedPartitions, DatastreamGroupPartitionsMetadata partitionMetadata, int maxPartitionsPerTask) {
     String datastreamGroupName = partitionMetadata.getDatastreamGroup().getName();
     LOG.info("START: assignPartitions for datasteam={}", datastreamGroupName);
     Map<String, PartitionThroughputInfo> partitionInfoMap = new HashMap<>(throughputInfo.getPartitionInfoMap());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -107,9 +107,9 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     }
 
     String datastreamGroupName = datastreamGroup.getName();
-    Pair<List<String>, Integer> assignedPartitionsAndTaskCount = getAssignedPartitionsAndTaskCountForDatastreamGroup(
+    Pair<Set<String>, Integer> assignedPartitionsAndTaskCount = getAssignedPartitionsAndTaskCountForDatastreamGroup(
         currentAssignment, datastreamGroupName);
-    List<String> assignedPartitions = assignedPartitionsAndTaskCount.getKey();
+    Set<String> assignedPartitions = assignedPartitionsAndTaskCount.getKey();
     int taskCount = assignedPartitionsAndTaskCount.getValue();
     LOG.info("Old partition assignment info, assignment: {}", currentAssignment);
     Validate.isTrue(taskCount > 0, String.format("No tasks found for datastream group %s", datastreamGroup));
@@ -117,7 +117,7 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
         "Zero tasks assigned. Retry leader partition assignment");
 
     // Calculating unassigned partitions
-    List<String> unassignedPartitions = new ArrayList<>(datastreamPartitions.getPartitions());
+    Set<String> unassignedPartitions = datastreamPartitions.getPartitions();
     unassignedPartitions.removeAll(assignedPartitions);
 
     ClusterThroughputInfo clusterThroughputInfo = new ClusterThroughputInfo(StringUtils.EMPTY, Collections.emptyMap());
@@ -192,7 +192,7 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
 
   @VisibleForTesting
   Map<String, Set<DatastreamTask>> doAssignment(ClusterThroughputInfo clusterThroughputInfo,
-      Map<String, Set<DatastreamTask>> currentAssignment, List<String> unassignedPartitions,
+      Map<String, Set<DatastreamTask>> currentAssignment, Set<String> unassignedPartitions,
       DatastreamGroupPartitionsMetadata datastreamPartitions) {
     Map<String, Set<DatastreamTask>> assignment = _assigner.assignPartitions(
         clusterThroughputInfo, currentAssignment, unassignedPartitions, datastreamPartitions, _maxPartitionPerTask);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -7,6 +7,7 @@ package com.linkedin.datastream.server.assignment;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -117,7 +118,7 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
         "Zero tasks assigned. Retry leader partition assignment");
 
     // Calculating unassigned partitions
-    Set<String> unassignedPartitions = datastreamPartitions.getPartitions();
+    Set<String> unassignedPartitions = new HashSet<>(datastreamPartitions.getPartitions());
     unassignedPartitions.removeAll(assignedPartitions);
 
     ClusterThroughputInfo clusterThroughputInfo = new ClusterThroughputInfo(StringUtils.EMPTY, Collections.emptyMap());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedTaskCountEstimator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedTaskCountEstimator.java
@@ -6,7 +6,6 @@
 package com.linkedin.datastream.server.assignment;
 
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -51,13 +50,13 @@ public class LoadBasedTaskCountEstimator {
    * Gets the estimated number of tasks based on per-partition throughput information.
    * NOTE: This does not take into account numPartitionsPerTask configuration
    * @param throughputInfo Per-partition throughput information
-   * @param assignedPartitions The list of assigned partitions
-   * @param unassignedPartitions The list of unassigned partitions
+   * @param assignedPartitions The set of assigned partitions
+   * @param unassignedPartitions The set of unassigned partitions
    * @param datastreamName Name of the datastream
    * @return The estimated number of tasks
    */
-  public int getTaskCount(ClusterThroughputInfo throughputInfo, List<String> assignedPartitions,
-      List<String> unassignedPartitions, String datastreamName) {
+  public int getTaskCount(ClusterThroughputInfo throughputInfo, Set<String> assignedPartitions,
+      Set<String> unassignedPartitions, String datastreamName) {
     Validate.notNull(throughputInfo, "null throughputInfo");
     Validate.notNull(assignedPartitions, "null assignedPartitions");
     Validate.notNull(unassignedPartitions, "null unassignedPartitions");

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -185,9 +185,9 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
     return resolveConfigWithMetadata(datastreamGroup, CFG_PARTITIONS_PER_TASK, _partitionsPerTask);
   }
 
-  protected Pair<List<String>, Integer> getAssignedPartitionsAndTaskCountForDatastreamGroup(
+  protected Pair<Set<String>, Integer> getAssignedPartitionsAndTaskCountForDatastreamGroup(
       Map<String, Set<DatastreamTask>> currentAssignment, String datastreamGroupName) {
-    List<String> assignedPartitions = new ArrayList<>();
+    Set<String> assignedPartitions = new HashSet<>();
     int taskCount = 0;
     for (Set<DatastreamTask> tasks : currentAssignment.values()) {
       Set<DatastreamTask> dgTask = tasks.stream().filter(t -> datastreamGroupName.equals(t.getTaskPrefix()))
@@ -218,9 +218,9 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
     String dgName = datastreamGroup.getName();
 
     // Step 1: collect the # of tasks and figured out the unassigned partitions
-    Pair<List<String>, Integer> assignedPartitionsAndTaskCount =
+    Pair<Set<String>, Integer> assignedPartitionsAndTaskCount =
         getAssignedPartitionsAndTaskCountForDatastreamGroup(currentAssignment, dgName);
-    List<String> assignedPartitions = assignedPartitionsAndTaskCount.getKey();
+    Set<String> assignedPartitions = assignedPartitionsAndTaskCount.getKey();
     int totalTaskCount = assignedPartitionsAndTaskCount.getValue();
     Validate.isTrue(totalTaskCount > 0, String.format("No tasks found for datastream group %s", dgName));
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestLoadBasedTaskCountEstimator.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestLoadBasedTaskCountEstimator.java
@@ -5,11 +5,11 @@
  */
 package com.linkedin.datastream.server;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
+import java.util.HashSet;
+import java.util.Set;
 
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
@@ -42,8 +42,8 @@ public class TestLoadBasedTaskCountEstimator {
   @Test
   public void emptyAssignmentReturnsZeroTasksTest() {
     ClusterThroughputInfo throughputInfo = _provider.getThroughputInfo("pizza");
-    List<String> assignedPartitions = Collections.emptyList();
-    List<String> unassignedPartitions = Collections.emptyList();
+    Set<String> assignedPartitions = Collections.emptySet();
+    Set<String> unassignedPartitions = Collections.emptySet();
     LoadBasedTaskCountEstimator estimator = new LoadBasedTaskCountEstimator(TASK_CAPACITY_MBPS,
         TASK_CAPACITY_UTILIZATION_PCT, DEFAULT_BYTES_IN_KB_RATE, DEFAULT_MSGS_IN_RATE);
     int taskCount = estimator.getTaskCount(throughputInfo, assignedPartitions, unassignedPartitions, "test");
@@ -53,9 +53,9 @@ public class TestLoadBasedTaskCountEstimator {
   @Test
   public void lowThroughputAssignmentReturnsOneTaskTest() {
     ClusterThroughputInfo throughputInfo = _provider.getThroughputInfo("pizza");
-    List<String> assignedPartitions = new ArrayList<>();
+    Set<String> assignedPartitions = new HashSet<>();
     assignedPartitions.add("Pepperoni-1");
-    List<String> unassignedPartitions = Collections.emptyList();
+    Set<String> unassignedPartitions = Collections.emptySet();
     LoadBasedTaskCountEstimator estimator = new LoadBasedTaskCountEstimator(TASK_CAPACITY_MBPS,
         TASK_CAPACITY_UTILIZATION_PCT, DEFAULT_BYTES_IN_KB_RATE, DEFAULT_MSGS_IN_RATE);
     int taskCount = estimator.getTaskCount(throughputInfo, assignedPartitions, unassignedPartitions, "test");
@@ -65,8 +65,8 @@ public class TestLoadBasedTaskCountEstimator {
   @Test
   public void highThroughputAssignmentTest() {
     ClusterThroughputInfo throughputInfo = _provider.getThroughputInfo("ice-cream");
-    List<String> assignedPartitions = Collections.emptyList();
-    List<String> unassignedPartitions = new ArrayList<>(throughputInfo.getPartitionInfoMap().keySet());
+    Set<String> assignedPartitions = Collections.emptySet();
+    Set<String> unassignedPartitions = throughputInfo.getPartitionInfoMap().keySet();
     LoadBasedTaskCountEstimator estimator = new LoadBasedTaskCountEstimator(TASK_CAPACITY_MBPS,
         TASK_CAPACITY_UTILIZATION_PCT, DEFAULT_BYTES_IN_KB_RATE, DEFAULT_MSGS_IN_RATE);
     int taskCount = estimator.getTaskCount(throughputInfo, assignedPartitions, unassignedPartitions, "test");
@@ -81,8 +81,8 @@ public class TestLoadBasedTaskCountEstimator {
   @Test
   public void highThroughputAssignmentTest2() {
     ClusterThroughputInfo throughputInfo = _provider.getThroughputInfo("donut");
-    List<String> assignedPartitions = Collections.emptyList();
-    List<String> unassignedPartitions = new ArrayList<>(throughputInfo.getPartitionInfoMap().keySet());
+    Set<String> assignedPartitions = Collections.emptySet();
+    Set<String> unassignedPartitions = throughputInfo.getPartitionInfoMap().keySet();
     LoadBasedTaskCountEstimator estimator = new LoadBasedTaskCountEstimator(TASK_CAPACITY_MBPS,
         TASK_CAPACITY_UTILIZATION_PCT, DEFAULT_BYTES_IN_KB_RATE, DEFAULT_MSGS_IN_RATE);
     int taskCount = estimator.getTaskCount(throughputInfo, assignedPartitions, unassignedPartitions, "test");
@@ -92,8 +92,8 @@ public class TestLoadBasedTaskCountEstimator {
   @Test
   public void partitionsHaveDefaultWeightTest() {
     ClusterThroughputInfo throughputInfo = new ClusterThroughputInfo("dummy", new HashMap<>());
-    List<String> assignedPartitions = Collections.emptyList();
-    List<String> unassignedPartitions = Arrays.asList("P1", "P2");
+    Set<String> assignedPartitions = Collections.emptySet();
+    Set<String> unassignedPartitions = new HashSet<>(Arrays.asList("P1", "P2"));
     LoadBasedTaskCountEstimator estimator = new LoadBasedTaskCountEstimator(TASK_CAPACITY_MBPS,
         TASK_CAPACITY_UTILIZATION_PCT, DEFAULT_BYTES_IN_KB_RATE, DEFAULT_MSGS_IN_RATE);
     int taskCount = estimator.getTaskCount(throughputInfo, assignedPartitions, unassignedPartitions, "test");
@@ -103,8 +103,8 @@ public class TestLoadBasedTaskCountEstimator {
   @Test
   public void throughputTaskEstimatorWithTopicLevelInformation() {
     ClusterThroughputInfo throughputInfo = _provider.getThroughputInfo("fruit");
-    List<String> assignedPartitions = Collections.emptyList();
-    List<String> unassignedPartitions = Arrays.asList("apple-0", "apple-1", "apple-2", "banana-0");
+    Set<String> assignedPartitions = Collections.emptySet();
+    Set<String> unassignedPartitions = new HashSet<>(Arrays.asList("apple-0", "apple-1", "apple-2", "banana-0"));
     LoadBasedTaskCountEstimator estimator = new LoadBasedTaskCountEstimator(TASK_CAPACITY_MBPS,
         TASK_CAPACITY_UTILIZATION_PCT, DEFAULT_BYTES_IN_KB_RATE, DEFAULT_MSGS_IN_RATE);
     int taskCount = estimator.getTaskCount(throughputInfo, assignedPartitions, unassignedPartitions, "test");

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssigner.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/assignment/TestLoadBasedPartitionAssigner.java
@@ -5,7 +5,6 @@
  */
 package com.linkedin.datastream.server.assignment;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -56,7 +55,7 @@ public class TestLoadBasedPartitionAssigner {
 
   @Test
   public void assignFromScratchTest() {
-    List<String> unassignedPartitions = Arrays.asList("P1", "P2", "P3");
+    Set<String> unassignedPartitions = new HashSet<>(Arrays.asList("P1", "P2", "P3"));
     ClusterThroughputInfo throughputInfo = getDummyClusterThroughputInfo(unassignedPartitions);
 
     Datastream ds1 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1")[0];
@@ -107,9 +106,9 @@ public class TestLoadBasedPartitionAssigner {
 
   @Test
   public void newAssignmentRetainsTasksFromOtherDatastreamsTest() {
-    List<String> assignedPartitions = Arrays.asList("P1", "P2");
-    List<String> unassignedPartitions = Collections.singletonList("P3");
-    List<String> allPartitions = new ArrayList<>(assignedPartitions);
+    Set<String> assignedPartitions = new HashSet<>(Arrays.asList("P1", "P2"));
+    Set<String> unassignedPartitions = Collections.singleton("P3");
+    Set<String> allPartitions = new HashSet<>(assignedPartitions);
     allPartitions.addAll(unassignedPartitions);
     ClusterThroughputInfo throughputInfo = getDummyClusterThroughputInfo(allPartitions);
 
@@ -169,7 +168,7 @@ public class TestLoadBasedPartitionAssigner {
   @Test
   public void assignmentDistributesPartitionsWhenThroughputInfoIsMissingTest() {
     // this tests the round-robin assignment of partitions that don't have throughput info
-    List<String> unassignedPartitions = Arrays.asList("P1", "P2", "P3", "P4");
+    Set<String> unassignedPartitions = new HashSet<>(Arrays.asList("P1", "P2", "P3", "P4"));
     ClusterThroughputInfo throughputInfo = new ClusterThroughputInfo("dummy", new HashMap<>());
 
     Datastream ds1 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds1")[0];
@@ -208,7 +207,7 @@ public class TestLoadBasedPartitionAssigner {
 
   @Test
   public void lightestTaskGetsNewPartitionTest() {
-    List<String> unassignedPartitions = Collections.singletonList("P4");
+    Set<String> unassignedPartitions = Collections.singleton("P4");
     Map<String, PartitionThroughputInfo> throughputInfoMap = new HashMap<>();
     throughputInfoMap.put("P1", new PartitionThroughputInfo(5, 5, "P1"));
     throughputInfoMap.put("P2", new PartitionThroughputInfo(5, 5, "P2"));
@@ -246,7 +245,7 @@ public class TestLoadBasedPartitionAssigner {
 
   @Test
   public void lightestTaskGetsNewPartitionWithTopicMetricsTest() {
-    List<String> unassignedPartitions = Arrays.asList("P-2", "P-3");
+    Set<String> unassignedPartitions = new HashSet<>(Arrays.asList("P-2", "P-3"));
     Map<String, PartitionThroughputInfo> throughputInfoMap = new HashMap<>();
     throughputInfoMap.put("P-1", new PartitionThroughputInfo(5, 5, "P-1"));
     throughputInfoMap.put("R", new PartitionThroughputInfo(5, 5, "R"));
@@ -288,7 +287,7 @@ public class TestLoadBasedPartitionAssigner {
 
   @Test
   public void throwsExceptionWhenNotEnoughRoomForAllPartitionsTest() {
-    List<String> unassignedPartitions = Arrays.asList("P4", "P5");
+    Set<String> unassignedPartitions = new HashSet<>(Arrays.asList("P4", "P5"));
     Map<String, PartitionThroughputInfo> throughputInfoMap = new HashMap<>();
     ClusterThroughputInfo throughputInfo = new ClusterThroughputInfo("dummy", throughputInfoMap);
 
@@ -312,7 +311,7 @@ public class TestLoadBasedPartitionAssigner {
 
   @Test
   public void taskWithRoomGetsNewPartitionTest() {
-    List<String> unassignedPartitions = Collections.singletonList("P4");
+    Set<String> unassignedPartitions = Collections.singleton("P4");
     Map<String, PartitionThroughputInfo> throughputInfoMap = new HashMap<>();
     throughputInfoMap.put("P1", new PartitionThroughputInfo(5, 5, "P1"));
     throughputInfoMap.put("P2", new PartitionThroughputInfo(5, 5, "P2"));
@@ -393,7 +392,7 @@ public class TestLoadBasedPartitionAssigner {
     return task;
   }
 
-  private ClusterThroughputInfo getDummyClusterThroughputInfo(List<String> partitions) {
+  private ClusterThroughputInfo getDummyClusterThroughputInfo(Set<String> partitions) {
     Map<String, PartitionThroughputInfo> partitionThroughputMap = new HashMap<>();
     for (String partitionName : partitions) {
       int bytesInRate = 5;


### PR DESCRIPTION
## Summary
- The coordinator thread should be able to finish any event in less than the configured heartbeat period (default 1 minute). Lately it has been observed that all the partition assignment events are taking more than approximately 1.5 minutes to complete for every request for large clusters with around ~500K partitions per datastream.

- The issue seems to be related to [this code](https://github.com/linkedin/brooklin/blob/a67108bcff9e3c8f5c22dbc44e04f91f200cc1cc/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java#L121) where the thread is stuck in the removeAll call, where one of the collections is a list. This may result in higher CPU usage.

- This has been confirmed with thread dumps and logs from a partition heavy cluster's performance. 
___
Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
