### PR TITLE
Add grace period for newly created CDC streams (suppress primary/alternate SLA, redirect latency to newlyOnboardedLatencyMs)

### DIFF
--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -604,9 +604,8 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected void handleNoOffsetForPartitionException(NoOffsetForPartitionException e) {
     _logger.info("Poll threw NoOffsetForPartitionException for partitions {}.", e.partitions());
     if (!_shutdown) {
-      // Default to EARLIEST for CDC connectors to avoid data loss for CDC+Bootstrap use-case.
-      // Starting from EARLIEST ensures the consumer reads all records including bootstrap
-      // snapshot data and change events from the bootstrap window. (DATAPIPES-33203)
+      // Default to EARLIEST to reuse any existing snapshot/data already in the topic when no
+      // committed offset is found. The auto.offset.reset consumer property wins if explicitly set.
       seekToStartPosition(_consumer, e.partitions(),
           _consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_EARLIEST));
     }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -604,9 +604,11 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected void handleNoOffsetForPartitionException(NoOffsetForPartitionException e) {
     _logger.info("Poll threw NoOffsetForPartitionException for partitions {}.", e.partitions());
     if (!_shutdown) {
-      // Seek to start position, by default we are starting from latest one as we just start consumption
+      // Default to EARLIEST for CDC connectors to avoid data loss for CDC+Bootstrap use-case.
+      // Starting from EARLIEST ensures the consumer reads all records including bootstrap
+      // snapshot data and change events from the bootstrap window. (DATAPIPES-33203)
       seekToStartPosition(_consumer, e.partitions(),
-          _consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_LATEST));
+          _consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_EARLIEST));
     }
   }
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaBasedConnectorTask.java
@@ -604,10 +604,9 @@ abstract public class AbstractKafkaBasedConnectorTask implements Runnable, Consu
   protected void handleNoOffsetForPartitionException(NoOffsetForPartitionException e) {
     _logger.info("Poll threw NoOffsetForPartitionException for partitions {}.", e.partitions());
     if (!_shutdown) {
-      // Default to EARLIEST to reuse any existing snapshot/data already in the topic when no
-      // committed offset is found. The auto.offset.reset consumer property wins if explicitly set.
+      // Seek to start position, by default we are starting from latest one as we just start consumption
       seekToStartPosition(_consumer, e.partitions(),
-          _consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_EARLIEST));
+          _consumerProps.getProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, CONSUMER_AUTO_OFFSET_RESET_CONFIG_LATEST));
     }
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -73,6 +73,7 @@ public class EventProducer implements DatastreamEventProducer {
   public static final String DEFAULT_FLUSH_INTERVAL_MS = String.valueOf(Duration.ofMinutes(5).toMillis());
 
   static final String EVENTS_LATENCY_MS_STRING = "eventsLatencyMs";
+  static final String SLA_EXCLUDED_LATENCY_MS_STRING = "slaExcludedLatencyMs";
   static final String EVENTS_SEND_LATENCY_MS_STRING = "eventsSendLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_LATENCY_MS_STRING = "throughputViolatingEventsLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_SEND_LATENCY_MS_STRING = "throughputViolatingEventsSendLatencyMs";
@@ -456,11 +457,15 @@ public class EventProducer implements DatastreamEventProducer {
     if (eventsSourceTimestamp > 0) {
       // Report availability metrics
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
-      reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
+      // Redirect the latency histogram to slaExcludedLatencyMs during the CDC catch-up grace window
+      // so lag alerts wired to eventsLatencyMs do not fire on the initial backlog drain. The catch-up
+      // curve is still observable on slaExcludedLatencyMs.
+      String latencyMetricName = isWithinSlaGracePeriod() ? SLA_EXCLUDED_LATENCY_MS_STRING : EVENTS_LATENCY_MS_STRING;
+      reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, latencyMetricName);
 
-      // During the CDC catch-up grace window suppress only the primary SLA counter so the strict
-      // 1-minute dashboard isn't polluted by initial backlog drain. The alternate SLA pair keeps
-      // emitting throughout — operators retain a coarser SLA signal end-to-end.
+      // Primary SLA pair is suppressed during grace so the strict 1-minute dashboard isn't polluted
+      // by initial backlog drain. The alternate SLA pair keeps emitting throughout — operators retain
+      // a coarser SLA signal end-to-end.
       if (!isWithinSlaGracePeriod()) {
         reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
             EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
@@ -735,6 +740,9 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + DROPPED_SENT_FROM_SERIALIZATION_ERROR));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_LATENCY_MS_STRING, Optional.of(
+        Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
+            BrooklinHistogramInfo.PERCENTILE_999))));
+    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + SLA_EXCLUDED_LATENCY_MS_STRING, Optional.of(
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
             BrooklinHistogramInfo.PERCENTILE_999))));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_SEND_LATENCY_MS_STRING));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -194,13 +194,7 @@ public class EventProducer implements DatastreamEventProducer {
 
     _newStreamSlaGracePeriodMs = Long.parseLong(
         config.getProperty(NEW_STREAM_SLA_GRACE_PERIOD_MS, DEFAULT_NEW_STREAM_SLA_GRACE_PERIOD_MS));
-
-    // Source-database parsing pulled forward so we can gate stream-creation-time parsing on
-    // whether this is a CDC source. Non-CDC sources (BMM kafka://, Inlogs, etc.) don't have a
-    // bootstrap window worth masking, so skip the work entirely for them.
-    String[] sourceParts = getSourcePathParts();
-    _sourceDatabase = (sourceParts != null && sourceParts.length > 1) ? sourceParts[1] : null;
-    _streamCreationTimeMs = (_sourceDatabase != null) ? parseStreamCreationTimeMs(task) : 0L;
+    _streamCreationTimeMs = parseStreamCreationTimeMs(task);
 
     _warnLogLatencyEnabled =
         Boolean.parseBoolean(config.getProperty(WARN_LOG_LATENCY_ENABLED, DEFAULT_WARN_LOG_LATENCY_ENABLED));
@@ -226,6 +220,9 @@ public class EventProducer implements DatastreamEventProducer {
 
     _enableThroughputMetrics =
         Boolean.parseBoolean(config.getProperty(CONFIG_ENABLE_THROUGHPUT_METRICS, Boolean.FALSE.toString()));
+
+    String[] sourceParts = getSourcePathParts();
+    _sourceDatabase = (sourceParts != null && sourceParts.length > 1) ? sourceParts[1] : null;
 
     _logger.info("Created event producer with customCheckpointing={}", customCheckpointing);
 
@@ -356,12 +353,19 @@ public class EventProducer implements DatastreamEventProducer {
     return broadcastMetadata;
   }
 
+  private boolean isCdcSource() {
+    return _sourceDatabase != null;
+  }
+
   /**
-   * Returns true while a CDC stream is still within its bootstrap-catch-up grace window.
-   * For non-CDC sources {@code _streamCreationTimeMs} is left at 0 by the constructor, so the
-   * arithmetic naturally short-circuits to false and SLA reporting is unaffected.
+   * Returns true while a CDC stream is still within its cdc-catch-up grace window. Non-CDC
+   * sources (BMM kafka://, Inlogs, etc.) always return false here so SLA reporting is
+   * unaffected for them.
    */
   private boolean isWithinSlaGracePeriod() {
+    if (!isCdcSource()) {
+      return false;
+    }
     return (System.currentTimeMillis() - _streamCreationTimeMs) < _newStreamSlaGracePeriodMs;
   }
 
@@ -454,9 +458,8 @@ public class EventProducer implements DatastreamEventProducer {
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
 
-      // SLA reporting is suppressed while a CDC stream is still draining its initial bootstrap
-      // backlog from EARLIEST; latency histograms above continue to fire so backlog visibility
-      // is preserved.
+      // SLA reporting is suppressed while a CDC stream is still draining its initial cdc backlog
+      // from EARLIEST; latency histograms above continue to fire so backlog visibility is preserved.
       if (!isWithinSlaGracePeriod()) {
         reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
             EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.common.DatastreamRuntimeException;
 import com.linkedin.datastream.common.ErrorLogger;
 import com.linkedin.datastream.metrics.BrooklinCounterInfo;
@@ -90,6 +91,8 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String WARN_LOG_LATENCY_THRESHOLD_MS = "warnLogLatencyThresholdMs";
   private static final String NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_ENABLED = "numEventsOutsideAltSlaLogEnabled";
   private static final String NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_FREQUENCY_MS = "numEventsOutsideAltSlaFrequencyMs";
+  private static final String NEW_STREAM_SLA_GRACE_PERIOD_MS = "newStreamSlaGracePeriodMs";
+  private static final String DEFAULT_NEW_STREAM_SLA_GRACE_PERIOD_MS = "7200000"; // 2 hours
   private static final String EVENTS_PRODUCED_OUTSIDE_SLA = "eventsProducedOutsideSla";
   private static final String EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA = "eventsProducedOutsideAlternateSla";
   private static final String DROPPED_SENT_FROM_SERIALIZATION_ERROR = "droppedSentFromSerializationError";
@@ -114,6 +117,10 @@ public class EventProducer implements DatastreamEventProducer {
   private final int _availabilityThresholdSlaMs;
   // Alternate SLA for comparison with the main SLA
   private final int _availabilityThresholdAlternateSlaMs;
+  // Grace period for new streams: skip SLA reporting for streams newer than this duration
+  private final long _newStreamSlaGracePeriodMs;
+  // Timestamp when the stream was created (from datastream metadata)
+  private final long _streamCreationTimeMs;
   // Whether to enable warning logs if the latency threshold is met
   private final boolean _warnLogLatencyEnabled;
   // Latency threshold at which to log a warning message
@@ -184,6 +191,29 @@ public class EventProducer implements DatastreamEventProducer {
 
     _availabilityThresholdAlternateSlaMs = Integer.parseInt(
         config.getProperty(AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS, DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS));
+
+    _newStreamSlaGracePeriodMs = Long.parseLong(
+        config.getProperty(NEW_STREAM_SLA_GRACE_PERIOD_MS, DEFAULT_NEW_STREAM_SLA_GRACE_PERIOD_MS));
+
+    // Use the oldest (min) CREATION_MS across deduped datastreams sharing this task. Once any one
+    // stream has been running past the grace window, the underlying consumer is at HEAD and SLA
+    // reporting should resume; using the newest creation time would let a freshly deduped stream
+    // suppress SLA on long-running siblings. Zero/missing/malformed values are filtered out and
+    // fall through to the fail-open default (0 → grace disabled).
+    long creationMs = 0;
+    try {
+      if (task.getDatastreams() != null && !task.getDatastreams().isEmpty()) {
+        creationMs = task.getDatastreams().stream()
+            .map(ds -> ds.getMetadata().getOrDefault(DatastreamMetadataConstants.CREATION_MS, "0"))
+            .mapToLong(Long::parseLong)
+            .filter(ms -> ms > 0)
+            .min()
+            .orElse(0L);
+      }
+    } catch (Exception e) {
+      _logger.warn("Failed to parse stream creation time, SLA grace period will not be applied", e);
+    }
+    _streamCreationTimeMs = creationMs;
 
     _warnLogLatencyEnabled =
         Boolean.parseBoolean(config.getProperty(WARN_LOG_LATENCY_ENABLED, DEFAULT_WARN_LOG_LATENCY_ENABLED));
@@ -409,11 +439,24 @@ public class EventProducer implements DatastreamEventProducer {
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
 
-      reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
-          EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
+      // Skip SLA reporting for newly created CDC streams during grace period (DATAPIPES-33203).
+      // CDC streams starting from EARLIEST offset have large initial lag during bootstrap catch-up
+      // which would trigger false SLA violations. CDC sources are identified by single-slash URI
+      // scheme (e.g. espresso:/, mysql:/, tidb:/) which yields a non-null _sourceDatabase; BMM
+      // double-slash URIs (kafka://) yield null and are excluded so MirrorMaker reports SLA from
+      // the first event.
+      boolean isCdcSource = _sourceDatabase != null;
+      boolean isWithinGracePeriod = isCdcSource
+          && _streamCreationTimeMs > 0
+          && (System.currentTimeMillis() - _streamCreationTimeMs) < _newStreamSlaGracePeriodMs;
 
-      reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
-          EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
+      if (!isWithinGracePeriod) {
+        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
+            EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
+
+        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
+            EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
+      }
 
       if (_logger.isDebugEnabled()) {
         if (sourceToDestinationLatencyMs > _availabilityThresholdSlaMs) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -73,7 +73,7 @@ public class EventProducer implements DatastreamEventProducer {
   public static final String DEFAULT_FLUSH_INTERVAL_MS = String.valueOf(Duration.ofMinutes(5).toMillis());
 
   static final String EVENTS_LATENCY_MS_STRING = "eventsLatencyMs";
-  static final String SLA_EXCLUDED_LATENCY_MS_STRING = "slaExcludedLatencyMs";
+  static final String NEWLY_ONBOARDED_LATENCY_MS_STRING = "newlyOnboardedLatencyMs";
   static final String EVENTS_SEND_LATENCY_MS_STRING = "eventsSendLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_LATENCY_MS_STRING = "throughputViolatingEventsLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_SEND_LATENCY_MS_STRING = "throughputViolatingEventsSendLatencyMs";
@@ -92,15 +92,10 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String WARN_LOG_LATENCY_THRESHOLD_MS = "warnLogLatencyThresholdMs";
   private static final String NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_ENABLED = "numEventsOutsideAltSlaLogEnabled";
   private static final String NUM_EVENTS_OUTSIDE_ALT_SLA_LOG_FREQUENCY_MS = "numEventsOutsideAltSlaFrequencyMs";
-  private static final String NEW_STREAM_SLA_GRACE_PERIOD_MS = "newStreamSlaGracePeriodMs";
-  private static final String DEFAULT_NEW_STREAM_SLA_GRACE_PERIOD_MS = "7200000"; // 2 hours
+  private static final String NEW_STREAM_GRACE_PERIOD_MS = "newStreamGracePeriodMs";
+  private static final String DEFAULT_NEW_STREAM_GRACE_PERIOD_MS = "7200000"; // 2 hours
   private static final String EVENTS_PRODUCED_OUTSIDE_SLA = "eventsProducedOutsideSla";
   private static final String EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA = "eventsProducedOutsideAlternateSla";
-  // Counterparts to EVENTS_PRODUCED_*_ALTERNATE_SLA, emitted only while a CDC stream is inside its
-  // catch-up grace window so the regular alternate-SLA dashboards stay clean while operators can
-  // still track grace-period stats on a dedicated counter.
-  private static final String SLA_EXCLUDED_WITHIN_ALTERNATE_SLA = "slaExcludedWithinAlternateSla";
-  private static final String SLA_EXCLUDED_OUTSIDE_ALTERNATE_SLA = "slaExcludedOutsideAlternateSla";
   private static final String DROPPED_SENT_FROM_SERIALIZATION_ERROR = "droppedSentFromSerializationError";
   static final String BYTES_PRODUCED_RATE = "bytesProducedRate";
   private static final String AGGREGATE = "aggregate";
@@ -123,8 +118,9 @@ public class EventProducer implements DatastreamEventProducer {
   private final int _availabilityThresholdSlaMs;
   // Alternate SLA for comparison with the main SLA
   private final int _availabilityThresholdAlternateSlaMs;
-  // Grace period for new streams: skip SLA reporting for streams newer than this duration
-  private final long _newStreamSlaGracePeriodMs;
+  // Grace period for newly created streams. While a stream is inside this window, primary/alternate
+  // SLA counters are suppressed and the latency histogram is redirected to newlyOnboardedLatencyMs.
+  private final long _newStreamGracePeriodMs;
   // Timestamp when the stream was created (from datastream metadata)
   private final long _streamCreationTimeMs;
   // Whether to enable warning logs if the latency threshold is met
@@ -198,8 +194,8 @@ public class EventProducer implements DatastreamEventProducer {
     _availabilityThresholdAlternateSlaMs = Integer.parseInt(
         config.getProperty(AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS, DEFAULT_AVAILABILITY_THRESHOLD_ALTERNATE_SLA_MS));
 
-    _newStreamSlaGracePeriodMs = Long.parseLong(
-        config.getProperty(NEW_STREAM_SLA_GRACE_PERIOD_MS, DEFAULT_NEW_STREAM_SLA_GRACE_PERIOD_MS));
+    _newStreamGracePeriodMs = Long.parseLong(
+        config.getProperty(NEW_STREAM_GRACE_PERIOD_MS, DEFAULT_NEW_STREAM_GRACE_PERIOD_MS));
     _streamCreationTimeMs = parseStreamCreationTimeMs(task);
 
     _warnLogLatencyEnabled =
@@ -365,24 +361,25 @@ public class EventProducer implements DatastreamEventProducer {
 
   /**
    * Returns true while a CDC stream is still within its cdc-catch-up grace window. Non-CDC
-   * sources (BMM kafka://, Inlogs, etc.) always return false here so SLA reporting is
-   * unaffected for them.
+   * sources (BMM kafka://, Inlogs, etc.) always return false here so neither SLA suppression
+   * nor the latency-histogram redirect applies to them.
    */
-  private boolean isWithinSlaGracePeriod() {
+  private boolean isWithinGracePeriod() {
     if (!isCdcSource()) {
       return false;
     }
-    return (System.currentTimeMillis() - _streamCreationTimeMs) < _newStreamSlaGracePeriodMs;
+    return (System.currentTimeMillis() - _streamCreationTimeMs) < _newStreamGracePeriodMs;
   }
 
   /**
-   * Single gate that decides whether to emit the regular primary / alternate SLA counters.
-   * Combines all current and future SLA-suppression conditions in one place — additional
-   * conditions (e.g. per-datastream opt-out flags) should be ORed in here so callers don't
-   * need to know about every gating condition individually.
+   * Single gate that decides whether to emit metrics to their regular destinations. When this
+   * returns false, primary and alternate SLA counters are suppressed and the latency histogram
+   * is redirected to newlyOnboardedLatencyMs. Combines all suppression conditions in one place
+   * — additional conditions (e.g. per-datastream opt-out flags) should be ORed in here so call
+   * sites do not need to know about every gating condition individually.
    */
-  private boolean shouldEmitSlaMetric() {
-    if (isWithinSlaGracePeriod()) {
+  private boolean shouldEmitMetric() {
+    if (isWithinGracePeriod()) {
       return false;
     }
     return true;
@@ -475,24 +472,20 @@ public class EventProducer implements DatastreamEventProducer {
     if (eventsSourceTimestamp > 0) {
       // Report availability metrics
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
-      // Redirect the latency histogram to slaExcludedLatencyMs while SLA emission is suppressed
+      // Redirect the latency histogram to newlyOnboardedLatencyMs while SLA emission is suppressed
       // so lag alerts wired to eventsLatencyMs do not fire on the initial CDC catch-up. The
-      // catch-up curve is still observable on slaExcludedLatencyMs.
-      String latencyMetricName = shouldEmitSlaMetric() ? EVENTS_LATENCY_MS_STRING : SLA_EXCLUDED_LATENCY_MS_STRING;
+      // catch-up curve is still observable on newlyOnboardedLatencyMs.
+      String latencyMetricName = shouldEmitMetric() ? EVENTS_LATENCY_MS_STRING : NEWLY_ONBOARDED_LATENCY_MS_STRING;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, latencyMetricName);
 
-      // While SLA emission is suppressed, the alternate SLA is still measured against its
-      // threshold but routed to a dedicated slaExcluded* counter pair so operators can track
-      // suppression-period stats without polluting the regular alternate-SLA dashboard.
-      if (shouldEmitSlaMetric()) {
+      // While shouldEmitMetric() returns false (currently only during the CDC catch-up grace
+      // window) both primary and alternate SLA counter pairs are suppressed entirely.
+      if (shouldEmitMetric()) {
         reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
             EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
 
         reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
             EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
-      } else {
-        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
-            SLA_EXCLUDED_WITHIN_ALTERNATE_SLA, SLA_EXCLUDED_OUTSIDE_ALTERNATE_SLA);
       }
 
       if (_logger.isDebugEnabled()) {
@@ -759,13 +752,11 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX + BYTES_PRODUCED_RATE));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA));
-    metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + SLA_EXCLUDED_WITHIN_ALTERNATE_SLA));
-    metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + SLA_EXCLUDED_OUTSIDE_ALTERNATE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + DROPPED_SENT_FROM_SERIALIZATION_ERROR));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_LATENCY_MS_STRING, Optional.of(
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
             BrooklinHistogramInfo.PERCENTILE_999))));
-    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + SLA_EXCLUDED_LATENCY_MS_STRING, Optional.of(
+    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + NEWLY_ONBOARDED_LATENCY_MS_STRING, Optional.of(
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
             BrooklinHistogramInfo.PERCENTILE_999))));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_SEND_LATENCY_MS_STRING));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -96,6 +96,11 @@ public class EventProducer implements DatastreamEventProducer {
   private static final String DEFAULT_NEW_STREAM_SLA_GRACE_PERIOD_MS = "7200000"; // 2 hours
   private static final String EVENTS_PRODUCED_OUTSIDE_SLA = "eventsProducedOutsideSla";
   private static final String EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA = "eventsProducedOutsideAlternateSla";
+  // Counterparts to EVENTS_PRODUCED_*_ALTERNATE_SLA, emitted only while a CDC stream is inside its
+  // catch-up grace window so the regular alternate-SLA dashboards stay clean while operators can
+  // still track grace-period stats on a dedicated counter.
+  private static final String SLA_EXCLUDED_WITHIN_ALTERNATE_SLA = "slaExcludedWithinAlternateSla";
+  private static final String SLA_EXCLUDED_OUTSIDE_ALTERNATE_SLA = "slaExcludedOutsideAlternateSla";
   private static final String DROPPED_SENT_FROM_SERIALIZATION_ERROR = "droppedSentFromSerializationError";
   static final String BYTES_PRODUCED_RATE = "bytesProducedRate";
   private static final String AGGREGATE = "aggregate";
@@ -371,6 +376,19 @@ public class EventProducer implements DatastreamEventProducer {
   }
 
   /**
+   * Single gate that decides whether to emit the regular primary / alternate SLA counters.
+   * Combines all current and future SLA-suppression conditions in one place — additional
+   * conditions (e.g. per-datastream opt-out flags) should be ORed in here so callers don't
+   * need to know about every gating condition individually.
+   */
+  private boolean shouldEmitSlaMetric() {
+    if (isWithinSlaGracePeriod()) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
    * Parse the stream creation time used for SLA grace-period gating. When multiple datastreams
    * share a task via dedup, returns the oldest (min) CREATION_MS so a freshly deduped stream
    * cannot suppress SLA on long-running siblings. Zero / missing / malformed values are filtered
@@ -457,22 +475,25 @@ public class EventProducer implements DatastreamEventProducer {
     if (eventsSourceTimestamp > 0) {
       // Report availability metrics
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
-      // Redirect the latency histogram to slaExcludedLatencyMs during the CDC catch-up grace window
-      // so lag alerts wired to eventsLatencyMs do not fire on the initial backlog drain. The catch-up
-      // curve is still observable on slaExcludedLatencyMs.
-      String latencyMetricName = isWithinSlaGracePeriod() ? SLA_EXCLUDED_LATENCY_MS_STRING : EVENTS_LATENCY_MS_STRING;
+      // Redirect the latency histogram to slaExcludedLatencyMs while SLA emission is suppressed
+      // so lag alerts wired to eventsLatencyMs do not fire on the initial CDC catch-up. The
+      // catch-up curve is still observable on slaExcludedLatencyMs.
+      String latencyMetricName = shouldEmitSlaMetric() ? EVENTS_LATENCY_MS_STRING : SLA_EXCLUDED_LATENCY_MS_STRING;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, latencyMetricName);
 
-      // Primary SLA pair is suppressed during grace so the strict 1-minute dashboard isn't polluted
-      // by initial backlog drain. The alternate SLA pair keeps emitting throughout — operators retain
-      // a coarser SLA signal end-to-end.
-      if (!isWithinSlaGracePeriod()) {
+      // While SLA emission is suppressed, the alternate SLA is still measured against its
+      // threshold but routed to a dedicated slaExcluded* counter pair so operators can track
+      // suppression-period stats without polluting the regular alternate-SLA dashboard.
+      if (shouldEmitSlaMetric()) {
         reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
             EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
-      }
 
-      reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
-          EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
+        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
+            EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
+      } else {
+        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
+            SLA_EXCLUDED_WITHIN_ALTERNATE_SLA, SLA_EXCLUDED_OUTSIDE_ALTERNATE_SLA);
+      }
 
       if (_logger.isDebugEnabled()) {
         if (sourceToDestinationLatencyMs > _availabilityThresholdSlaMs) {
@@ -738,6 +759,8 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinMeterInfo(METRICS_PREFIX + BYTES_PRODUCED_RATE));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA));
+    metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + SLA_EXCLUDED_WITHIN_ALTERNATE_SLA));
+    metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + SLA_EXCLUDED_OUTSIDE_ALTERNATE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + DROPPED_SENT_FROM_SERIALIZATION_ERROR));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_LATENCY_MS_STRING, Optional.of(
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -458,15 +458,16 @@ public class EventProducer implements DatastreamEventProducer {
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
 
-      // SLA reporting is suppressed while a CDC stream is still draining its initial cdc backlog
-      // from EARLIEST; latency histograms above continue to fire so backlog visibility is preserved.
+      // During the CDC catch-up grace window suppress only the primary SLA counter so the strict
+      // 1-minute dashboard isn't polluted by initial backlog drain. The alternate SLA pair keeps
+      // emitting throughout — operators retain a coarser SLA signal end-to-end.
       if (!isWithinSlaGracePeriod()) {
         reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
             EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
-
-        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
-            EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
       }
+
+      reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
+          EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
 
       if (_logger.isDebugEnabled()) {
         if (sourceToDestinationLatencyMs > _availabilityThresholdSlaMs) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -73,7 +73,7 @@ public class EventProducer implements DatastreamEventProducer {
   public static final String DEFAULT_FLUSH_INTERVAL_MS = String.valueOf(Duration.ofMinutes(5).toMillis());
 
   static final String EVENTS_LATENCY_MS_STRING = "eventsLatencyMs";
-  static final String NEWLY_ONBOARDED_LATENCY_MS_STRING = "newlyOnboardedLatencyMs";
+  static final String EVENTS_LATENCY_MS_SLA_INELIGIBLE_STRING = "eventsLatencyMsSlaIneligible";
   static final String EVENTS_SEND_LATENCY_MS_STRING = "eventsSendLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_LATENCY_MS_STRING = "throughputViolatingEventsLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_SEND_LATENCY_MS_STRING = "throughputViolatingEventsSendLatencyMs";
@@ -119,7 +119,7 @@ public class EventProducer implements DatastreamEventProducer {
   // Alternate SLA for comparison with the main SLA
   private final int _availabilityThresholdAlternateSlaMs;
   // Grace period for newly created streams. While a stream is inside this window, primary/alternate
-  // SLA counters are suppressed and the latency histogram is redirected to newlyOnboardedLatencyMs.
+  // SLA counters are suppressed and the latency histogram is redirected to eventsLatencyMsSlaIneligible.
   private final long _newStreamGracePeriodMs;
   // Timestamp when the stream was created (from datastream metadata)
   private final long _streamCreationTimeMs;
@@ -374,7 +374,7 @@ public class EventProducer implements DatastreamEventProducer {
   /**
    * Single gate that decides whether to emit metrics to their regular destinations. When this
    * returns false, primary and alternate SLA counters are suppressed and the latency histogram
-   * is redirected to newlyOnboardedLatencyMs. Combines all suppression conditions in one place
+   * is redirected to eventsLatencyMsSlaIneligible. Combines all suppression conditions in one place
    * — additional conditions (e.g. per-datastream opt-out flags) should be ORed in here so call
    * sites do not need to know about every gating condition individually.
    */
@@ -472,10 +472,10 @@ public class EventProducer implements DatastreamEventProducer {
     if (eventsSourceTimestamp > 0) {
       // Report availability metrics
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
-      // Redirect the latency histogram to newlyOnboardedLatencyMs while SLA emission is suppressed
+      // Redirect the latency histogram to eventsLatencyMsSlaIneligible while SLA emission is suppressed
       // so lag alerts wired to eventsLatencyMs do not fire on the initial CDC catch-up. The
-      // catch-up curve is still observable on newlyOnboardedLatencyMs.
-      String latencyMetricName = shouldEmitMetric() ? EVENTS_LATENCY_MS_STRING : NEWLY_ONBOARDED_LATENCY_MS_STRING;
+      // catch-up curve is still observable on eventsLatencyMsSlaIneligible.
+      String latencyMetricName = shouldEmitMetric() ? EVENTS_LATENCY_MS_STRING : EVENTS_LATENCY_MS_SLA_INELIGIBLE_STRING;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, latencyMetricName);
 
       // While shouldEmitMetric() returns false (currently only during the CDC catch-up grace
@@ -756,7 +756,7 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_LATENCY_MS_STRING, Optional.of(
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
             BrooklinHistogramInfo.PERCENTILE_999))));
-    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + NEWLY_ONBOARDED_LATENCY_MS_STRING, Optional.of(
+    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_LATENCY_MS_SLA_INELIGIBLE_STRING, Optional.of(
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
             BrooklinHistogramInfo.PERCENTILE_999))));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_SEND_LATENCY_MS_STRING));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -195,25 +195,12 @@ public class EventProducer implements DatastreamEventProducer {
     _newStreamSlaGracePeriodMs = Long.parseLong(
         config.getProperty(NEW_STREAM_SLA_GRACE_PERIOD_MS, DEFAULT_NEW_STREAM_SLA_GRACE_PERIOD_MS));
 
-    // Use the oldest (min) CREATION_MS across deduped datastreams sharing this task. Once any one
-    // stream has been running past the grace window, the underlying consumer is at HEAD and SLA
-    // reporting should resume; using the newest creation time would let a freshly deduped stream
-    // suppress SLA on long-running siblings. Zero/missing/malformed values are filtered out and
-    // fall through to the fail-open default (0 → grace disabled).
-    long creationMs = 0;
-    try {
-      if (task.getDatastreams() != null && !task.getDatastreams().isEmpty()) {
-        creationMs = task.getDatastreams().stream()
-            .map(ds -> ds.getMetadata().getOrDefault(DatastreamMetadataConstants.CREATION_MS, "0"))
-            .mapToLong(Long::parseLong)
-            .filter(ms -> ms > 0)
-            .min()
-            .orElse(0L);
-      }
-    } catch (Exception e) {
-      _logger.warn("Failed to parse stream creation time, SLA grace period will not be applied", e);
-    }
-    _streamCreationTimeMs = creationMs;
+    // Source-database parsing pulled forward so we can gate stream-creation-time parsing on
+    // whether this is a CDC source. Non-CDC sources (BMM kafka://, Inlogs, etc.) don't have a
+    // bootstrap window worth masking, so skip the work entirely for them.
+    String[] sourceParts = getSourcePathParts();
+    _sourceDatabase = (sourceParts != null && sourceParts.length > 1) ? sourceParts[1] : null;
+    _streamCreationTimeMs = (_sourceDatabase != null) ? parseStreamCreationTimeMs(task) : 0L;
 
     _warnLogLatencyEnabled =
         Boolean.parseBoolean(config.getProperty(WARN_LOG_LATENCY_ENABLED, DEFAULT_WARN_LOG_LATENCY_ENABLED));
@@ -239,9 +226,6 @@ public class EventProducer implements DatastreamEventProducer {
 
     _enableThroughputMetrics =
         Boolean.parseBoolean(config.getProperty(CONFIG_ENABLE_THROUGHPUT_METRICS, Boolean.FALSE.toString()));
-
-    String[] sourceParts = getSourcePathParts();
-    _sourceDatabase = (sourceParts != null && sourceParts.length > 1) ? sourceParts[1] : null;
 
     _logger.info("Created event producer with customCheckpointing={}", customCheckpointing);
 
@@ -372,6 +356,37 @@ public class EventProducer implements DatastreamEventProducer {
     return broadcastMetadata;
   }
 
+  /**
+   * Returns true while a CDC stream is still within its bootstrap-catch-up grace window.
+   * For non-CDC sources {@code _streamCreationTimeMs} is left at 0 by the constructor, so the
+   * arithmetic naturally short-circuits to false and SLA reporting is unaffected.
+   */
+  private boolean isWithinSlaGracePeriod() {
+    return (System.currentTimeMillis() - _streamCreationTimeMs) < _newStreamSlaGracePeriodMs;
+  }
+
+  /**
+   * Parse the stream creation time used for SLA grace-period gating. When multiple datastreams
+   * share a task via dedup, returns the oldest (min) CREATION_MS so a freshly deduped stream
+   * cannot suppress SLA on long-running siblings. Zero / missing / malformed values are filtered
+   * out; the method returns 0 in those cases (grace disabled, fail-open to SLA reporting).
+   */
+  private long parseStreamCreationTimeMs(DatastreamTask task) {
+    try {
+      if (task.getDatastreams() != null && !task.getDatastreams().isEmpty()) {
+        return task.getDatastreams().stream()
+            .map(ds -> ds.getMetadata().getOrDefault(DatastreamMetadataConstants.CREATION_MS, "0"))
+            .mapToLong(Long::parseLong)
+            .filter(ms -> ms > 0)
+            .min()
+            .orElse(0L);
+      }
+    } catch (Exception e) {
+      _logger.warn("Failed to parse stream creation time, SLA grace period will not be applied", e);
+    }
+    return 0L;
+  }
+
   // Report SLA metrics for aggregate, connector and task
   private void reportSLAMetrics(String topicOrDatastreamName, boolean isWithinSLA, String metricNameForWithinSLA,
       String metricNameForOutsideSLA) {
@@ -439,18 +454,10 @@ public class EventProducer implements DatastreamEventProducer {
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
 
-      // Skip SLA reporting for newly created CDC streams during grace period (DATAPIPES-33203).
-      // CDC streams starting from EARLIEST offset have large initial lag during bootstrap catch-up
-      // which would trigger false SLA violations. CDC sources are identified by single-slash URI
-      // scheme (e.g. espresso:/, mysql:/, tidb:/) which yields a non-null _sourceDatabase; BMM
-      // double-slash URIs (kafka://) yield null and are excluded so MirrorMaker reports SLA from
-      // the first event.
-      boolean isCdcSource = _sourceDatabase != null;
-      boolean isWithinGracePeriod = isCdcSource
-          && _streamCreationTimeMs > 0
-          && (System.currentTimeMillis() - _streamCreationTimeMs) < _newStreamSlaGracePeriodMs;
-
-      if (!isWithinGracePeriod) {
+      // SLA reporting is suppressed while a CDC stream is still draining its initial bootstrap
+      // backlog from EARLIEST; latency histograms above continue to fire so backlog visibility
+      // is preserved.
+      if (!isWithinSlaGracePeriod()) {
         reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
             EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
 

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -265,7 +265,7 @@ public class TestEventProducer {
   }
 
   // ---------------------------------------------------------------------------
-  // SLA grace-period tests (DATAPIPES-33203)
+  // SLA grace-period tests
   //
   // Aggregate-level counters are used as the assertion surface:
   //   - EventProducer.aggregate.eventsProducedOutsideSla is pre-registered in the

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -6,6 +6,7 @@
 package com.linkedin.datastream.server;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Properties;
@@ -16,11 +17,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.serde.SerDe;
@@ -259,6 +262,200 @@ public class TestEventProducer {
         "No per-database metric should exist for BMM double-slash URI");
     Assert.assertNotNull(metrics.getMetric("EventProducer.aggregate." + EventProducer.BYTES_PRODUCED_RATE),
         "Aggregate bytesProducedRate should still exist for BMM");
+  }
+
+  // ---------------------------------------------------------------------------
+  // SLA grace-period tests (DATAPIPES-33203)
+  //
+  // Aggregate-level counters are used as the assertion surface:
+  //   - EventProducer.aggregate.eventsProducedOutsideSla is pre-registered in the
+  //     constructor (count 0), so it always exists.
+  //   - EventProducer.aggregate.eventsProducedWithinSla is NOT pre-registered.
+  //     Its presence/absence is therefore a clean signal of whether
+  //     reportSLAMetrics() ran (i.e. whether the grace gate let the call through).
+  // ---------------------------------------------------------------------------
+
+  private static final String SLA_WITHIN_AGG = "EventProducer.aggregate.eventsProducedWithinSla";
+  private static final String SLA_WITHIN_ALT_AGG = "EventProducer.aggregate.eventsProducedWithinAlternateSla";
+
+  @Test
+  public void testSlaGraceActiveForNewCdcStream() {
+    // CDC source (single-slash mysql:/) + freshly-created stream → grace gate engaged → SLA suppressed.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-new")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
+        String.valueOf(System.currentTimeMillis()));
+    sendOneEventThroughProducer(datastream, new Properties());
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "withinSla counter must not be created during grace period for new CDC stream");
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
+        "withinAlternateSla counter must not be created during grace period for new CDC stream");
+  }
+
+  @Test
+  public void testSlaGraceExpiredForOldCdcStream() {
+    // CDC source + creation timestamp older than the 2h default grace window → SLA reporting active.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-old")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    long threeHoursAgo = System.currentTimeMillis() - (3 * 60 * 60 * 1000L);
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(threeHoursAgo));
+    sendOneEventThroughProducer(datastream, new Properties());
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Counter withinAgg = (Counter) metrics.getMetric(SLA_WITHIN_AGG);
+    Assert.assertNotNull(withinAgg, "withinSla counter must be created once grace period has expired");
+    Assert.assertEquals(withinAgg.getCount(), 1L,
+        "Single send with fresh source timestamp should be reported as within SLA");
+  }
+
+  @Test
+  public void testSlaGraceNotAppliedToMirrorMakerSource() {
+    // BMM source (double-slash kafka://) → _sourceDatabase == null → grace gate disabled regardless
+    // of CREATION_MS. This is the primary regression guard for the MM-exclusion fix.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-bmm-new")[0];
+    datastream.getSource().setConnectionString("kafka://broker:9092/someTopic");
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
+        String.valueOf(System.currentTimeMillis()));
+    sendOneEventThroughProducer(datastream, new Properties());
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Counter withinAgg = (Counter) metrics.getMetric(SLA_WITHIN_AGG);
+    Assert.assertNotNull(withinAgg, "MirrorMaker streams must report SLA from the first event, regardless of stream age");
+    Assert.assertEquals(withinAgg.getCount(), 1L);
+  }
+
+  @Test
+  public void testSlaGraceFailsOpenWhenCreationMsMissing() {
+    // CDC source but no CREATION_MS metadata → _streamCreationTimeMs stays 0 → gate disabled (fail-open).
+    // Note: DatastreamTestUtils.createDatastreams auto-populates CREATION_MS, so we explicitly remove
+    // it to exercise the missing-metadata path.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-nomd")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    datastream.getMetadata().remove(DatastreamMetadataConstants.CREATION_MS);
+    sendOneEventThroughProducer(datastream, new Properties());
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "Missing CREATION_MS must fail open to SLA reporting, not silently suppress it");
+  }
+
+  @Test
+  public void testSlaGraceFailsOpenWhenCreationMsMalformed() {
+    // Malformed CREATION_MS → NumberFormatException caught in constructor → grace disabled.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-bad")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, "not-a-long");
+    sendOneEventThroughProducer(datastream, new Properties());
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "Malformed CREATION_MS must fail open to SLA reporting");
+  }
+
+  @Test
+  public void testLatencyHistogramStillFiresDuringGracePeriod() {
+    // Latency histogram and per-topic latency metrics are intentionally NOT gated by the grace period
+    // so operators retain visibility into ramp-up backlogs even while SLA counters are suppressed.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-latency")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
+        String.valueOf(System.currentTimeMillis()));
+
+    String someTopicName = "graceLatencyTopic";
+    sendOneEventThroughProducer(datastream, new Properties(), someTopicName);
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "Latency histogram must continue to fire during grace period");
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "SLA counters should still be suppressed alongside the live latency histogram");
+  }
+
+  @Test
+  public void testCustomGracePeriodOverride() {
+    // Operator-specified grace period should win over the 2h default. With a 1ms window, a stream
+    // created "now" should already be past grace by the time the producer records its first event.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-custom")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
+        String.valueOf(System.currentTimeMillis() - 10));
+
+    Properties props = new Properties();
+    props.put("newStreamSlaGracePeriodMs", "1");
+    sendOneEventThroughProducer(datastream, props);
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "Custom 1ms grace period should expire before the first event is reported");
+  }
+
+  @Test
+  public void testSlaGraceDedupedTaskUsesOldestCreationTime() {
+    // Two CDC datastreams deduped onto one task: one created 3h ago, one created now.
+    // Grace gate must follow the OLDEST stream (3h ago, past grace) → SLA reporting active.
+    long now = System.currentTimeMillis();
+    long threeHoursAgo = now - (3 * 60 * 60 * 1000L);
+
+    Datastream oldDs = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-old")[0];
+    oldDs.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    oldDs.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(threeHoursAgo));
+
+    Datastream newDs = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-new")[0];
+    newDs.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    newDs.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(now));
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Arrays.asList(oldDs, newDs));
+    sendOneEventThroughTask(task, new Properties(), "someTopicName");
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "Deduped task with at least one old stream must report SLA (oldest stream is past grace)");
+  }
+
+  @Test
+  public void testSlaGraceDedupedTaskAllStreamsNew() {
+    // All streams on the deduped task are within the grace window → SLA suppressed.
+    long now = System.currentTimeMillis();
+
+    Datastream newDsA = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-newA")[0];
+    newDsA.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    newDsA.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(now));
+
+    Datastream newDsB = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-newB")[0];
+    newDsB.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    newDsB.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(now - 60_000L));
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Arrays.asList(newDsA, newDsB));
+    sendOneEventThroughTask(task, new Properties(), "someTopicName");
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "All streams within grace window → SLA suppressed across the deduped task");
+  }
+
+  private void sendOneEventThroughProducer(Datastream datastream, Properties props) {
+    sendOneEventThroughProducer(datastream, props, "someTopicName");
+  }
+
+  private void sendOneEventThroughProducer(Datastream datastream, Properties props, String topicName) {
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+    sendOneEventThroughTask(task, props, topicName);
+  }
+
+  private void sendOneEventThroughTask(DatastreamTaskImpl task, Properties props, String topicName) {
+    TransportProvider transport = new NoOpTransportProviderAdminFactory.NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        DatastreamRecordMetadata metadata =
+            new DatastreamRecordMetadata(record.getCheckpoint(), topicName, record.getPartition().orElse(0));
+        onComplete.onCompletion(metadata, null);
+      }
+    };
+    EventProducer eventProducer = new EventProducer(task, transport, new NoOpCheckpointProvider(), props, false);
+    eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
   }
 
   private DatastreamProducerRecord createDatastreamProducerRecord() {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -356,8 +356,8 @@ public class TestEventProducer {
   }
 
   @Test
-  public void testLatencyHistogramRedirectedToNewlyOnboardedDuringGracePeriod() {
-    // During grace, the lag histogram is redirected from eventsLatencyMs to newlyOnboardedLatencyMs
+  public void testLatencyHistogramRedirectedToSlaIneligibleDuringGracePeriod() {
+    // During grace, the lag histogram is redirected from eventsLatencyMs to eventsLatencyMsSlaIneligible
     // so lag alerts on the primary metric do not fire on initial CDC catch-up. Both primary and
     // alternate SLA counters are suppressed entirely during the grace window.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-latency")[0];
@@ -373,8 +373,8 @@ public class TestEventProducer {
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "eventsLatencyMs must NOT fire during grace period — that's what lag alerts are wired to");
     Assert.assertNotNull(
-        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.NEWLY_ONBOARDED_LATENCY_MS_STRING),
-        "newlyOnboardedLatencyMs should receive the redirected latency observation during grace");
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_SLA_INELIGIBLE_STRING),
+        "eventsLatencyMsSlaIneligible should receive the redirected latency observation during grace");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
         "Alternate-SLA counter should remain suppressed during grace period");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
