### PR TITLE
Add per-datastream SLA metric opt-out via system.disableSlaMetric 

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -383,7 +383,7 @@ public class EventProducer implements DatastreamEventProducer {
    * sites do not need to know about every gating condition individually.
    */
   private boolean shouldEmitMetric() {
-    if(_disableSlaMetric){
+    if (_disableSlaMetric) {
       return false;
     }
     if (isWithinGracePeriod()) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -592,27 +592,20 @@ public class EventProducer implements DatastreamEventProducer {
    * Looks for config {@value CFG_DISABLE_SLA_METRIC} in the datastream metadata and returns its value.
    * Default value is false.
    *
-   * <p>The flag is only honored for tasks owning a single datastream. When a task hosts multiple
-   * datastreams (i.e. they are deduped onto the same task and share one EventProducer), one
-   * stream's opt-out would otherwise suppress {@code eventsLatencyMs} for every stream in the
-   * group. In that case the flag is ignored and a warning is logged.
+   * <p>Only honored for tasks owning a single datastream. Deduped tasks (multiple datastreams
+   * sharing one EventProducer) always return false, since one stream's opt-out would otherwise
+   * suppress {@code eventsLatencyMs} for every stream in the group.
    */
   private boolean getDisableSlaMetric(DatastreamTask task) {
-    boolean requested = Boolean.parseBoolean(task.getDatastreams()
+    if (task.getDatastreams().size() > 1) {
+      return false;
+    }
+    return Boolean.parseBoolean(task.getDatastreams()
         .stream()
         .findFirst()
         .map(Datastream::getMetadata)
         .map(metadata -> metadata.getOrDefault(CFG_DISABLE_SLA_METRIC, Boolean.FALSE.toString()))
         .orElse(Boolean.FALSE.toString()));
-
-    if (requested && task.getDatastreams().size() > 1) {
-      _logger.warn("Ignoring {}=true on task {} because it hosts {} deduped datastreams; "
-              + "the flag is only honored for non-deduped streams to avoid suppressing the metric "
-              + "for other streams in the group.",
-          CFG_DISABLE_SLA_METRIC, task.getDatastreamTaskName(), task.getDatastreams().size());
-      return false;
-    }
-    return requested;
   }
 
   @Override

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -73,6 +73,7 @@ public class EventProducer implements DatastreamEventProducer {
   public static final String DEFAULT_FLUSH_INTERVAL_MS = String.valueOf(Duration.ofMinutes(5).toMillis());
 
   static final String EVENTS_LATENCY_MS_STRING = "eventsLatencyMs";
+  static final String SLA_EXCLUDED_LATENCY_MS_STRING = "slaExcludedLatencyMs";
   static final String EVENTS_SEND_LATENCY_MS_STRING = "eventsSendLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_LATENCY_MS_STRING = "throughputViolatingEventsLatencyMs";
   static final String THROUGHPUT_VIOLATING_EVENTS_SEND_LATENCY_MS_STRING = "throughputViolatingEventsSendLatencyMs";
@@ -409,11 +410,11 @@ public class EventProducer implements DatastreamEventProducer {
     String topicOrDatastreamName = _enablePerTopicMetrics ? metadata.getTopic() : datastreamName;
     // Treat all events within this record equally (assume same timestamp)
     if (eventsSourceTimestamp > 0) {
-      // Report availability metrics
+      // Report availability metrics. Streams that opt out via system.disableSlaMetric still emit
+      // a latency histogram, but under slaExcludedLatencyMs so they don't pollute the SLA metric.
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
-      if (!_disableSlaMetric) {
-        reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
-      }
+      String latencyMetricName = _disableSlaMetric ? SLA_EXCLUDED_LATENCY_MS_STRING : EVENTS_LATENCY_MS_STRING;
+      reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, latencyMetricName);
 
       reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
           EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
@@ -707,6 +708,9 @@ public class EventProducer implements DatastreamEventProducer {
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA));
     metrics.add(new BrooklinCounterInfo(METRICS_PREFIX + DROPPED_SENT_FROM_SERIALIZATION_ERROR));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_LATENCY_MS_STRING, Optional.of(
+        Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
+            BrooklinHistogramInfo.PERCENTILE_999))));
+    metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + SLA_EXCLUDED_LATENCY_MS_STRING, Optional.of(
         Arrays.asList(BrooklinHistogramInfo.PERCENTILE_50, BrooklinHistogramInfo.PERCENTILE_99,
             BrooklinHistogramInfo.PERCENTILE_999))));
     metrics.add(new BrooklinHistogramInfo(METRICS_PREFIX + EVENTS_SEND_LATENCY_MS_STRING));

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -478,7 +478,7 @@ public class EventProducer implements DatastreamEventProducer {
     // Treat all events within this record equally (assume same timestamp)
     if (eventsSourceTimestamp > 0) {
       // Report availability metrics. Streams that opt out via system.disableSlaMetric still emit
-      // a latency histogram, but under slaExcludedLatencyMs so they don't pollute the SLA metric.
+      // a latency histogram, but under eventsLatencyMsSlaIneligible so they don't pollute the SLA metric.
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
       // Redirect the latency histogram to eventsLatencyMsSlaIneligible while SLA emission is suppressed
       // so lag alerts wired to eventsLatencyMs do not fire on the initial CDC catch-up. The

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -591,14 +591,28 @@ public class EventProducer implements DatastreamEventProducer {
   /**
    * Looks for config {@value CFG_DISABLE_SLA_METRIC} in the datastream metadata and returns its value.
    * Default value is false.
+   *
+   * <p>The flag is only honored for tasks owning a single datastream. When a task hosts multiple
+   * datastreams (i.e. they are deduped onto the same task and share one EventProducer), one
+   * stream's opt-out would otherwise suppress {@code eventsLatencyMs} for every stream in the
+   * group. In that case the flag is ignored and a warning is logged.
    */
   private boolean getDisableSlaMetric(DatastreamTask task) {
-    return Boolean.parseBoolean(task.getDatastreams()
+    boolean requested = Boolean.parseBoolean(task.getDatastreams()
         .stream()
         .findFirst()
         .map(Datastream::getMetadata)
         .map(metadata -> metadata.getOrDefault(CFG_DISABLE_SLA_METRIC, Boolean.FALSE.toString()))
         .orElse(Boolean.FALSE.toString()));
+
+    if (requested && task.getDatastreams().size() > 1) {
+      _logger.warn("Ignoring {}=true on task {} because it hosts {} deduped datastreams; "
+              + "the flag is only honored for non-deduped streams to avoid suppressing the metric "
+              + "for other streams in the group.",
+          CFG_DISABLE_SLA_METRIC, task.getDatastreamTaskName(), task.getDatastreams().size());
+      return false;
+    }
+    return requested;
   }
 
   @Override

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -416,11 +416,13 @@ public class EventProducer implements DatastreamEventProducer {
       String latencyMetricName = _disableSlaMetric ? SLA_EXCLUDED_LATENCY_MS_STRING : EVENTS_LATENCY_MS_STRING;
       reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, latencyMetricName);
 
-      reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
-          EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
+      if (!_disableSlaMetric) {
+        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
+            EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
 
-      reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
-          EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
+        reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdAlternateSlaMs,
+            EVENTS_PRODUCED_WITHIN_ALTERNATE_SLA, EVENTS_PRODUCED_OUTSIDE_ALTERNATE_SLA);
+      }
 
       if (_logger.isDebugEnabled()) {
         if (sourceToDestinationLatencyMs > _availabilityThresholdSlaMs) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -383,6 +383,9 @@ public class EventProducer implements DatastreamEventProducer {
    * sites do not need to know about every gating condition individually.
    */
   private boolean shouldEmitMetric() {
+    if(_disableSlaMetric){
+      return false;
+    }
     if (isWithinGracePeriod()) {
       return false;
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/EventProducer.java
@@ -51,6 +51,7 @@ public class EventProducer implements DatastreamEventProducer {
 
   public static final String CFG_SKIP_MSG_SERIALIZATION_ERRORS = "skipMessageOnSerializationErrors";
   public static final String DEFAULT_SKIP_MSG_SERIALIZATION_ERRORS = "false";
+  public static final String CFG_DISABLE_SLA_METRIC = "system.disableSlaMetric";
   public static final String CONFIG_FLUSH_INTERVAL_MS = "flushIntervalMs";
   public static final String CONFIG_ENABLE_PER_TOPIC_METRICS = "enablePerTopicMetrics";
   public static final String CONFIG_ENABLE_PER_TOPIC_EVENT_LATENCY_METRICS = "enablePerTopicEventLatencyMetrics";
@@ -125,6 +126,7 @@ public class EventProducer implements DatastreamEventProducer {
   private final boolean _skipMessageOnSerializationErrors;
   private final boolean _enablePerTopicMetrics;
   private final boolean _enablePerTopicEventLatencyMetrics;
+  private final boolean _disableSlaMetric;
   private final boolean _enableThroughputMetrics;
   // Cached source database name parsed from the connection string at construction time (null for non-CDC sources)
   private final String _sourceDatabase;
@@ -206,6 +208,8 @@ public class EventProducer implements DatastreamEventProducer {
     _enablePerTopicEventLatencyMetrics =
         Boolean.parseBoolean(config.getProperty(CONFIG_ENABLE_PER_TOPIC_EVENT_LATENCY_METRICS,
             Boolean.FALSE.toString()));
+
+    _disableSlaMetric = getDisableSlaMetric(task);
 
     _enableThroughputMetrics =
         Boolean.parseBoolean(config.getProperty(CONFIG_ENABLE_THROUGHPUT_METRICS, Boolean.FALSE.toString()));
@@ -407,7 +411,9 @@ public class EventProducer implements DatastreamEventProducer {
     if (eventsSourceTimestamp > 0) {
       // Report availability metrics
       long sourceToDestinationLatencyMs = System.currentTimeMillis() - eventsSourceTimestamp;
-      reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
+      if (!_disableSlaMetric) {
+        reportEventLatencyMetrics(topicOrDatastreamName, metadata, sourceToDestinationLatencyMs, EVENTS_LATENCY_MS_STRING);
+      }
 
       reportSLAMetrics(topicOrDatastreamName, sourceToDestinationLatencyMs <= _availabilityThresholdSlaMs,
           EVENTS_PRODUCED_WITHIN_SLA, EVENTS_PRODUCED_OUTSIDE_SLA);
@@ -580,6 +586,19 @@ public class EventProducer implements DatastreamEventProducer {
         .map(Datastream::getMetadata)
         .map(metadata -> metadata.getOrDefault(CFG_SKIP_MSG_SERIALIZATION_ERRORS, skipMessageOnSerializationErrors))
         .orElse(skipMessageOnSerializationErrors));
+  }
+
+  /**
+   * Looks for config {@value CFG_DISABLE_SLA_METRIC} in the datastream metadata and returns its value.
+   * Default value is false.
+   */
+  private boolean getDisableSlaMetric(DatastreamTask task) {
+    return Boolean.parseBoolean(task.getDatastreams()
+        .stream()
+        .findFirst()
+        .map(Datastream::getMetadata)
+        .map(metadata -> metadata.getOrDefault(CFG_DISABLE_SLA_METRIC, Boolean.FALSE.toString()))
+        .orElse(Boolean.FALSE.toString()));
   }
 
   @Override

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -465,6 +465,93 @@ public class TestEventProducer {
         "Alternate-SLA counter must remain suppressed during grace across the deduped task");
   }
 
+  // ---------------------------------------------------------------------------
+  // system.disableSlaMetric opt-out tests
+  //
+  // The opt-out is a per-datastream metadata flag that, when set, suppresses
+  // primary + alternate SLA counters and redirects the latency histogram from
+  // eventsLatencyMs to eventsLatencyMsSlaIneligible. Honored only for tasks
+  // that own a single datastream — deduped tasks ignore the flag so one
+  // stream's opt-out cannot suppress eventsLatencyMs for the whole group.
+  //
+  // Tests use a creation timestamp 3h in the past to bypass the CDC grace
+  // gate, so the only thing being exercised is the opt-out path itself.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testDisableSlaMetricSuppressesSlaCountersAndRedirectsLatency() {
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-opt-out")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    long threeHoursAgo = System.currentTimeMillis() - (3 * 60 * 60 * 1000L);
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(threeHoursAgo));
+    datastream.getMetadata().put(EventProducer.CFG_DISABLE_SLA_METRIC, Boolean.TRUE.toString());
+
+    String topicName = "optOutLatencyTopic";
+    sendOneEventThroughProducer(datastream, new Properties(), topicName);
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_AGG),
+        "Primary withinSla counter must not be created when system.disableSlaMetric=true");
+    Assert.assertNull(metrics.getMetric(SLA_WITHIN_ALT_AGG),
+        "Alternate-SLA counter must not be created when system.disableSlaMetric=true");
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + topicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "eventsLatencyMs must not fire for opted-out streams");
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + topicName + "." + EventProducer.EVENTS_LATENCY_MS_SLA_INELIGIBLE_STRING),
+        "Latency observation should be redirected to eventsLatencyMsSlaIneligible for opted-out streams");
+  }
+
+  @Test
+  public void testDisableSlaMetricFalseLeavesSlaReportingActive() {
+    // Explicit false should behave identically to the flag being absent.
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-opt-out-false")[0];
+    datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    long threeHoursAgo = System.currentTimeMillis() - (3 * 60 * 60 * 1000L);
+    datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(threeHoursAgo));
+    datastream.getMetadata().put(EventProducer.CFG_DISABLE_SLA_METRIC, Boolean.FALSE.toString());
+
+    String topicName = "optOutFalseTopic";
+    sendOneEventThroughProducer(datastream, new Properties(), topicName);
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Counter withinAgg = (Counter) metrics.getMetric(SLA_WITHIN_AGG);
+    Assert.assertNotNull(withinAgg, "withinSla counter should be created when opt-out flag is false");
+    Assert.assertEquals(withinAgg.getCount(), 1L);
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + topicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "eventsLatencyMs must fire normally when opt-out flag is false");
+  }
+
+  @Test
+  public void testDisableSlaMetricIgnoredForDedupedTask() {
+    // Two datastreams sharing one EventProducer: one opted out, one not. The opt-out must be
+    // ignored so the non-opted-out stream's SLA reporting is preserved.
+    long threeHoursAgo = System.currentTimeMillis() - (3 * 60 * 60 * 1000L);
+
+    Datastream optedOut = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-dedup-optout")[0];
+    optedOut.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    optedOut.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(threeHoursAgo));
+    optedOut.getMetadata().put(EventProducer.CFG_DISABLE_SLA_METRIC, Boolean.TRUE.toString());
+
+    Datastream regular = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-dedup-regular")[0];
+    regular.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
+    regular.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(threeHoursAgo));
+
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Arrays.asList(optedOut, regular));
+    String topicName = "dedupOptOutTopic";
+    sendOneEventThroughTask(task, new Properties(), topicName);
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Counter withinAgg = (Counter) metrics.getMetric(SLA_WITHIN_AGG);
+    Assert.assertNotNull(withinAgg,
+        "Deduped task must ignore opt-out — one stream's flag cannot suppress SLA for the whole group");
+    Assert.assertEquals(withinAgg.getCount(), 1L);
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + topicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "eventsLatencyMs must continue to fire for deduped tasks regardless of any member's opt-out flag");
+  }
+
   private void sendOneEventThroughProducer(Datastream datastream, Properties props) {
     sendOneEventThroughProducer(datastream, props, "someTopicName");
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -261,6 +261,128 @@ public class TestEventProducer {
         "Aggregate bytesProducedRate should still exist for BMM");
   }
 
