### PR TITLE
Unblock waiting threads sooner

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4134,12 +4134,12 @@ public class TestCoordinator {
                       // Step 2
                       // Handling an event requires acquiring the coordinator's object.
                       handleEvent(new CoordinatorEvent(CoordinatorEvent.EventType.NO_OP, null));
-                      // Step 3
-                      notifyThreadsWaitingForCoordinatorObjectSynchronization();
                       if (isInterruptedInSleep) {
                         break;
                       }
                     }
+                    // Step 3
+                    notifyThreadsWaitingForCoordinatorObjectSynchronization();
                   }
                 };
                 testCoordinatorEventProcessor[0].setDaemon(true);
@@ -4167,7 +4167,7 @@ public class TestCoordinator {
   @Test
   public void testSessionExpiryCallbackThreadAttemptingToAcquireCoordinatorObjectAfterHandlingEvent() throws Exception {
     String testCluster = "dummyCluster";
-    long testHeartbeatPeriod = Duration.ofSeconds(5).toMillis();
+    long testHeartbeatPeriod = Duration.ofSeconds(2).toMillis();
 
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_CLUSTER, testCluster);
@@ -4202,16 +4202,16 @@ public class TestCoordinator {
                         // Making sure we sleep for less than heartbeat period to
                         // mock the scenario where the zk session expiry thread
                         // is waiting for notification from the event thread.
-                        Thread.sleep(testHeartbeatPeriod - Duration.ofMillis(2000).toMillis());
+                        Thread.sleep(testHeartbeatPeriod - Duration.ofMillis(500).toMillis());
                       } catch (InterruptedException e) {
                         isInterruptedInSleep = true;
                       }
-                      // Step 3
-                      notifyThreadsWaitingForCoordinatorObjectSynchronization();
                       if (isInterruptedInSleep) {
                         break;
                       }
                     }