@@ -397,8 +397,8 @@ public class TestEventProducer {
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "eventsLatencyMs must fire once the grace period has expired");
     Assert.assertNull(
-        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.NEWLY_ONBOARDED_LATENCY_MS_STRING),
-        "newlyOnboardedLatencyMs should not be touched outside the grace window");
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_SLA_INELIGIBLE_STRING),
+        "eventsLatencyMsSlaIneligible should not be touched outside the grace window");
   }
 
   @Test

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -280,7 +280,8 @@ public class TestEventProducer {
 
   @Test
   public void testSlaGraceActiveForNewCdcStream() {
-    // CDC source (single-slash mysql:/) + freshly-created stream → grace gate engaged → SLA suppressed.
+    // CDC source (single-slash mysql:/) + freshly-created stream → grace gate engaged. Only the
+    // primary SLA counter is suppressed; the alternate-SLA pair keeps emitting end-to-end.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-new")[0];
     datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
     datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
@@ -289,9 +290,12 @@ public class TestEventProducer {
 
     DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
-        "withinSla counter must not be created during grace period for new CDC stream");
-    Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
-        "withinAlternateSla counter must not be created during grace period for new CDC stream");
+        "Primary withinSla counter must not be created during grace period for new CDC stream");
+    Counter withinAltAgg = (Counter) metrics.getMetric(SLA_WITHIN_ALT_AGG);
+    Assert.assertNotNull(withinAltAgg,
+        "Alternate-SLA counter must keep emitting during grace period so observability is preserved");
+    Assert.assertEquals(withinAltAgg.getCount(), 1L,
+        "Single send with fresh source timestamp should be reported as within alternate SLA");
   }
 
   @Test