+  @Test
+  public void testDisableSlaMetricSuppressesEventsLatencyMs() {
+    String datastreamName = "datastream-testDisableSlaMetric";
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, datastreamName)[0];
+    datastream.getMetadata().put(EventProducer.CFG_DISABLE_SLA_METRIC, "true");
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+
+    String someTopicName = "someTopicName";
+    TransportProvider transport = new NoOpTransportProviderAdminFactory.NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        DatastreamRecordMetadata metadata =
+            new DatastreamRecordMetadata(record.getCheckpoint(), someTopicName, record.getPartition().orElse(0));
+        onComplete.onCompletion(metadata, null);
+      }
+    };
+
+    EventProducer eventProducer =
+        new EventProducer(task, transport, new NoOpCheckpointProvider(), new Properties(), false);
+
+    eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    String connectorType = DummyConnector.CONNECTOR_TYPE;
+
+    // eventsLatencyMs must NOT be emitted at any level when flag is set
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "Per-topic eventsLatencyMs should not exist when system.disableSlaMetric=true");
+    Assert.assertNull(
+        metrics.getMetric("EventProducer.aggregate." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "Aggregate eventsLatencyMs should not exist when system.disableSlaMetric=true");
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + connectorType + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "Connector-type eventsLatencyMs should not exist when system.disableSlaMetric=true");
+
+    // Within/outside SLA counters must still be emitted
+    Assert.assertNotNull(metrics.getMetric("EventProducer.aggregate.eventsProducedWithinSla"),
+        "Aggregate eventsProducedWithinSla should still exist when SLA metric is disabled");
+    Assert.assertNotNull(metrics.getMetric("EventProducer.aggregate.eventsProducedOutsideSla"),
+        "Aggregate eventsProducedOutsideSla should still exist when SLA metric is disabled");
+
+    // totalEventsProduced and eventProduceRate must still be emitted
+    Assert.assertNotNull(metrics.getMetric("EventProducer.aggregate.totalEventsProduced"),
+        "totalEventsProduced should still exist when SLA metric is disabled");
+    Assert.assertNotNull(metrics.getMetric("EventProducer.aggregate.eventProduceRate"),
+        "eventProduceRate should still exist when SLA metric is disabled");
+
+    // eventsSendLatencyMs is unrelated to the flag and must still be emitted
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_SEND_LATENCY_MS_STRING),
+        "eventsSendLatencyMs should still exist when SLA metric is disabled");
+  }
+
+  @Test
+  public void testDisableSlaMetricDefaultEmitsEventsLatencyMs() {
+    String datastreamName = "datastream-testDisableSlaMetricDefault";
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, datastreamName)[0];
+    // Do NOT set CFG_DISABLE_SLA_METRIC — should default to false
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+
+    String someTopicName = "someTopicName";
+    TransportProvider transport = new NoOpTransportProviderAdminFactory.NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        DatastreamRecordMetadata metadata =
+            new DatastreamRecordMetadata(record.getCheckpoint(), someTopicName, record.getPartition().orElse(0));
+        onComplete.onCompletion(metadata, null);
+      }
+    };
+
+    EventProducer eventProducer =
+        new EventProducer(task, transport, new NoOpCheckpointProvider(), new Properties(), false);
+
+    eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "eventsLatencyMs should be emitted by default (flag absent)");
+  }
+
+  @Test
+  public void testDisableSlaMetricDoesNotAffectThroughputViolatingPath() {
+    String datastreamName = "datastream-testDisableSlaMetricThroughput";
+    Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, datastreamName)[0];
+    datastream.getMetadata().put(EventProducer.CFG_DISABLE_SLA_METRIC, "true");
+    DatastreamTaskImpl task = new DatastreamTaskImpl(Collections.singletonList(datastream));
+
+    String someTopicName = "throughputViolatingTopic";
+    TransportProvider transport = new NoOpTransportProviderAdminFactory.NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        DatastreamRecordMetadata metadata =
+            new DatastreamRecordMetadata(record.getCheckpoint(), someTopicName, record.getPartition().orElse(0));
+        onComplete.onCompletion(metadata, null);
+      }
+    };
+
+    // Provider routes this topic to the throughput-violating path
+    EventProducer eventProducer = new EventProducer(task, transport, new NoOpCheckpointProvider(),
+        new Properties(), false, t -> Collections.singleton(someTopicName));
+
+    eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+
+    // The throughput-violating latency metric must keep flowing even when the SLA flag is set
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "."
+            + EventProducer.THROUGHPUT_VIOLATING_EVENTS_LATENCY_MS_STRING),
+        "throughputViolatingEventsLatencyMs should still be emitted when system.disableSlaMetric=true");
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer.aggregate." + EventProducer.THROUGHPUT_VIOLATING_EVENTS_LATENCY_MS_STRING),
+        "Aggregate throughputViolatingEventsLatencyMs should still be emitted");
+
+    // The standard eventsLatencyMs is on the other branch and shouldn't be emitted at all here
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "Standard eventsLatencyMs should not be emitted on the throughput-violating path");
+  }
+
   private DatastreamProducerRecord createDatastreamProducerRecord() {
     return createDatastreamProducerRecord(0, "0", 1);
   }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -6,8 +6,10 @@
 package com.linkedin.datastream.server;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.atomic.AtomicInteger;
 
