### PR TITLE
Add CDC-bootstrap-aware dedup logic to SourceBasedDeduper

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -143,13 +143,4 @@ public class DatastreamMetadataConstants {
    */
   public static final String CDC_BOOTSTRAP_REQUIRED_KEY = "system.cdcBootstrapRequired";
 
-  /**
-   * Start position value indicating the consumer should begin from the earliest available offset.
-   */
-  public static final String CDC_START_POSITION_EARLIEST = "earliest";
-
-  /**
-   * Start position value indicating the consumer should begin from the latest offset.
-   */
-  public static final String CDC_START_POSITION_LATEST = "latest";
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -142,4 +142,14 @@ public class DatastreamMetadataConstants {
    * initialized to an earlier position to replay historical data before catching up to the live tail.
    */
   public static final String CDC_BOOTSTRAP_REQUIRED_KEY = "system.cdcBootstrapRequired";
+
+  /**
+   * Start position value indicating the consumer should begin from the earliest available offset.
+   */
+  public static final String CDC_START_POSITION_EARLIEST = "earliest";
+
+  /**
+   * Start position value indicating the consumer should begin from the latest offset.
+   */
+  public static final String CDC_START_POSITION_LATEST = "latest";
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -136,4 +136,10 @@ public class DatastreamMetadataConstants {
    * which at least one partition violates the brooklin's permissible throughput bounds.
    */
   public static final String THROUGHPUT_VIOLATING_TOPICS = "throughputViolatingTopics";
+
+  /**
+   * Indicates whether the datastream requires CDC bootstrap, i.e. the consumer offset is
+   * initialized to an earlier position to replay historical data before catching up to the live tail.
+   */
+  public static final String CDC_BOOTSTRAP_REQUIRED_KEY = "system.cdcBootstrapRequired";
 }

--- a/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaDatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaDatastreamMetadataConstants.java
@@ -22,4 +22,8 @@ public class KafkaDatastreamMetadataConstants {
 
   // Enable topic auto creation for this Kafka data stream
   public static final String ENABLE_TOPIC_AUTO_CREATION = "system.enableTopicAutoCreation";
+
+  // Kafka consumer start position values used when no checkpoint exists for a CDC datastream
+  public static final String CDC_START_POSITION_EARLIEST = "earliest";
+  public static final String CDC_START_POSITION_LATEST = "latest";
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
@@ -70,7 +70,8 @@ public class SourceBasedDeduper extends AbstractDatastreamDeduper {
   public static final String CONFIG_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY = "cdcBootstrapRequiredMetadataKey";
 
   /** Default value of the metadata key used to identify CDC+BST streams. */
-  public static final String DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY = "system.cdcBootstrapRequired";
+  public static final String DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY =
+      DatastreamMetadataConstants.CDC_BOOTSTRAP_REQUIRED_KEY;
 
   /**
    * Grace-period window in <em>milliseconds</em> applied to existing CDC+BST streams when a new

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
@@ -7,36 +7,326 @@ package com.linkedin.datastream.server;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 import java.util.stream.Collectors;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
+import com.linkedin.datastream.common.DatastreamMetadataConstants;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 
 
 /**
- * Deduper that uses the source to figure out whether two datastreams can be deduped.
+ * Deduper that uses the source connection string to determine whether two datastreams can share
+ * the same destination and tasks.
+ *
+ * <h3>Legacy behavior (default)</h3>
+ * <p>When the new stream does not carry the CDC-bootstrap metadata key (configurable via
+ * {@link #CONFIG_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY},
+ * default {@value #DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY}), the original logic applies:
+ * any existing stream with an identical source connection string is a dedup candidate and the
+ * first match is returned.
+ *
+ * <h3>CDC-bootstrap-aware behavior</h3>
+ * <p>When {@value #DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY} is present on the new stream,
+ * CDC-bootstrap-aware dedup is activated. Two stream types are recognized:
+ * <ul>
+ *   <li><em>CDC-only</em>  — metadata key absent or set to {@code false}. The consumer offset
+ *       is initialized to the <em>latest</em> Kafka offset, so the stream only reads events
+ *       produced after it was created.</li>
+ *   <li><em>CDC+BST</em>   — metadata key set to {@code true}. The consumer offset of source topic is
+ *       intentionally initialized to an <em>earlier</em> offset (before the current tail) so
+ *       that the stream can catch up on historical lag before switching to live replication.
+ *       During this catch-up window the stream is considered "in grace period".</li>
+ * </ul>
+ *
+ * <p>Cross-type dedup eligibility is governed by two configurable time windows. Both default
+ * to {@code 0}, which means the window is treated as immediately expired and cross-type dedup
+ * is always permitted when no same-type candidate is found.
+ *
+ * <ul>
+ *   <li>{@link #CONFIG_NEW_STREAM_GRACE_PERIOD_MS} — the grace period (in milliseconds) that a
+ *       CDC+BST stream requires to finish catching up on lag from its earlier start offset.
+ *       A new CDC-only stream arriving during this window cannot dedup against the CDC+BST stream
+ *       because the CDC+BST stream's offsets are behind the live tail; the CDC-only stream would
+ *       miss events that the CDC+BST has not yet replicated. Once the grace window expires, the
+ *       CDC+BST stream has caught up and cross-type dedup is safe.</li>
+ *   <li>{@link #CONFIG_SNAPSHOT_WORST_REFRESH_DAYS} — the worst-case snapshot refresh window
+ *       (in days) for a CDC-only stream. When a new CDC+BST stream arrives, it needs to start
+ *       from an earlier offset to capture a full snapshot. If the existing CDC-only stream was
+ *       created within this window, its starting offset is still recent enough that the CDC+BST
+ *       stream's required earlier offset would fall outside what the CDC-only stream covers;
+ *       a new independent destination must be created. Once this window has expired, the CDC-only
+ *       stream is old enough that deduping the new CDC+BST stream against it is safe.</li>
+ * </ul>
  */
 public class SourceBasedDeduper extends AbstractDatastreamDeduper {
   private static final Logger LOG = LoggerFactory.getLogger(SourceBasedDeduper.class);
 
+  /** Config key for the metadata flag that marks a stream as requiring CDC bootstrap. */
+  public static final String CONFIG_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY = "cdcBootstrapRequiredMetadataKey";
+
+  /** Default value of the metadata key used to identify CDC+BST streams. */
+  public static final String DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY = "system.cdcBootstrapRequired";
+
+  /**
+   * Grace-period window in <em>milliseconds</em> applied to existing CDC+BST streams when a new
+   * CDC-only stream is being created. A CDC+BST candidate is eligible for dedup only after this
+   * window has expired. Default {@code 0} means the window is treated as immediately expired
+   * (always eligible).
+   *
+   * <p>This key intentionally shares the same unit and semantics as
+   * {@code brooklin.server.eventProducer.newStreamGracePeriodMs} so that a single config value
+   * can drive both the EventProducer SLA grace period and this dedup eligibility window.
+   */
+  public static final String CONFIG_NEW_STREAM_GRACE_PERIOD_MS = "newStreamGracePeriodMs";
+
+  /**
+   * Snapshot-refresh window in days applied to existing CDC-only streams when a new CDC+BST stream
+   * is being created. A CDC-only candidate is eligible for dedup only after this window has expired.
+   * Default {@code 0} means the window is treated as immediately expired (always eligible).
+   */
+  public static final String CONFIG_SNAPSHOT_WORST_REFRESH_DAYS = "snapshotWorstRefreshDays";
+
+  private static final long DEFAULT_NEW_STREAM_GRACE_PERIOD_MS = 0;
+  private static final long DEFAULT_SNAPSHOT_WORST_REFRESH_DAYS = 0;
+
+  private static final long MS_PER_DAY = 24 * 3_600_000L;
+
+  private final String _cdcBootstrapRequiredMetadataKey;
+  private final long _newStreamGracePeriodMs;
+  private final long _snapshotWorstRefreshMs;
+
+  /** Creates a deduper with all settings at their defaults. */
+  public SourceBasedDeduper() {
+    this(new Properties());
+  }
+
+  /**
+   * Creates a deduper configured from {@code props}.
+   *
+   * @param props deduper-domain properties (keys without the {@code deduper.} prefix,
+   *              as produced by {@code VerifiableProperties.getDomainProperties("deduper")})
+   */
+  public SourceBasedDeduper(Properties props) {
+    _cdcBootstrapRequiredMetadataKey = props.getProperty(CONFIG_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY,
+        DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY);
+    _newStreamGracePeriodMs = Long.parseLong(props.getProperty(CONFIG_NEW_STREAM_GRACE_PERIOD_MS,
+        String.valueOf(DEFAULT_NEW_STREAM_GRACE_PERIOD_MS)));
+    _snapshotWorstRefreshMs = Long.parseLong(props.getProperty(CONFIG_SNAPSHOT_WORST_REFRESH_DAYS,
+        String.valueOf(DEFAULT_SNAPSHOT_WORST_REFRESH_DAYS))) * MS_PER_DAY;
+  }
+
+  /**
+   * Entry point. Delegates to legacy source-equality logic when the new stream has no
+   * CDC-bootstrap metadata key; otherwise delegates to CDC-bootstrap-aware logic.
+   */
   @Override
   public Optional<Datastream> dedupeStreams(Datastream stream, List<Datastream> candidates)
       throws DatastreamValidationException {
-    List<Datastream> duplicateDatastreams = candidates.stream()
-        .filter(d -> d.getSource().equals(stream.getSource()))
+    if (!stream.hasMetadata() || stream.getMetadata() == null
+        || !stream.getMetadata().containsKey(_cdcBootstrapRequiredMetadataKey)) {
+      return findDedupCandidateBySource(stream, candidates);
+    }
+    return findDedupCandidateCdcBootstrapAware(stream, candidates);
+  }
+
+  /**
+   * Legacy dedup: returns the first existing stream whose source connection string matches the
+   * new stream's source. Used for all non-CDC connectors and any stream lacking the bootstrap flag.
+   *
+   * @param newStream  the stream being created
+   * @param candidates pre-filtered existing streams that meet the baseline reuse requirements
+   * @return the first matching stream, or {@link Optional#empty()} if none found
+   */
+  private Optional<Datastream> findDedupCandidateBySource(Datastream newStream, List<Datastream> candidates) {
+    List<Datastream> sameSourceStreams = candidates.stream()
+        .filter(d -> d.getSource().equals(newStream.getSource()))
         .collect(Collectors.toList());
 
-    Optional<Datastream> reusedStream = Optional.empty();
+    if (sameSourceStreams.isEmpty()) {
+      return Optional.empty();
+    }
+    LOG.info("Deduping stream {} against existing stream {} (source match)",
+        newStream.getName(), sameSourceStreams.get(0).getName());
+    return Optional.of(sameSourceStreams.get(0));
+  }
 
-    if (!duplicateDatastreams.isEmpty()) {
-      reusedStream = Optional.of(duplicateDatastreams.get(0));
-      LOG.info("Found duplicate datastreams {} for datastream {}, picked {}",
-          duplicateDatastreams, stream, reusedStream);
+  /**
+   * CDC-bootstrap-aware dedup. Splits same-source candidates into CDC-only and CDC+BST buckets,
+   * then delegates based on whether the new stream itself requires bootstrap.
+   *
+   * @param newStream  the stream being created (must carry the CDC-bootstrap metadata key)
+   * @param candidates pre-filtered existing streams that meet the baseline reuse requirements
+   * @return the chosen dedup target, or {@link Optional#empty()} if a new destination should be created
+   */
+  private Optional<Datastream> findDedupCandidateCdcBootstrapAware(Datastream newStream,
+      List<Datastream> candidates) {
+    boolean newStreamRequiresCdcBootstrap = Boolean.parseBoolean(
+        newStream.getMetadata().getOrDefault(_cdcBootstrapRequiredMetadataKey, "false"));
+
+    List<Datastream> sameSourceCandidates = candidates.stream()
+        .filter(d -> d.getSource().equals(newStream.getSource()))
+        .collect(Collectors.toList());
+
+    List<Datastream> cdcOnlyCandidates = sameSourceCandidates.stream()
+        .filter(d -> !isCdcBootstrapRequiredStream(d))
+        .collect(Collectors.toList());
+
+    List<Datastream> cdcBstCandidates = sameSourceCandidates.stream()
+        .filter(this::isCdcBootstrapRequiredStream)
+        .collect(Collectors.toList());
+
+    if (newStreamRequiresCdcBootstrap) {
+      return findDedupCandidateForNewCdcBootstrapStream(newStream, cdcOnlyCandidates, cdcBstCandidates);
+    } else {
+      return findDedupCandidateForNewCdcOnlyStream(newStream, cdcOnlyCandidates, cdcBstCandidates);
+    }
+  }
+
+  /**
+   * Dedup logic for a new <em>CDC+BST</em> stream ({@code cdcBootstrapRequired=true}).
+   *
+   * <p>A CDC+BST stream starts consuming from an earlier source Kafka offset so it can replicate
+   * historical data before catching up to the live tail.
+   *
+   * <ol>
+   *   <li><b>Existing CDC+BST candidate</b> — dedup immediately, no timing check needed.
+   *       Both streams have the same earlier-offset semantics so they can safely share a
+   *       destination.</li>
+   *   <li><b>Existing CDC-only candidate whose snapshot-refresh window has expired</b>
+   *       ({@code creationTime + snapshotWorstRefreshDays < now}) — dedup against it.
+   *       The CDC-only stream is old enough that its retained data covers the earlier offset
+   *       position the new CDC+BST stream requires.</li>
+   *   <li><b>No eligible candidate</b> — create a new independent destination. This happens
+   *       when only a recent CDC-only stream exists: its offset history does not reach back
+   *       far enough for the CDC+BST stream's earlier start position.</li>
+   * </ol>
+   *
+   * @param newStream          the CDC+BST stream being created
+   * @param cdcOnlyCandidates  existing CDC-only streams for the same source
+   * @param cdcBstCandidates   existing CDC+BST streams for the same source
+   * @return the chosen dedup target, or {@link Optional#empty()} if a new destination should be created
+   */
+  private Optional<Datastream> findDedupCandidateForNewCdcBootstrapStream(Datastream newStream,
+      List<Datastream> cdcOnlyCandidates, List<Datastream> cdcBstCandidates) {
+
+    // Step 1: prefer an existing CDC+BST stream — identical offset/type, always eligible.
+    if (!cdcBstCandidates.isEmpty()) {
+      Datastream candidate = cdcBstCandidates.get(0);
+      LOG.info("Deduping new CDC+BST stream {} against existing CDC+BST stream {}",
+          newStream.getName(), candidate.getName());
+      return Optional.of(candidate);
     }
 
-    return reusedStream;
+    // Step 2: fall back to a CDC-only stream whose snapshot-refresh window has expired.
+    Optional<Datastream> eligibleCdcStream = cdcOnlyCandidates.stream()
+        .filter(d -> hasWindowExpired(d, _snapshotWorstRefreshMs))
+        .findFirst();
+    if (eligibleCdcStream.isPresent()) {
+      LOG.info("No CDC+BST stream found; deduping new CDC+BST stream {} against CDC stream {} "
+              + "whose snapshot-refresh window has expired",
+          newStream.getName(), eligibleCdcStream.get().getName());
+      return eligibleCdcStream;
+    }
+
+    // Step 3: no eligible candidate — create a new destination.
+    LOG.info("No eligible dedup candidate for new CDC+BST stream {}; a new destination will be created",
+        newStream.getName());
+    return Optional.empty();
+  }
+
+  /**
+   * Dedup logic for a new <em>CDC-only</em> stream ({@code cdcBootstrapRequired=false} or absent).
+   *
+   * <p>A CDC-only stream starts from the <em>latest</em> Kafka offset and only reads events
+   * produced after creation. It can share a destination with another stream only when their
+   * effective offset positions are compatible.
+   *
+   * <ol>
+   *   <li><b>Existing CDC+BST candidate whose grace window has expired</b>
+   *       ({@code creationTime + newStreamGracePeriodMs < now}) — dedup against it.
+   *       The CDC+BST stream started from an earlier offset to catch up on historical lag, but
+   *       its grace window expiring means it has finished catching up and its consumer position
+   *       has reached the live tail. At that point the two streams' effective offsets converge
+   *       and sharing a destination is safe.</li>
+   *   <li><b>Existing CDC-only candidate</b> — dedup immediately, no timing check needed.
+   *       Both streams start from the latest offset so they are always compatible.</li>
+   *   <li><b>No eligible candidate</b> — create a new independent destination. This happens
+   *       when only a CDC+BST stream exists that is still within its grace window (still
+   *       catching up); deduping now would cause the new CDC-only stream to miss events that
+   *       the CDC+BST has not yet replicated.</li>
+   * </ol>
+   *
+   * @param newStream          the CDC-only stream being created
+   * @param cdcOnlyCandidates  existing CDC-only streams for the same source
+   * @param cdcBstCandidates   existing CDC+BST streams for the same source
+   * @return the chosen dedup target, or {@link Optional#empty()} if a new destination should be created
+   */
+  private Optional<Datastream> findDedupCandidateForNewCdcOnlyStream(Datastream newStream,
+      List<Datastream> cdcOnlyCandidates, List<Datastream> cdcBstCandidates) {
+
+    // Step 1: prefer a CDC+BST stream whose grace window has expired (bootstrap phase is done).
+    Optional<Datastream> eligibleCdcBstStream = cdcBstCandidates.stream()
+        .filter(d -> hasWindowExpired(d, _newStreamGracePeriodMs))
+        .findFirst();
+    if (eligibleCdcBstStream.isPresent()) {
+      LOG.info("Deduping new CDC stream {} against CDC+BST stream {} whose grace window has expired",
+          newStream.getName(), eligibleCdcBstStream.get().getName());
+      return eligibleCdcBstStream;
+    }
+
+    // Step 2: fall back to an existing CDC-only stream.
+    if (!cdcOnlyCandidates.isEmpty()) {
+      Datastream candidate = cdcOnlyCandidates.get(0);
+      LOG.info("Deduping new CDC stream {} against existing CDC stream {}",
+          newStream.getName(), candidate.getName());
+      return Optional.of(candidate);
+    }
+
+    // Step 3: no eligible candidate — create a new destination.
+    LOG.info("No eligible dedup candidate for new CDC stream {}; a new destination will be created",
+        newStream.getName());
+    return Optional.empty();
+  }
+
+  /**
+   * Returns {@code true} when the given stream carries the CDC-bootstrap metadata flag set to
+   * {@code true}, indicating it is a CDC+BST stream.
+   *
+   * @param stream the stream to inspect
+   * @return {@code true} if the stream is a CDC+BST stream, {@code false} otherwise
+   */
+  private boolean isCdcBootstrapRequiredStream(Datastream stream) {
+    if (!stream.hasMetadata() || stream.getMetadata() == null) {
+      return false;
+    }
+    return Boolean.parseBoolean(stream.getMetadata().getOrDefault(_cdcBootstrapRequiredMetadataKey, "false"));
+  }
+
+  /**
+   * Returns {@code true} when the given stream's time window has expired, i.e.
+   * {@code creationTime + windowMs < currentTime}.
+   *
+   * <p>When {@code windowMs} is {@code 0} (the default), the condition
+   * {@code creationTime + 0 < currentTime} is always {@code true} for any existing stream,
+   * so the window is treated as immediately expired and dedup is always permitted.
+   *
+   * <p>Returns {@code false} when {@code system.creation.ms} metadata is absent (cannot
+   * determine age; conservatively treat as not expired).
+   *
+   * @param stream   the existing candidate stream
+   * @param windowMs the window duration in milliseconds
+   * @return {@code true} if the window has expired, {@code false} otherwise
+   */
+  private static boolean hasWindowExpired(Datastream stream, long windowMs) {
+    if (!stream.hasMetadata() || stream.getMetadata() == null
+        || !stream.getMetadata().containsKey(DatastreamMetadataConstants.CREATION_MS)) {
+      return false;
+    }
+    long creationMs = Long.parseLong(stream.getMetadata().get(DatastreamMetadataConstants.CREATION_MS));
+    return System.currentTimeMillis() >= creationMs + windowMs;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduper.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 
 import com.linkedin.datastream.common.Datastream;
 import com.linkedin.datastream.common.DatastreamMetadataConstants;
+import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
 
 
@@ -111,12 +112,12 @@ public class SourceBasedDeduper extends AbstractDatastreamDeduper {
    *              as produced by {@code VerifiableProperties.getDomainProperties("deduper")})
    */
   public SourceBasedDeduper(Properties props) {
+    VerifiableProperties vProps = new VerifiableProperties(props);
     _cdcBootstrapRequiredMetadataKey = props.getProperty(CONFIG_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY,
         DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY);
-    _newStreamGracePeriodMs = Long.parseLong(props.getProperty(CONFIG_NEW_STREAM_GRACE_PERIOD_MS,
-        String.valueOf(DEFAULT_NEW_STREAM_GRACE_PERIOD_MS)));
-    _snapshotWorstRefreshMs = Long.parseLong(props.getProperty(CONFIG_SNAPSHOT_WORST_REFRESH_DAYS,
-        String.valueOf(DEFAULT_SNAPSHOT_WORST_REFRESH_DAYS))) * MS_PER_DAY;
+    _newStreamGracePeriodMs = vProps.getLong(CONFIG_NEW_STREAM_GRACE_PERIOD_MS, DEFAULT_NEW_STREAM_GRACE_PERIOD_MS);
+    _snapshotWorstRefreshMs = Math.multiplyExact(
+        vProps.getLong(CONFIG_SNAPSHOT_WORST_REFRESH_DAYS, DEFAULT_SNAPSHOT_WORST_REFRESH_DAYS), MS_PER_DAY);
   }
 
   /**
@@ -126,8 +127,7 @@ public class SourceBasedDeduper extends AbstractDatastreamDeduper {
   @Override
   public Optional<Datastream> dedupeStreams(Datastream stream, List<Datastream> candidates)
       throws DatastreamValidationException {
-    if (!stream.hasMetadata() || stream.getMetadata() == null
-        || !stream.getMetadata().containsKey(_cdcBootstrapRequiredMetadataKey)) {
+    if (!stream.hasMetadata() || !stream.getMetadata().containsKey(_cdcBootstrapRequiredMetadataKey)) {
       return findDedupCandidateBySource(stream, candidates);
     }
     return findDedupCandidateCdcBootstrapAware(stream, candidates);
@@ -300,7 +300,7 @@ public class SourceBasedDeduper extends AbstractDatastreamDeduper {
    * @return {@code true} if the stream is a CDC+BST stream, {@code false} otherwise
    */
   private boolean isCdcBootstrapRequiredStream(Datastream stream) {
-    if (!stream.hasMetadata() || stream.getMetadata() == null) {
+    if (!stream.hasMetadata()) {
       return false;
     }
     return Boolean.parseBoolean(stream.getMetadata().getOrDefault(_cdcBootstrapRequiredMetadataKey, "false"));
@@ -308,21 +308,24 @@ public class SourceBasedDeduper extends AbstractDatastreamDeduper {
 
   /**
    * Returns {@code true} when the given stream's time window has expired, i.e.
-   * {@code creationTime + windowMs < currentTime}.
+   * {@code System.currentTimeMillis() >= creationTime + windowMs}.
    *
-   * <p>When {@code windowMs} is {@code 0} (the default), the condition
-   * {@code creationTime + 0 < currentTime} is always {@code true} for any existing stream,
-   * so the window is treated as immediately expired and dedup is always permitted.
+   * <p>When {@code windowMs} is {@code 0}, returns {@code true} unconditionally — the window
+   * is treated as immediately expired regardless of whether {@code system.creation.ms} metadata
+   * is present. This handles legacy streams that pre-date the metadata field.
    *
-   * <p>Returns {@code false} when {@code system.creation.ms} metadata is absent (cannot
-   * determine age; conservatively treat as not expired).
+   * <p>Returns {@code false} when {@code windowMs > 0} and {@code system.creation.ms} metadata
+   * is absent (cannot determine age; conservatively treat as not expired).
    *
    * @param stream   the existing candidate stream
    * @param windowMs the window duration in milliseconds
    * @return {@code true} if the window has expired, {@code false} otherwise
    */
   private static boolean hasWindowExpired(Datastream stream, long windowMs) {
-    if (!stream.hasMetadata() || stream.getMetadata() == null
+    if (windowMs == 0) {
+      return true;
+    }
+    if (!stream.hasMetadata()
         || !stream.getMetadata().containsKey(DatastreamMetadataConstants.CREATION_MS)) {
       return false;
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduperFactory.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/SourceBasedDeduperFactory.java
@@ -17,6 +17,6 @@ import com.linkedin.datastream.server.api.connector.DatastreamDeduperFactory;
 public class SourceBasedDeduperFactory implements DatastreamDeduperFactory {
   @Override
   public DatastreamDeduper createDatastreamDeduper(Properties deduperProperties) {
-    return new SourceBasedDeduper();
+    return new SourceBasedDeduper(deduperProperties);
   }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestSourceBasedDeduper.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestSourceBasedDeduper.java
@@ -8,6 +8,7 @@ package com.linkedin.datastream.server;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Optional;
+import java.util.Properties;
 
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -86,6 +87,188 @@ public class TestSourceBasedDeduper {
     SourceBasedDeduper deduper = new SourceBasedDeduper();
     Optional<Datastream> foundDatastream = deduper.findExistingDatastream(datastream, Arrays.asList(datastream1, datastream2));
     Assert.assertFalse(foundDatastream.isPresent());
+  }
+
+  /**
+   * Generate a datastream decorated with CDC-bootstrap metadata and an optional creation timestamp.
+   * {@code creationMs = 0} simulates an old stream whose time window has expired;
+   * {@code creationMs = System.currentTimeMillis()} simulates a freshly-created stream still inside its window.
+   * Pass {@code creationMs < 0} to omit the {@code system.creation.ms} key entirely.
+   */
+  private static Datastream generateCdcDatastream(int seed, boolean withDestination,
+      boolean cdcBootstrapRequired, long creationMs) {
+    Datastream ds = generateDatastream(seed, withDestination);
+    ds.getMetadata().put(SourceBasedDeduper.DEFAULT_CDC_BOOTSTRAP_REQUIRED_METADATA_KEY,
+        String.valueOf(cdcBootstrapRequired));
+    if (creationMs >= 0) {
+      ds.getMetadata().put(DatastreamMetadataConstants.CREATION_MS, String.valueOf(creationMs));
+    }
+    return ds;
+  }
+
+  private static SourceBasedDeduper cdcDeduper() {
+    Properties props = new Properties();
+    props.setProperty(SourceBasedDeduper.CONFIG_NEW_STREAM_GRACE_PERIOD_MS, "3600000"); // 1 hour
+    props.setProperty(SourceBasedDeduper.CONFIG_SNAPSHOT_WORST_REFRESH_DAYS, "4");
+    return new SourceBasedDeduper(props);
+  }
+
+  // ---- Case 1: new CDC+BST → existing CDC+BST → always dedup ----
+  @Test
+  public void testCdcBstNewVsExistingCdcBst() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, true, -1);
+    Datastream candidate = generateCdcDatastream(0, true, true, System.currentTimeMillis());
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals(result.get(), candidate);
+  }
+
+  // ---- Case 2: new CDC-only + existing CDC+BST whose grace window is ACTIVE → new destination ----
+  @Test
+  public void testCdcOnlyNewVsExistingCdcBstGraceActive() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, false, -1);
+    // creationMs = now → grace window (1 hour) has not expired
+    Datastream candidate = generateCdcDatastream(0, true, true, System.currentTimeMillis());
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertFalse(result.isPresent());
+  }
+
+  // ---- Case 3: new CDC-only + existing CDC+BST whose grace window has EXPIRED → dedup ----
+  @Test
+  public void testCdcOnlyNewVsExistingCdcBstGraceExpired() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, false, -1);
+    // creationMs = 0 (epoch) → grace window always expired
+    Datastream candidate = generateCdcDatastream(0, true, true, 0);
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals(result.get(), candidate);
+  }
+
+  // ---- Case 4: new CDC+BST + existing CDC-only whose snapshot-refresh window is ACTIVE → new destination ----
+  @Test
+  public void testCdcBstNewVsExistingCdcOnlySnapshotWindowActive() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, true, -1);
+    // creationMs = now → 4-day snapshot window has not expired
+    Datastream candidate = generateCdcDatastream(0, true, false, System.currentTimeMillis());
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertFalse(result.isPresent());
+  }
+
+  // ---- Case 5: new CDC+BST + existing CDC-only whose snapshot-refresh window has EXPIRED → dedup ----
+  @Test
+  public void testCdcBstNewVsExistingCdcOnlySnapshotWindowExpired() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, true, -1);
+    // creationMs = 0 (epoch) → 4-day snapshot window always expired
+    Datastream candidate = generateCdcDatastream(0, true, false, 0);
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals(result.get(), candidate);
+  }
+
+  // ---- Case 6: new CDC-only + existing CDC-only → always dedup (no timing check) ----
+  @Test
+  public void testCdcOnlyNewVsExistingCdcOnly() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, false, -1);
+    Datastream candidate = generateCdcDatastream(0, true, false, System.currentTimeMillis());
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals(result.get(), candidate);
+  }
+
+  // ---- Case 7: legacy path — new stream has no system.cdcBootstrapRequired → source-equality match ----
+  @Test
+  public void testLegacyPathNoCdcBootstrapKey() throws DatastreamValidationException {
+    // New stream: no system.cdcBootstrapRequired key at all (uses generateDatastream, not generateCdcDatastream)
+    Datastream newStream = generateDatastream(0, false);
+    // Candidate carries the metadata key but that should not matter for the legacy path
+    Datastream candidateSameSource = generateCdcDatastream(0, true, true, 0);
+    Datastream candidateDifferentSource = generateCdcDatastream(1, true, true, 0);
+
+    SourceBasedDeduper deduper = cdcDeduper();
+    // Same source → dedup (legacy source-equality logic)
+    Optional<Datastream> result = deduper.findExistingDatastream(newStream,
+        Arrays.asList(candidateSameSource, candidateDifferentSource));
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals(result.get(), candidateSameSource);
+
+    // Different source → no match
+    Assert.assertFalse(deduper.findExistingDatastream(newStream,
+        Collections.singletonList(candidateDifferentSource)).isPresent());
+  }
+
+  // ---- Preference order: CDC+BST candidate takes priority over CDC-only candidate for new CDC+BST stream ----
+  @Test
+  public void testCdcBstNewPrefersExistingCdcBstOverExpiredCdcOnly() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, true, -1);
+    Datastream cdcOnly = generateCdcDatastream(0, true, false, 0); // snapshot window expired
+    Datastream cdcBst = generateCdcDatastream(0, true, true, System.currentTimeMillis());
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Arrays.asList(cdcOnly, cdcBst));
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals(result.get(), cdcBst);
+  }
+
+  // ---- Preference order: new CDC-only prefers expired CDC+BST over CDC-only when both are present ----
+  @Test
+  public void testCdcOnlyNewPrefersExpiredCdcBstOverCdcOnly() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, false, -1);
+    Datastream cdcBst = generateCdcDatastream(0, true, true, 0); // grace expired
+    Datastream cdcOnly = generateCdcDatastream(0, true, false, System.currentTimeMillis());
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Arrays.asList(cdcBst, cdcOnly));
+    Assert.assertTrue(result.isPresent());
+    Assert.assertEquals(result.get(), cdcBst);
+  }
+
+  // ---- hasWindowExpired: absent system.creation.ms → conservatively treated as NOT expired ----
+
+  // New CDC-only + CDC+BST candidate with no creation.ms → window cannot be verified → new destination
+  @Test
+  public void testCdcOnlyNewVsCdcBstMissingCreationMs() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, false, -1);
+    // creationMs < 0 → no system.creation.ms key set on candidate
+    Datastream candidate = generateCdcDatastream(0, true, true, -1);
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertFalse(result.isPresent());
+  }
+
+  // New CDC+BST + CDC-only candidate with no creation.ms → window cannot be verified → new destination
+  @Test
+  public void testCdcBstNewVsCdcOnlyMissingCreationMs() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, true, -1);
+    // No system.creation.ms → hasWindowExpired returns false → candidate not eligible
+    Datastream candidate = generateCdcDatastream(0, true, false, -1);
+    Optional<Datastream> result = cdcDeduper().findExistingDatastream(newStream, Collections.singletonList(candidate));
+    Assert.assertFalse(result.isPresent());
+  }
+
+  // ---- Default deduper (windowMs=0): all candidates with any creation.ms are immediately eligible ----
+  @Test
+  public void testDefaultDedupeConfigWindowsDisabled() throws DatastreamValidationException {
+    // Default constructor → both windows default to 0 → hasWindowExpired always true for any stream with creation.ms
+    SourceBasedDeduper defaultDeduper = new SourceBasedDeduper();
+
+    // New CDC-only vs CDC+BST with very recent creation.ms: window=0 → immediately expired → dedup
+    Datastream newCdcOnly = generateCdcDatastream(0, false, false, -1);
+    Datastream cdcBstCandidate = generateCdcDatastream(0, true, true, System.currentTimeMillis());
+    Optional<Datastream> result = defaultDeduper.findExistingDatastream(newCdcOnly,
+        Collections.singletonList(cdcBstCandidate));
+    Assert.assertTrue(result.isPresent());
+
+    // New CDC+BST vs CDC-only with very recent creation.ms: window=0 → immediately expired → dedup
+    Datastream newCdcBst = generateCdcDatastream(0, false, true, -1);
+    Datastream cdcOnlyCandidate = generateCdcDatastream(0, true, false, System.currentTimeMillis());
+    result = defaultDeduper.findExistingDatastream(newCdcBst, Collections.singletonList(cdcOnlyCandidate));
+    Assert.assertTrue(result.isPresent());
+  }
+
+  // ---- Different source in CDC-aware path → no match ----
+  @Test
+  public void testCdcAwarePathDifferentSourceNoMatch() throws DatastreamValidationException {
+    Datastream newStream = generateCdcDatastream(0, false, true, -1);
+    // Candidate has different source (seed=1)
+    Datastream differentSourceCandidate = generateCdcDatastream(1, true, true, System.currentTimeMillis());
+    Datastream differentSourceCdcOnly = generateCdcDatastream(1, true, false, 0);
+    Assert.assertFalse(cdcDeduper().findExistingDatastream(newStream,
+        Arrays.asList(differentSourceCandidate, differentSourceCdcOnly)).isPresent());
   }
 
   @Test