@@ -356,8 +360,9 @@ public class TestEventProducer {
 
   @Test
   public void testLatencyHistogramStillFiresDuringGracePeriod() {
-    // Latency histogram and per-topic latency metrics are intentionally NOT gated by the grace period
-    // so operators retain visibility into ramp-up backlogs even while SLA counters are suppressed.
+    // Latency histogram, alternate-SLA counters, and per-topic latency metrics are intentionally
+    // NOT gated by the grace period so operators retain visibility into ramp-up backlogs even
+    // while the primary SLA counter is suppressed.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-latency")[0];
     datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
     datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
@@ -370,8 +375,10 @@ public class TestEventProducer {
     Assert.assertNotNull(
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "Latency histogram must continue to fire during grace period");
+    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
+        "Alternate-SLA counter must fire during grace period");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
-        "SLA counters should still be suppressed alongside the live latency histogram");
+        "Primary SLA counter should remain suppressed during grace period");
   }
 
   @Test
@@ -433,7 +440,9 @@ public class TestEventProducer {
 
     DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
-        "All streams within grace window → SLA suppressed across the deduped task");
+        "All streams within grace window → primary SLA suppressed across the deduped task");
+    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
+        "Alternate-SLA counter must keep emitting during grace period");
   }
 
   private void sendOneEventThroughProducer(Datastream datastream, Properties props) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -277,13 +277,11 @@ public class TestEventProducer {
 
   private static final String SLA_WITHIN_AGG = "EventProducer.aggregate.eventsProducedWithinSla";
   private static final String SLA_WITHIN_ALT_AGG = "EventProducer.aggregate.eventsProducedWithinAlternateSla";
-  private static final String SLA_EXCLUDED_WITHIN_ALT_AGG = "EventProducer.aggregate.slaExcludedWithinAlternateSla";
 
   @Test
   public void testSlaGraceActiveForNewCdcStream() {
-    // CDC source (single-slash mysql:/) + freshly-created stream → grace gate engaged. Both regular
-    // SLA pairs are suppressed; the alternate-SLA evaluation is redirected to slaExcluded* counters
-    // so operators can still track grace-period stats without polluting the regular dashboards.
+    // CDC source (single-slash mysql:/) + freshly-created stream → grace gate engaged. Both
+    // primary and alternate SLA counter pairs are suppressed entirely.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-new")[0];
     datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
     datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
@@ -294,12 +292,7 @@ public class TestEventProducer {
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
         "Primary withinSla counter must not be created during grace period for new CDC stream");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
-        "Regular alternate-SLA counter must not be touched during grace period");
-    Counter slaExcludedWithinAltAgg = (Counter) metrics.getMetric(SLA_EXCLUDED_WITHIN_ALT_AGG);
-    Assert.assertNotNull(slaExcludedWithinAltAgg,
-        "slaExcludedWithinAlternateSla counter must be created during grace for grace-period tracking");
-    Assert.assertEquals(slaExcludedWithinAltAgg.getCount(), 1L,
-        "Single send with fresh source timestamp should be reported as within alternate SLA threshold");
+        "Alternate-SLA counter must not be created during grace period for new CDC stream");
   }
 
   @Test
