### PR TITLE
Apply lock at Coordinator class level

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -3230,6 +3230,7 @@ public class TestCoordinator {
       Assert.assertTrue(t != null && t.isAlive());
       Assert.assertTrue(PollUtils.poll(() -> instance1.getIsLeader().getAsBoolean(), 100, 30000));
     }
+    instance1._coordinatorEventThreadExiting = false;
 
     instance1.stop();
     instance1.getDatastreamCache().getZkclient().close();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -390,7 +390,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       if (!_coordinatorEventThreadExiting) {
         _log.info("Thread {} will wait for notification from the event thread for {} ms.",
             Thread.currentThread().getName(), duration.toMillis());
-        this.wait(duration.toMillis());
+        wait(duration.toMillis());
       }
 
     } catch (InterruptedException exception) {
@@ -2370,9 +2370,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           _log.error("CoordinatorEventProcessor failed", t);
         }
       }
-      synchronized (this) {
+      synchronized (Coordinator.class) {
         _coordinatorEventThreadExiting = true;
-        this.notifyAll();
+        notifyAll();
       }
       _log.info("END CoordinatorEventProcessor");
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -390,7 +390,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       if (!_coordinatorEventThreadExiting) {
         _log.info("Thread {} will wait for notification from the event thread for {} ms.",
             Thread.currentThread().getName(), duration.toMillis());
-        wait(duration.toMillis());
+        this.wait(duration.toMillis());
       }
 
     } catch (InterruptedException exception) {
@@ -2370,11 +2370,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           _log.error("CoordinatorEventProcessor failed", t);
         }
       }
-      synchronized (Coordinator.class) {
+      synchronized (Coordinator.this) {
         _coordinatorEventThreadExiting = true;
         _log.info("notify waiting threads for Coordinator object lock, "
             + "_coordinatorEventThreadExiting={}", _coordinatorEventThreadExiting);
-        notifyAll();
+        Coordinator.this.notifyAll();
       }
       _log.info("END CoordinatorEventProcessor");
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -221,7 +221,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private volatile boolean _shutdown = false;
   // TODO we have _shutdown, eventThread and now _coordinatorEventThreadExiting, for some distinct usage,
   //  we should revisit and refactor to have less variation
-  private volatile boolean _coordinatorEventThreadExiting = false;
+  protected volatile boolean _coordinatorEventThreadExiting = false;
 
   private CoordinatorEventProcessor _eventThread;
   private ScheduledExecutorService _scheduledExecutor;
@@ -2370,6 +2370,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           _log.error("CoordinatorEventProcessor failed", t);
         }
       }
+      _log.info("Exiting eventThread _shutdown={} isInterrupted={}", _shutdown, isInterrupted());
       synchronized (Coordinator.this) {
         _coordinatorEventThreadExiting = true;
         _log.info("notify waiting threads for Coordinator object lock, "

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2372,6 +2372,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       }
       synchronized (Coordinator.class) {
         _coordinatorEventThreadExiting = true;
+        _log.info("notify waiting threads for Coordinator object lock, "
+            + "_coordinatorEventThreadExiting={}", _coordinatorEventThreadExiting);
         notifyAll();
       }
       _log.info("END CoordinatorEventProcessor");


### PR DESCRIPTION
As part of https://github.com/linkedin/brooklin/pull/975 where we used 

```
synchronized (this) {...}
```
it was giving lock on the `CoordinatorEventProcessor` instance.  However, we need a lock on the `Coordinator` class, hence the notifyAll was not working as expected.

This PR fixes the above regression by introducing 
```
synchronized (Coordinator.class) {
```