### PR DESCRIPTION
## Summary

  - **SourceBasedDeduper**: Added two time-window guards to prevent unsafe cross-type dedup between CDC-only and CDC+BST streams:
    - `newStreamGracePeriodMs`: blocks a new CDC-only stream from deduping against a CDC+BST stream still in its catch-up grace period. The CDC+BST stream's offsets are behind the live tail — deduping would cause the CDC-only stream to miss events.
    - `snapshotWorstRefreshDays`: blocks a new CDC+BST stream from deduping against a CDC-only stream created within the worst-case GPFS snapshot staleness window (4 days). The CDC-only stream's offset 
  history would not reach back far enough for the CDC+BST stream's required earlier start position.
  - **SourceBasedDeduperFactory**: Pass `deduperProperties` through to the `SourceBasedDeduper` constructor so domain-sliced connector config reaches the deduper correctly.
  
  Both windows default to `0` (disabled), preserving existing behavior for all non-CDC connectors. When `system.cdcBootstrapRequired` is absent on the new stream the legacy source-equality path is taken 
  unchanged.
  
  ## Testing Done
  
  - [x] `testCdcBstNewVsExistingCdcBst` — same type always dedups
  - [x] `testCdcOnlyNewVsExistingCdcBstGraceActive` — CDC-only blocked during CDC+BST grace window
  - [x] `testCdcOnlyNewVsExistingCdcBstGraceExpired` — CDC-only allowed after grace expires
  - [x] `testCdcBstNewVsExistingCdcOnlySnapshotWindowActive` — CDC+BST blocked during snapshot window
  - [x] `testCdcBstNewVsExistingCdcOnlySnapshotWindowExpired` — CDC+BST allowed after window expires
  - [x] `testCdcOnlyNewVsExistingCdcOnly` — same type always dedups
  - [x] `testLegacyPathNoCdcBootstrapKey` — legacy source-equality path unaffected
  - [x] `testCdcBstNewPrefersExistingCdcBstOverExpiredCdcOnly` — priority ordering verified
  - [x] `testCdcOnlyNewPrefersExpiredCdcBstOverCdcOnly` — priority ordering verified
  - [x] `testCdcOnlyNewVsCdcBstMissingCreationMs` — conservative block when `system.creation.ms` absent
  - [x] `testCdcBstNewVsCdcOnlyMissingCreationMs` — conservative block when `system.creation.ms` absent
  - [x] `testDefaultDedupeConfigWindowsDisabled` — `windowMs=0` always allows dedup (backward-compatible default)
  - [x] `testCdcAwarePathDifferentSourceNoMatch` — different source → no match