@@ -363,10 +356,10 @@ public class TestEventProducer {
   }
 
   @Test
-  public void testLatencyHistogramRedirectedToSlaExcludedDuringGracePeriod() {
-    // During grace, the lag histogram is redirected from eventsLatencyMs to slaExcludedLatencyMs
-    // so lag alerts on the primary metric do not fire on initial CDC catch-up. Alternate-SLA
-    // counters continue to emit so observability is preserved end-to-end.
+  public void testLatencyHistogramRedirectedToNewlyOnboardedDuringGracePeriod() {
+    // During grace, the lag histogram is redirected from eventsLatencyMs to newlyOnboardedLatencyMs
+    // so lag alerts on the primary metric do not fire on initial CDC catch-up. Both primary and
+    // alternate SLA counters are suppressed entirely during the grace window.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-latency")[0];
     datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
     datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
@@ -380,12 +373,10 @@ public class TestEventProducer {
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "eventsLatencyMs must NOT fire during grace period — that's what lag alerts are wired to");
     Assert.assertNotNull(
-        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
-        "slaExcludedLatencyMs should receive the redirected latency observation during grace");
-    Assert.assertNotNull(metrics.getMetric(SLA_EXCLUDED_WITHIN_ALT_AGG),
-        "slaExcludedWithinAlternateSla counter must fire during grace period");
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.NEWLY_ONBOARDED_LATENCY_MS_STRING),
+        "newlyOnboardedLatencyMs should receive the redirected latency observation during grace");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
-        "Regular alternate-SLA counter should remain untouched during grace period");
+        "Alternate-SLA counter should remain suppressed during grace period");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
         "Primary SLA counter should remain suppressed during grace period");
   }
