### PR TITLE
Add Method to Extract Undecorated Topic from Datastream Metadata for Accurate SLA Latency Reporting

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/transport/DatastreamRecordMetadata.java
@@ -123,6 +123,17 @@ public class DatastreamRecordMetadata {
     return _topic;
   }
 
+ /**
+  * Gets the topic name without any decorations or modifications.
+  * This base implementation simply returns the topic name as is.
+  * Subclasses may override this method to provide custom topic name undecorating logic.
+  * @return The undecorated topic name
+  */
+ public String getUndecoratedTopic() {
+   // It is kept for backward compatibility.
+   return _topic;
+ }
+
   /**
    * An index identifying the exact {@link com.linkedin.datastream.common.BrooklinEnvelope} event produced,
    * from those obtainable through {@link com.linkedin.datastream.server.DatastreamProducerRecord#getEvents()}

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -337,7 +337,7 @@ public class EventProducer implements DatastreamEventProducer {
     if (_numEventsOutsideAltSlaLogEnabled) {
       try {
         if (sourceToDestinationLatencyMs > _availabilityThresholdAlternateSlaMs) {
-          TopicPartition topicPartition = new TopicPartition(metadata.getTopic(), metadata.getSourcePartition());
+          TopicPartition topicPartition = new TopicPartition(metadata.getUndecoratedTopic(), metadata.getSourcePartition());
           int numEvents = _trackEventsOutsideAltSlaMap.getOrDefault(topicPartition, 0);
           _trackEventsOutsideAltSlaMap.put(topicPartition, numEvents + 1);
         }
@@ -506,7 +506,8 @@ public class EventProducer implements DatastreamEventProducer {
         // Report metrics
         checkpoint(metadata.getPartition(), metadata.getCheckpoint());
         // Reporting separate metrics for throughput violating topics.
-        if (_throughputViolatingTopicsProvider.apply(_datastreamTask).contains(metadata.getTopic())) {
+
+        if (_throughputViolatingTopicsProvider.apply(_datastreamTask).contains(metadata.getUndecoratedTopic())) {
           reportMetricsForThroughputViolatingTopics(metadata, eventSourceTimestamp, eventSendTimestamp);
         } else {
           reportMetrics(metadata, eventSourceTimestamp, eventSendTimestamp);

--- a/gradle/buildscript.gradle
+++ b/gradle/buildscript.gradle
@@ -8,6 +8,7 @@ repositories {
         maven {
             url "https://linkedin.jfrog.io/artifactory/open-source"
         }
+        maven { url "https://repo.grails.org/grails/core/" }
     }
 }
 

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.5.5"
+  version = "5.5.6"
 }
 
 subprojects {


### PR DESCRIPTION
##Problem & Solution Overview
This PR introduces a new method getUndecoratedTopic() to extract the undecorated topic from the DatastreamRecordMetadata. This method was needed to address an issue where the SLA latency metrics were not being reported correctly due to the presence of topic decorations.

Previously, when extracting the topic name from the metadata, any decorations were included, causing issues with accurate SLA latency reporting. The new method ensures that only the undecorated topic name is used for reporting metrics related to SLA latency, leading to more accurate metrics for throughput and SLA violations.

##Changes

- Added getUndecoratedTopic() method: This method extracts the undecorated topic name from the metadata.
- Modified SLA reporting logic: The latency metrics are now correctly reported by using the undecorated topic name.
This was implemented in the onSendCallback() method where metrics for topics violating the SLA throughput are now based on the undecorated topic name.

##Testing

- [ ] Validated that the SLA reporting logic now uses the undecorated topic name and calculates the latency metrics correctly.


