### PR TITLE
Honor datastream metadata reuse when assigning group.id

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/GroupIdConstructor.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/GroupIdConstructor.java
@@ -77,14 +77,14 @@ public interface GroupIdConstructor {
       groupId = datastream.getMetadata().get(DatastreamMetadataConstants.GROUP_ID);
       logger.ifPresent(log -> log.info("Datastream {} has group ID specified in metadata. Will use that ID: {}",
           datastream.getName(), groupId));
-    } else if (!existingDatastreamsWithGroupIdOverride.isEmpty()) {
+    } else if (!existingDatastreamsWithGroupIdOverride.isEmpty() && DatastreamUtils.isReuseAllowed(datastream)) {
       // if existing datastream has group ID in it already, copy it over.
       groupId = existingDatastreamsWithGroupIdOverride.get(0).getMetadata().get(DatastreamMetadataConstants.GROUP_ID);
       logger.ifPresent(
           log -> log.info("Found existing datastream {} for datastream {} with group ID. Copying its group id: {}",
               existingDatastreamsWithGroupIdOverride.get(0).getName(), datastream.getName(), groupId));
     } else {
-      // else create and and keep it in metadata.
+      // else create and keep it in metadata.
       groupId = constructGroupId(datastream);
       logger.ifPresent(
           log -> log.info("Constructed group ID for datastream {}. Group id: {}", datastream.getName(), groupId));


### PR DESCRIPTION
Honor datastream metadata reuse when assigning group.id

Important: DO NOT REPORT SECURITY ISSUES DIRECTLY ON GITHUB.  
For reporting security issues and contributing security fixes,  
please, email security@linkedin.com instead, as described in  
the contribution guidelines.

Please, take a minute to review the contribution guidelines at:  
https://github.com/linkedin/Brooklin/blob/master/CONTRIBUTING.md