@@ -406,8 +397,8 @@ public class TestEventProducer {
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "eventsLatencyMs must fire once the grace period has expired");
     Assert.assertNull(
-        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
-        "slaExcludedLatencyMs should not be touched outside the grace window");
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.NEWLY_ONBOARDED_LATENCY_MS_STRING),
+        "newlyOnboardedLatencyMs should not be touched outside the grace window");
   }
 
   @Test
@@ -420,7 +411,7 @@ public class TestEventProducer {
         String.valueOf(System.currentTimeMillis() - 10));
 
     Properties props = new Properties();
-    props.put("newStreamSlaGracePeriodMs", "1");
+    props.put("newStreamGracePeriodMs", "1");
     sendOneEventThroughProducer(datastream, props);
 
     DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
@@ -471,9 +462,7 @@ public class TestEventProducer {
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
         "All streams within grace window → primary SLA suppressed across the deduped task");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
-        "Regular alternate-SLA counter must remain suppressed during grace");
-    Assert.assertNotNull(metrics.getMetric(SLA_EXCLUDED_WITHIN_ALT_AGG),
-        "slaExcludedWithinAlternateSla counter must fire during grace for the deduped task");
+        "Alternate-SLA counter must remain suppressed during grace across the deduped task");
   }
 
   private void sendOneEventThroughProducer(Datastream datastream, Properties props) {

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -359,10 +359,10 @@ public class TestEventProducer {
   }
 
   @Test
-  public void testLatencyHistogramStillFiresDuringGracePeriod() {
-    // Latency histogram, alternate-SLA counters, and per-topic latency metrics are intentionally
-    // NOT gated by the grace period so operators retain visibility into ramp-up backlogs even
-    // while the primary SLA counter is suppressed.
+  public void testLatencyHistogramRedirectedToSlaExcludedDuringGracePeriod() {
+    // During grace, the lag histogram is redirected from eventsLatencyMs to slaExcludedLatencyMs
+    // so lag alerts on the primary metric do not fire on initial CDC catch-up. Alternate-SLA
+    // counters continue to emit so observability is preserved end-to-end.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-latency")[0];
     datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
     datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
@@ -372,13 +372,36 @@ public class TestEventProducer {
     sendOneEventThroughProducer(datastream, new Properties(), someTopicName);
 
     DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
-    Assert.assertNotNull(
+    Assert.assertNull(
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
-        "Latency histogram must continue to fire during grace period");
+        "eventsLatencyMs must NOT fire during grace period — that's what lag alerts are wired to");
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "slaExcludedLatencyMs should receive the redirected latency observation during grace");
     Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
         "Alternate-SLA counter must fire during grace period");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
         "Primary SLA counter should remain suppressed during grace period");
+  }
+
+  @Test
+  public void testLatencyHistogramFiresOnPrimaryAfterGracePeriod() {
+    // Post-grace: latency observations go back to eventsLatencyMs (the metric lag alerts watch).
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-latency-old")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    long threeHoursAgo = System.currentTimeMillis() - (3 * 60 * 60 * 1000L);
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(threeHoursAgo));
+
+    String someTopicName = "postGraceLatencyTopic";
+    sendOneEventThroughProducer(datastream, new Properties(), someTopicName);
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "eventsLatencyMs must fire once the grace period has expired");
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "slaExcludedLatencyMs should not be touched outside the grace window");
   }
 
   @Test

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -277,11 +277,13 @@ public class TestEventProducer {
 
   private static final String SLA_WITHIN_AGG = "EventProducer.aggregate.eventsProducedWithinSla";
   private static final String SLA_WITHIN_ALT_AGG = "EventProducer.aggregate.eventsProducedWithinAlternateSla";
+  private static final String SLA_EXCLUDED_WITHIN_ALT_AGG = "EventProducer.aggregate.slaExcludedWithinAlternateSla";
 
   @Test
   public void testSlaGraceActiveForNewCdcStream() {
-    // CDC source (single-slash mysql:/) + freshly-created stream → grace gate engaged. Only the
-    // primary SLA counter is suppressed; the alternate-SLA pair keeps emitting end-to-end.
+    // CDC source (single-slash mysql:/) + freshly-created stream → grace gate engaged. Both regular
+    // SLA pairs are suppressed; the alternate-SLA evaluation is redirected to slaExcluded* counters
+    // so operators can still track grace-period stats without polluting the regular dashboards.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-new")[0];
     datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
     datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
@@ -291,11 +293,13 @@ public class TestEventProducer {
     DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
         "Primary withinSla counter must not be created during grace period for new CDC stream");
-    Counter withinAltAgg = (Counter) metrics.getMetric(SLA_WITHIN_ALT_AGG);
-    Assert.assertNotNull(withinAltAgg,
-        "Alternate-SLA counter must keep emitting during grace period so observability is preserved");
-    Assert.assertEquals(withinAltAgg.getCount(), 1L,
-        "Single send with fresh source timestamp should be reported as within alternate SLA");
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
+        "Regular alternate-SLA counter must not be touched during grace period");
+    Counter slaExcludedWithinAltAgg = (Counter) metrics.getMetric(SLA_EXCLUDED_WITHIN_ALT_AGG);
+    Assert.assertNotNull(slaExcludedWithinAltAgg,
+        "slaExcludedWithinAlternateSla counter must be created during grace for grace-period tracking");
+    Assert.assertEquals(slaExcludedWithinAltAgg.getCount(), 1L,
+        "Single send with fresh source timestamp should be reported as within alternate SLA threshold");
   }
 
   @Test