@@ -21,6 +23,7 @@ import com.codahale.metrics.MetricRegistry;
 
 import com.linkedin.datastream.common.BrooklinEnvelope;
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.connectors.DummyConnector;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
 import com.linkedin.datastream.serde.SerDe;
@@ -341,6 +344,47 @@ public class TestEventProducer {
     Assert.assertNotNull(
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "eventsLatencyMs should be emitted by default (flag absent)");
+  }
+
+  @Test
+  public void testDisableSlaMetricIgnoredOnDedupedTask() {
+    // Two datastreams sharing one task simulates the deduped case. Honoring the flag here would
+    // suppress eventsLatencyMs for the other stream in the group too — so the producer should
+    // ignore it.
+    Datastream ds1 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-deduped-1")[0];
+    Datastream ds2 = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-deduped-2")[0];
+    // Only one of the deduped streams sets the flag
+    ds1.getMetadata().put(EventProducer.CFG_DISABLE_SLA_METRIC, "true");
+    // Force shared task prefix so DatastreamTaskImpl treats them as a single deduped task
+    String sharedPrefix = DatastreamTaskImpl.getTaskPrefix(ds1);
+    ds1.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, sharedPrefix);
+    ds2.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, sharedPrefix);
+    List<Datastream> dedupedStreams = Arrays.asList(ds1, ds2);
+    DatastreamTaskImpl task = new DatastreamTaskImpl(dedupedStreams);
+
+    String someTopicName = "someTopicName";
+    TransportProvider transport = new NoOpTransportProviderAdminFactory.NoOpTransportProvider() {
+      @Override
+      public void send(String destination, DatastreamProducerRecord record, SendCallback onComplete) {
+        DatastreamRecordMetadata metadata =
+            new DatastreamRecordMetadata(record.getCheckpoint(), someTopicName, record.getPartition().orElse(0));
+        onComplete.onCompletion(metadata, null);
+      }
+    };
+
+    EventProducer eventProducer =
+        new EventProducer(task, transport, new NoOpCheckpointProvider(), new Properties(), false);
+
+    eventProducer.send(createDatastreamProducerRecord(), (m, e) -> { });
+
+    DynamicMetricsManager metrics = DynamicMetricsManager.getInstance();
+    // Flag must be ignored — eventsLatencyMs should still be emitted for the deduped group
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "eventsLatencyMs must still be emitted for deduped tasks even if one stream sets the flag");
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer.aggregate." + EventProducer.EVENTS_LATENCY_MS_STRING),
+        "Aggregate eventsLatencyMs must still be emitted for deduped tasks");
   }
 
   @Test

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -265,7 +265,7 @@ public class TestEventProducer {
   }
 
   @Test