+                    // Step 3
+                    notifyThreadsWaitingForCoordinatorObjectSynchronization();
                   }
                 };
                 testCoordinatorEventProcessor[0].setDaemon(true);

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4167,12 +4167,11 @@ public class TestCoordinator {
   @Test
   public void testSessionExpiryCallbackThreadAttemptingToAcquireCoordinatorObjectAfterHandlingEvent() throws Exception {
     String testCluster = "dummyCluster";
-    long testHeartbeatPeriod = Duration.ofSeconds(2).toMillis();
+    long testHeartbeatPeriod = Duration.ofSeconds(5).toMillis();
 
     Properties properties = new Properties();
     properties.put(CoordinatorConfig.CONFIG_CLUSTER, testCluster);
     properties.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, _zkConnectionString);
-    // custom heartbeat period of 2 second.
     properties.put(CoordinatorConfig.CONFIG_HEARTBEAT_PERIOD_MS, String.valueOf(testHeartbeatPeriod));
 
     final Coordinator.CoordinatorEventProcessor[] testCoordinatorEventProcessor = {null};
@@ -4203,7 +4202,7 @@ public class TestCoordinator {
                         // Making sure we sleep for less than heartbeat period to
                         // mock the scenario where the zk session expiry thread
                         // is waiting for notification from the event thread.
-                        Thread.sleep(testHeartbeatPeriod - Duration.ofMillis(500).toMillis());
+                        Thread.sleep(testHeartbeatPeriod - Duration.ofMillis(2000).toMillis());
                       } catch (InterruptedException e) {
                         isInterruptedInSleep = true;
                       }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -385,6 +385,10 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // explicitly via this CV.
       _log.info("Thread {} will wait for notification from the event thread for {} ms.",
           Thread.currentThread().getName(), duration.toMillis());
+      // The goal of this wait is to give eventThread a chance to acquire a lock on the coordinator object for the handleEvent
+      // ideally, we would use while loop here to avoid spurious signals, but in our case, we have a while loop
+      // which calls this method, so it is ok. Also, this if condition helps us to not continue go into wait mode,
+      // because it may cause shutdown to not run gracefully if the connecting deployment system has shorter timeouts
       if (!_handleEventCompleted) {
         this.wait(duration.toMillis());
       }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -384,9 +384,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // attempting to acquire the Coordinator object. We never halt the event thread (coordinator thread)
       // explicitly via this CV.
 
-      // The goal of this wait is to give eventThread a chance to acquire a lock on the coordinator object for the handleEvent
-      // ideally, we would use while loop here to avoid spurious signals, but in our case, we have a while loop
-      // which calls this method, so it is ok. Also, this if condition helps us to not continue go into wait mode,
+      // The goal of this wait is to give eventThread a chance to acquire a lock on the coordinator object for the
+      // handleEvent. Ideally, we would use while loop here to avoid spurious signals, but in our case, we have a while
+      // loop which calls this method, so it is ok. Also, this if condition helps us to not continue go into wait mode,
       // because it may cause shutdown to not run gracefully if the connecting deployment system has shorter timeouts
       if (!_coordinatorEventThreadExiting) {
         _log.info("Thread {} will wait for notification from the event thread for {} ms.",

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -219,9 +219,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private final Map<String, SerdeAdmin> _serdeAdmins = new HashMap<>();
   private final Map<String, Authorizer> _authorizers = new HashMap<>();
   private volatile boolean _shutdown = false;
-  // TODO we have _shutdown, eventThread and now _coordinatorStopped, for some distinct usage,
+  // TODO we have _shutdown, eventThread and now _handleEventCompleted, for some distinct usage,
   //  we should revisit and refactor to have less variation
-  private volatile boolean _coordinatorStopped = false;
+  private volatile boolean _handleEventCompleted = false;
 
   private CoordinatorEventProcessor _eventThread;
   private ScheduledExecutorService _scheduledExecutor;
@@ -385,7 +385,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // explicitly via this CV.
       _log.info("Thread {} will wait for notification from the event thread for {} ms.",
           Thread.currentThread().getName(), duration.toMillis());
-      if (!_coordinatorStopped) {
+      if (!_handleEventCompleted) {
         this.wait(duration.toMillis());
       }
 
@@ -2253,7 +2253,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   // We are only calling notify on the synchronized Coordinator Object's ("this") waiting threads.
   // Suppressing the Naked_Notify warning on this.
   protected synchronized void notifyThreadsWaitingForCoordinatorObjectSynchronization() {
-    _coordinatorStopped = true;
+    _handleEventCompleted = true;
     this.notifyAll();
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2348,6 +2348,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         try {
           CoordinatorEvent event = _eventQueue.take();
           if (event != null) {
+            // metrics
             handleEvent(event);
             notifyThreadsWaitingForCoordinatorObjectSynchronization();
           }
@@ -2358,6 +2359,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           _log.error("CoordinatorEventProcessor failed", t);
         }
       }
+      notifyThreadsWaitingForCoordinatorObjectSynchronization();
       _log.info("END CoordinatorEventProcessor");
     }
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -219,7 +219,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private final Map<String, SerdeAdmin> _serdeAdmins = new HashMap<>();
   private final Map<String, Authorizer> _authorizers = new HashMap<>();
   private volatile boolean _shutdown = false;
-  private volatile boolean _notified = false;
+  private volatile boolean _coordinatorStopped = false;
 
   private CoordinatorEventProcessor _eventThread;
   private ScheduledExecutorService _scheduledExecutor;
@@ -383,7 +383,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // explicitly via this CV.
       _log.info("Thread {} will wait for notification from the event thread for {} ms.",
           Thread.currentThread().getName(), duration.toMillis());
-      while (!_notified) {
+      while (!_coordinatorStopped) {
         this.wait(duration.toMillis());
       }
 
@@ -2251,7 +2251,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   // We are only calling notify on the synchronized Coordinator Object's ("this") waiting threads.
   // Suppressing the Naked_Notify warning on this.
   protected synchronized void notifyThreadsWaitingForCoordinatorObjectSynchronization() {
-    _notified = true;
+    _coordinatorStopped = true;
     this.notifyAll();
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -220,7 +220,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private final Map<String, Authorizer> _authorizers = new HashMap<>();
   private volatile boolean _shutdown = false;
   // TODO we have _shutdown, eventThread and now _coordinatorStopped, for some distinct usage,
-  //  we should see if we can revisit and refactor to have less variation
+  //  we should revisit and refactor to have less variation
   private volatile boolean _coordinatorStopped = false;
 
   private CoordinatorEventProcessor _eventThread;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -219,6 +219,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private final Map<String, SerdeAdmin> _serdeAdmins = new HashMap<>();
   private final Map<String, Authorizer> _authorizers = new HashMap<>();
   private volatile boolean _shutdown = false;
+  // TODO we have _shutdown, eventThread and now _coordinatorStopped, for some distinct usage,
+  // we should see if we can revisit and refactor to have less variation
   private volatile boolean _coordinatorStopped = false;
 
   private CoordinatorEventProcessor _eventThread;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2348,7 +2348,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         try {
           CoordinatorEvent event = _eventQueue.take();
           if (event != null) {
-            // metrics
             handleEvent(event);
             notifyThreadsWaitingForCoordinatorObjectSynchronization();
           }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -31,10 +31,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
-import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReadWriteLock;
-import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.BooleanSupplier;
 import java.util.function.Function;
@@ -1168,7 +1166,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   }
 
   protected synchronized void handleEvent(CoordinatorEvent event) {
-    _eventBeingHandled = true;
     _log.info("START: Handle event " + event.getType() + ", Instance: " + _adapter.getInstanceName());
     boolean isLeader = _adapter.isLeader();
     if (!isLeader && isLeaderEvent(event.getType())) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2364,7 +2364,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           CoordinatorEvent event = _eventQueue.take();
           if (event != null) {
             handleEvent(event);
-//            notifyThreadsWaitingForCoordinatorObjectSynchronization();
           }
         } catch (InterruptedException e) {
           _log.warn("CoordinatorEventProcessor interrupted", e);
@@ -2373,7 +2372,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           _log.error("CoordinatorEventProcessor failed", t);
         }
       }
-//      notifyThreadsWaitingForCoordinatorObjectSynchronization();
       _log.info("END CoordinatorEventProcessor");
     }
   }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -383,7 +383,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // explicitly via this CV.
       _log.info("Thread {} will wait for notification from the event thread for {} ms.",
           Thread.currentThread().getName(), duration.toMillis());
-      while (!_coordinatorStopped) {
+      if (!_coordinatorStopped) {
         this.wait(duration.toMillis());
       }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -220,7 +220,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private final Map<String, Authorizer> _authorizers = new HashMap<>();
   private volatile boolean _shutdown = false;
   // TODO we have _shutdown, eventThread and now _coordinatorStopped, for some distinct usage,
-  // we should see if we can revisit and refactor to have less variation
+  //  we should see if we can revisit and refactor to have less variation
   private volatile boolean _coordinatorStopped = false;
 
   private CoordinatorEventProcessor _eventThread;

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.5.0-SNAPSHOT"
+  version = "5.5.1-SNAPSHOT"
 }
 
 subprojects {


### PR DESCRIPTION
currently, during the shutdown, we always wait 60seconds before we unblock other waiting threads(zk callback thread or main threads) on coordinator object, this was being added as part of https://github.com/linkedin/brooklin/pull/964, our expectation was  the intrinsic CV will help us with notifying blocking threads sooner, but `notifyAll` was not mentioned at the right place, which was making other threads to be blocked on for 60 seconds always.


This PR uses explicit state variable for intrinsic CV, checks the new state variable `_handleEventCompleted` and wait only if false. From evenThread run method, we update the state variable and call notifyAll() outside the while loop; when shutdown is true. This will help blocking thread to unblock and have a chance to acquire the lock on the coordinator object and perform the clean shutdown.