@@ -378,8 +382,10 @@ public class TestEventProducer {
     Assert.assertNotNull(
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
         "slaExcludedLatencyMs should receive the redirected latency observation during grace");
-    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
-        "Alternate-SLA counter must fire during grace period");
+    Assert.assertNotNull(metrics.getMetric(SLA_EXCLUDED_WITHIN_ALT_AGG),
+        "slaExcludedWithinAlternateSla counter must fire during grace period");
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
+        "Regular alternate-SLA counter should remain untouched during grace period");
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
         "Primary SLA counter should remain suppressed during grace period");
   }
@@ -464,8 +470,10 @@ public class TestEventProducer {
     DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
     Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
         "All streams within grace window → primary SLA suppressed across the deduped task");
-    Assert.assertNotNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
-        "Alternate-SLA counter must keep emitting during grace period");
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
+        "Regular alternate-SLA counter must remain suppressed during grace");
+    Assert.assertNotNull(metrics.getMetric(SLA_EXCLUDED_WITHIN_ALT_AGG),
+        "slaExcludedWithinAlternateSla counter must fire during grace for the deduped task");
   }
 
   private void sendOneEventThroughProducer(Datastream datastream, Properties props) {


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                                                                                                
  - Add a new `newStreamGracePeriodMs` config in `EventProducer` (default 2h, operator-overridable via `brooklin.server.eventProducer.newStreamGracePeriodMs` in `server.properties`). While newly created CDC streams drain their initial CDC backlog from EARLIEST, source-to-destination latencies are inherently large;
  without a grace window every event would be reported as primary-SLA-violating and lag alerts wired to `eventsLatencyMs` would fire.                                                                                                                                                                                       
  - During the grace window:
    - **Primary SLA** (`eventsProducedWithinSla` / `eventsProducedOutsideSla`) is suppressed.                                                                                                                                                                                                                               
    - **Alternate SLA** (`eventsProducedWithinAlternateSla` / `eventsProducedOutsideAlternateSla`) is suppressed.                                                                                                                                                                                                           
    - **`eventsLatencyMs` is redirected to `eventsLatencyMsSlaIneligible`** so lag alerts wired to `eventsLatencyMs` do not fire on initial backlog drain. The catch-up curve stays observable on the dedicated histogram.                                                                                                       
  - Warning logs and other rate / volume / send-latency metrics are NOT gated.                                                                                                                                                                                                                                              
  - Restrict the grace gate to CDC sources via an explicit `isCdcSource()` check (single-slash-URI heuristic, the same one used by the throughput-attribution metrics). MirrorMaker (`kafka://`) and other non-CDC sources are unaffected — neither SLA suppression nor the latency-histogram redirect applies.             
  - When multiple datastreams share a `DatastreamTask` via dedup, use the oldest creation time across the task so a freshly deduped stream cannot suppress metrics on long-running siblings.                                                                                                                                
  - All metric-emission gating goes through a single `shouldEmitMetric()` wrapper. Future suppression conditions (e.g. per-datastream opt-out flags) should be ORed into that one method so call sites stay simple.                                                                                                         
                                                                                                                                                                                                                                                                                                                            
  ## Notes / scope                                                                                                                                                                                                                                                                                                          
  - This PR was originally also going to change the no-offset-found fallback in `AbstractKafkaBasedConnectorTask` from LATEST to EARLIEST, but that change has been reverted (`390132ee`). LinkedIn-internal CDC connectors no longer use this base class (migrated to `AbstractXinfraBasedConnectorTask`); CDC's EARLIEST  
  behaviour is handled in the internal connector subclass.                                                                                                                                                                                                                                                                  
  - MySQL CDC will continue to default to LATEST since it does not depend on existing snapshots.
  - Distinct from #1005: that PR introduces `slaExcludedLatencyMs` for a per-datastream opt-out flag (permanent, manual). This PR introduces `newlyOnboardedLatencyMs` for an automatic time-bounded grace window for new CDC streams. Different histograms, different triggers, no merge conflict.                         
                                                                                                                                                                                                                                                                                                                            
  ## Test plan                                                                                                                                                                                                                                                                                                              
  - [x] 11 tests in `TestEventProducer` covering:                                                                                                                                                                                                                                                                           
    - New CDC stream in grace → primary and alternate SLA both suppressed                                                                                                                                                                                                                                                   
    - Old CDC stream past grace → primary and alternate SLA emit normally                                                                                                                                                                                                                                                   
    - MirrorMaker source not affected even with fresh `CREATION_MS`                                                                                                                                                                                                                                                         
    - Fail-open when `CREATION_MS` is missing or malformed                                                                                                                                                                                                                                                                  
    - `eventsLatencyMs` redirected to `newlyOnboardedLatencyMs` during grace                                                                                                                                                                                                                                                
    - `eventsLatencyMs` fires (and `newlyOnboardedLatencyMs` does not) post-grace                                                                                                                                                                                                                                           
    - Custom `newStreamGracePeriodMs` config override honoured                                                                                                                                                                                                                                                              
    - Deduped task with oldest stream past grace → metrics emit normally                                                                                                                                                                                                                                                    
    - Deduped task with all streams within grace → metrics suppressed/redirected uniformly                                                                                                                                                                                                                                  
  - [x] All 16 tests in `TestEventProducer` pass under JDK 8 (project's required toolchain):
        `JAVA_HOME=<jdk8> ./gradlew :datastream-server:test --tests com.linkedin.datastream.server.TestEventProducer`