-  public void testDisableSlaMetricSuppressesEventsLatencyMs() {
+  public void testDisableSlaMetricRedirectsToSlaExcludedLatencyMs() {
     String datastreamName = "datastream-testDisableSlaMetric";
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, datastreamName)[0];
     datastream.getMetadata().put(EventProducer.CFG_DISABLE_SLA_METRIC, "true");
@@ -299,6 +299,17 @@ public class TestEventProducer {
     Assert.assertNull(
         metrics.getMetric("EventProducer." + connectorType + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "Connector-type eventsLatencyMs should not exist when system.disableSlaMetric=true");
+
+    // slaExcludedLatencyMs must be emitted at all three levels in place of eventsLatencyMs
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "Per-topic slaExcludedLatencyMs should be emitted when system.disableSlaMetric=true");
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer.aggregate." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "Aggregate slaExcludedLatencyMs should be emitted when system.disableSlaMetric=true");
+    Assert.assertNotNull(
+        metrics.getMetric("EventProducer." + connectorType + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "Connector-type slaExcludedLatencyMs should be emitted when system.disableSlaMetric=true");
 
     // Within/outside SLA counters must still be emitted
     Assert.assertNotNull(metrics.getMetric("EventProducer.aggregate.eventsProducedWithinSla"),
@@ -344,6 +355,9 @@ public class TestEventProducer {
     Assert.assertNotNull(
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "eventsLatencyMs should be emitted by default (flag absent)");
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "slaExcludedLatencyMs should not be emitted by default (flag absent)");
   }
 
   @Test
@@ -385,6 +399,9 @@ public class TestEventProducer {
     Assert.assertNotNull(
         metrics.getMetric("EventProducer.aggregate." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "Aggregate eventsLatencyMs must still be emitted for deduped tasks");
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "slaExcludedLatencyMs must not be emitted for deduped tasks");
   }
 
   @Test
@@ -425,6 +442,10 @@ public class TestEventProducer {
     Assert.assertNull(
         metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.EVENTS_LATENCY_MS_STRING),
         "Standard eventsLatencyMs should not be emitted on the throughput-violating path");
+    // slaExcludedLatencyMs is also on the standard path; should not be emitted on the throughput-violating path
+    Assert.assertNull(
+        metrics.getMetric("EventProducer." + someTopicName + "." + EventProducer.SLA_EXCLUDED_LATENCY_MS_STRING),
+        "slaExcludedLatencyMs should not be emitted on the throughput-violating path");
   }
 
   private DatastreamProducerRecord createDatastreamProducerRecord() {


### PR DESCRIPTION
## Summary                                                                                 
  - Introduces a new datastream metadata flag `system.disableSlaMetric` that lets individual streams opt out of SLA metric emission.
  - When enabled, `EventProducer` suppresses both primary and alternate SLA counters (`eventsProducedWithinSla` / `eventsProducedOutsideSla`) and redirects the latency histogram from `eventsLatencyMs` to `eventsLatencyMsSlaIneligible`, so lag   
  alerts wired to `eventsLatencyMs` do not fire for opted-out streams while their latency curve remains observable.                                                                                                                                  
  - The flag is read once at construction (`getDisableSlaMetric`) and gated through the existing `shouldEmitMetric()` chokepoint, keeping all suppression conditions (grace period + opt-out) in one place.                                          
  - Honored only for non-deduped tasks (single datastream owners). Deduped tasks short-circuit to `false` so one stream's opt-out cannot suppress `eventsLatencyMs` for every stream sharing the `EventProducer`.                                    
                                                                                                                                                                                                                                                     
  ## Test plan                                                                                                                                                                                                                                       
  - [ ] Unit tests cover: opt-out suppresses SLA counters and redirects latency histogram; deduped tasks ignore the flag; default behavior unchanged when flag is absent or `false`.                                                                 
  - [ ] Verify on a canary stream with `system.disableSlaMetric=true` that `eventsLatencyMs` / `eventsProducedWithinSla` / `eventsProducedOutsideSla` are not emitted and `eventsLatencyMsSlaIneligible` is.                                         
  - [ ] Verify a regular stream alongside it still emits the standard SLA metrics.                                                                                                                                                                   
          