### PR TITLE
Update handle assignment error metric

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -742,7 +742,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       queueEvent = false;
 
       EventType meter = isDatastreamUpdate ? HANDLE_DATASTREAM_CHANGE_WITH_UPDATE : HANDLE_ASSIGNMENT_CHANGE;
-      _log.warn("Updating metric for event " + meter);
+      _log.warn("Updating metric for event={}", meter);
       _metrics.updateKeyedMeter(CoordinatorMetrics.getKeyedMeter(meter), 1);
     }
 


### PR DESCRIPTION
Update when handle assignment error metric is incremented.
1. When an ExecutionException is thrown indicating assignment failed
2. When we exhaust all retries (even if due to timeouts or something else)