### PR TITLE
Stream provisioning metric changes

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2492,13 +2492,6 @@ public class TestCoordinator {
     setup._datastreamKafkaCluster.shutdown();
   }
 
-  /**
-   * Verifies that the INITIALIZING -> READY transition for a newly created datastream:
-   *   1. Increments the Coordinator.timeToReadyMs histogram with a non-negative sample.
-   *   2. Increments the Coordinator.slowProvisioningCount counter when the configured
-   *      threshold is exceeded. A threshold of 0 ms guarantees any positive duration
-   *      is classified as slow.
-   */
   @Test
   public void testTimeToReadyMetricsOnCreate() throws Exception {
     String testCluster = "testTimeToReadyMetricsOnCreate";
@@ -2525,13 +2518,13 @@ public class TestCoordinator {
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
     Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
-        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
 
     Histogram histogram =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
     Assert.assertNotNull(histogram,
         "Coordinator.timeToReadyMs histogram should be registered after a stream goes READY");
-    Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, WAIT_TIMEOUT_MS),
+    Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, 30000),
         "timeToReadyMs histogram count did not increase after stream transitioned to READY");
     long maxValue = histogram.getSnapshot().getMax();
     Assert.assertTrue(maxValue >= 0, "timeToReadyMs sample should be non-negative, got: " + maxValue);
@@ -2540,7 +2533,7 @@ public class TestCoordinator {
         DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
     Assert.assertNotNull(counter,
         "Coordinator.slowProvisioningCount counter should be registered after a stream goes READY");
-    Assert.assertTrue(PollUtils.poll(() -> counter.getCount() > counterCountBefore, 100, WAIT_TIMEOUT_MS),
+    Assert.assertTrue(PollUtils.poll(() -> counter.getCount() > counterCountBefore, 100, 30000),
         "slowProvisioningCount should increment when duration exceeds threshold");
 
     coordinator.stop();
@@ -2573,13 +2566,22 @@ public class TestCoordinator {
         DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
     long countBefore = counterBefore == null ? 0L : counterBefore.getCount();
 
+    Histogram histogramBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    long histogramCountBefore = histogramBefore == null ? 0L : histogramBefore.getCount();
+
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
     Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
-        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
 
-    // Give the coordinator event loop time to do anything it might (incorrectly) do.
-    Thread.sleep(500);
+    // Wait for the histogram to increment - this proves recordTimeToReadyMs has finished
+    // running, which means any counter increment (or non-increment) decision has been made.
+    Histogram histogram =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    Assert.assertNotNull(histogram, "Histogram should exist after stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, 30000),
+        "Histogram count did not increment - recordTimeToReadyMs may not have run yet");
 
     Counter readyCounter =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -5,8 +5,6 @@
  */
 package com.linkedin.datastream.server;
 
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Histogram;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -54,7 +52,9 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.common.collect.ImmutableList;

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2582,6 +2582,92 @@ public class TestCoordinator {
     zkClient.close();
   }
 
+  /**
+   * Verifies that the slowProvisioningCount counter increments when a datastream's
+   * INITIALIZING -> READY duration exceeds the configured threshold. A threshold of 0 ms
+   * guarantees the freshly-created datastream is classified as slow.
+   */
+  @Test
+  public void testSlowProvisioningCounterIncrementsWhenAboveThreshold() throws Exception {
+    String testCluster = "testSlowProvisioningCounterAboveThreshold";
+    String connectorType = "testConnectorType";
+    String datastreamName = "TestSlowStream";
+
+    Properties override = new Properties();
+    override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS, "0");
+
+    Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, override);
+    TestHookConnector connector = new TestHookConnector("connector1", connectorType);
+    coordinator.addConnector(connectorType, connector, new BroadcastStrategy(Optional.empty()), false,
+        new SourceBasedDeduper(), null);
+    coordinator.start();
+
+    com.codahale.metrics.Counter counterBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
+    long countBefore = counterBefore == null ? 0L : counterBefore.getCount();
+
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+    DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
+
+    com.codahale.metrics.Counter readyCounter =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
+    Assert.assertNotNull(readyCounter,
+        "Coordinator.slowProvisioningCount counter should be registered after a stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> readyCounter.getCount() > countBefore, 100, WAIT_TIMEOUT_MS),
+        "slowProvisioningCount should increment when duration exceeds threshold");
+
+    coordinator.stop();
+    coordinator.getDatastreamCache().getZkclient().close();
+    zkClient.close();
+  }
+
+  /**
+   * Verifies that the slowProvisioningCount counter does NOT increment when a datastream's
+   * INITIALIZING -> READY duration is below the configured threshold. Uses a 1 hour threshold
+   * so that the fast in-test provisioning never exceeds it.
+   */
+  @Test
+  public void testSlowProvisioningCounterDoesNotIncrementWhenBelowThreshold() throws Exception {
+    String testCluster = "testSlowProvisioningCounterBelowThreshold";
+    String connectorType = "testConnectorType";
+    String datastreamName = "TestFastStream";
+
+    Properties override = new Properties();
+    override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS,
+        String.valueOf(Duration.ofHours(1).toMillis()));
+
+    Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, override);
+    TestHookConnector connector = new TestHookConnector("connector1", connectorType);
+    coordinator.addConnector(connectorType, connector, new BroadcastStrategy(Optional.empty()), false,
+        new SourceBasedDeduper(), null);
+    coordinator.start();
+
+    com.codahale.metrics.Counter counterBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
+    long countBefore = counterBefore == null ? 0L : counterBefore.getCount();
+
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+    DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
+
+    // Give the coordinator event loop time to do anything it might (incorrectly) do.
+    Thread.sleep(500);
+
+    com.codahale.metrics.Counter readyCounter =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
+    if (readyCounter != null) {
+      Assert.assertEquals(readyCounter.getCount(), countBefore,
+          "slowProvisioningCount must not increment when duration is below threshold");
+    }
+
+    coordinator.stop();
+    coordinator.getDatastreamCache().getZkclient().close();
+    zkClient.close();
+  }
+
   @Test
   public void testHeartbeat() throws Exception {
     // Use 1s heartbeat period for quicker execution

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -52,7 +52,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -2511,9 +2510,9 @@ public class TestCoordinator {
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
     long histogramCountBefore = histogramBefore == null ? 0L : histogramBefore.getCount();
 
-    Counter counterBefore =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
-    long counterCountBefore = counterBefore == null ? 0L : counterBefore.getCount();
+    Meter meterBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
+    long meterCountBefore = meterBefore == null ? 0L : meterBefore.getCount();
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
@@ -2529,12 +2528,12 @@ public class TestCoordinator {
     long maxValue = histogram.getSnapshot().getMax();
     Assert.assertTrue(maxValue >= 0, "timeToReadyMs sample should be non-negative, got: " + maxValue);
 
-    Counter counter =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
-    Assert.assertNotNull(counter,
-        "Coordinator.slowProvisioningCount counter should be registered after a stream goes READY");
-    Assert.assertTrue(PollUtils.poll(() -> counter.getCount() > counterCountBefore, 100, 30000),
-        "slowProvisioningCount should increment when duration exceeds threshold");
+    Meter meter =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
+    Assert.assertNotNull(meter,
+        "Coordinator.slowProvisioningRate meter should be registered after a stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> meter.getCount() > meterCountBefore, 100, 30000),
+        "slowProvisioningRate should increment when duration exceeds threshold");
 
     coordinator.stop();
     coordinator.getDatastreamCache().getZkclient().close();
@@ -2542,8 +2541,8 @@ public class TestCoordinator {
   }
 
   @Test
-  public void testSlowProvisioningCounterDoesNotIncrementWhenBelowThreshold() throws Exception {
-    String testCluster = "testSlowProvisioningCounterBelowThreshold";
+  public void testSlowProvisioningRateDoesNotIncrementWhenBelowThreshold() throws Exception {
+    String testCluster = "testSlowProvisioningRateBelowThreshold";
     String connectorType = "testConnectorType";
     String datastreamName = "TestFastStream";
 
@@ -2557,9 +2556,9 @@ public class TestCoordinator {
         new SourceBasedDeduper(), null);
     coordinator.start();
 
-    Counter counterBefore =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
-    long countBefore = counterBefore == null ? 0L : counterBefore.getCount();
+    Meter meterBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
+    long meterCountBefore = meterBefore == null ? 0L : meterBefore.getCount();
 
     Histogram histogramBefore =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
@@ -2571,19 +2570,81 @@ public class TestCoordinator {
         DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
 
     // Wait for the histogram to increment - this proves recordTimeToReadyMs has finished
-    // running, which means any counter increment (or non-increment) decision has been made.
+    // running, which means any meter increment (or non-increment) decision has been made.
     Histogram histogram =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
     Assert.assertNotNull(histogram, "Histogram should exist after stream goes READY");
     Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, 30000),
         "Histogram count did not increment - recordTimeToReadyMs may not have run yet");
 
-    Counter readyCounter =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
-    if (readyCounter != null) {
-      Assert.assertEquals(readyCounter.getCount(), countBefore,
-          "slowProvisioningCount must not increment when duration is below threshold");
+    Meter readyMeter =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
+    if (readyMeter != null) {
+      Assert.assertEquals(readyMeter.getCount(), meterCountBefore,
+          "slowProvisioningRate must not increment when duration is below threshold");
     }
+
+    coordinator.stop();
+    coordinator.getDatastreamCache().getZkclient().close();
+    zkClient.close();
+  }
+
+  /**
+   * Resuming a datastream STOPPED -> READY must NOT update either the timeToReadyMs histogram or the
+   * slowProvisioningRate meter. Both metrics are intended to capture only the initial creation
+   * flow's INITIALIZING -> READY transition.
+   */
+  @Test
+  public void testTimeToReadyMetricsNotEmittedOnResume() throws Exception {
+    String testCluster = "testTimeToReadyMetricsNotEmittedOnResume";
+    String connectorType = "testConnectorType";
+    String datastreamName = "TestResumeStream";
+
+    // Threshold of 0 ensures any positive duration would trigger the meter — so the assertion
+    // that the meter does NOT increase on resume is meaningful (it's not just below-threshold).
+    Properties override = new Properties();
+    override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS, "0");
+
+    Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, override);
+    TestHookConnector connector = new TestHookConnector("connector1", connectorType);
+    coordinator.addConnector(connectorType, connector, new BroadcastStrategy(Optional.empty()), false,
+        new SourceBasedDeduper(), null);
+    coordinator.start();
+
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+    DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
+
+    // Capture counts after the initial creation has settled.
+    Histogram histogram =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    Assert.assertNotNull(histogram, "Histogram should exist after the initial create");
+    Meter meter =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
+    Assert.assertNotNull(meter, "Meter should exist after the initial create");
+    long histogramCountAfterCreate = histogram.getCount();
+    long meterCountAfterCreate = meter.getCount();
+
+    // Stop and then resume the datastream. The resume path bypasses the INITIALIZING -> READY
+    // transition in handleDatastreamAddOrDelete, so neither metric should change.
+    Datastream ds = DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName);
+    ds.setStatus(DatastreamStatus.STOPPED);
+    DatastreamTestUtils.updateDatastreams(zkClient, testCluster, ds);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.STOPPED.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
+
+    ds.setStatus(DatastreamStatus.READY);
+    DatastreamTestUtils.updateDatastreams(zkClient, testCluster, ds);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
+
+    // Give the coordinator event loop time to process anything it might (incorrectly) do.
+    Thread.sleep(500);
+    Assert.assertEquals(histogram.getCount(), histogramCountAfterCreate,
+        "timeToReadyMs histogram count must not increase on resume from STOPPED");
+    Assert.assertEquals(meter.getCount(), meterCountAfterCreate,
+        "slowProvisioningRate meter count must not increase on resume from STOPPED");
 
     coordinator.stop();
     coordinator.getDatastreamCache().getZkclient().close();

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2490,6 +2490,98 @@ public class TestCoordinator {
     setup._datastreamKafkaCluster.shutdown();
   }
 
+  /**
+   * Verifies that the Coordinator.timeToReadyMs histogram receives a sample when a datastream
+   * completes the INITIALIZING -> READY transition. The recorded value should be a non-negative
+   * duration roughly equal to (now - system.creation.ms).
+   */
+  @Test
+  public void testTimeToReadyHistogramOnCreate() throws Exception {
+    TestSetup setup = createTestCoordinator();
+
+    com.codahale.metrics.Histogram histogram =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    long countBefore = histogram == null ? 0L : histogram.getCount();
+
+    String datastreamName = "TestTimeToReadyStream";
+    Datastream stream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, datastreamName)[0];
+    stream.getSource().setConnectionString(DummyConnector.VALID_DUMMY_SOURCE);
+    stream.getDestination()
+        .setConnectionString(new KafkaDestination(setup._datastreamKafkaCluster.getKafkaCluster().getZkConnection(),
+            "TestTimeToReadyTopic", false).getDestinationURI());
+    CreateResponse createResponse = setup._resource.create(stream);
+    Assert.assertNull(createResponse.getError());
+    Assert.assertEquals(createResponse.getStatus(), HttpStatus.S_201_CREATED);
+
+    // Wait for the stream to reach READY status, which is when the histogram sample is recorded.
+    Assert.assertTrue(PollUtils.poll(() -> {
+      Datastream queried = setup._resource.get(datastreamName);
+      return queried != null && DatastreamStatus.READY.equals(queried.getStatus());
+    }, 200, WAIT_TIMEOUT_MS));
+
+    com.codahale.metrics.Histogram readyHistogram =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    Assert.assertNotNull(readyHistogram, "Coordinator.timeToReadyMs histogram should be registered after a stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> readyHistogram.getCount() > countBefore, 100, WAIT_TIMEOUT_MS),
+        "timeToReadyMs histogram count did not increase after stream transitioned to READY");
+
+    long maxValue = readyHistogram.getSnapshot().getMax();
+    Assert.assertTrue(maxValue >= 0, "timeToReadyMs sample should be non-negative, got: " + maxValue);
+
+    setup._datastreamKafkaCluster.shutdown();
+  }
+
+  /**
+   * Verifies that resuming a datastream (STOPPED -> READY transition driven directly via the
+   * datastream resource / store) does NOT increment the Coordinator.timeToReadyMs histogram.
+   * The metric is intended to capture only the initial creation flow.
+   */
+  @Test
+  public void testTimeToReadyHistogramNotEmittedOnResume() throws Exception {
+    String testCluster = "testTimeToReadyHistogramNotEmittedOnResume";
+    String connectorType = "testConnectorType";
+    String datastreamName = "TestResumeStream";
+
+    Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster);
+    TestHookConnector connector = new TestHookConnector("connector1", connectorType);
+    coordinator.addConnector(connectorType, connector, new BroadcastStrategy(Optional.empty()), false,
+        new SourceBasedDeduper(), null);
+    coordinator.start();
+
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+    DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
+
+    // Capture histogram count after the initial creation has settled.
+    com.codahale.metrics.Histogram histogram =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    Assert.assertNotNull(histogram, "Histogram should exist after the initial create");
+    long countAfterCreate = histogram.getCount();
+
+    // Stop and then resume the datastream. The resume path bypasses the INITIALIZING -> READY
+    // transition in handleDatastreamAddOrDelete, so the histogram count must not change.
+    Datastream ds = DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName);
+    ds.setStatus(DatastreamStatus.STOPPED);
+    DatastreamTestUtils.updateDatastreams(zkClient, testCluster, ds);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.STOPPED.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
+
+    ds.setStatus(DatastreamStatus.READY);
+    DatastreamTestUtils.updateDatastreams(zkClient, testCluster, ds);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
+
+    // Give the coordinator event loop time to process anything it might (incorrectly) do.
+    Thread.sleep(500);
+    Assert.assertEquals(histogram.getCount(), countAfterCreate,
+        "timeToReadyMs histogram count must not increase on resume from STOPPED");
+
+    coordinator.stop();
+    coordinator.getDatastreamCache().getZkclient().close();
+    zkClient.close();
+  }
+
   @Test
   public void testHeartbeat() throws Exception {
     // Use 1s heartbeat period for quicker execution

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -5,6 +5,8 @@
  */
 package com.linkedin.datastream.server;
 
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -2491,107 +2493,17 @@ public class TestCoordinator {
   }
 
   /**
-   * Verifies that the Coordinator.timeToReadyMs histogram receives a sample when a datastream
-   * completes the INITIALIZING -> READY transition. The recorded value should be a non-negative
-   * duration roughly equal to (now - system.creation.ms).
+   * Verifies that the INITIALIZING -> READY transition for a newly created datastream:
+   *   1. Increments the Coordinator.timeToReadyMs histogram with a non-negative sample.
+   *   2. Increments the Coordinator.slowProvisioningCount counter when the configured
+   *      threshold is exceeded. A threshold of 0 ms guarantees any positive duration
+   *      is classified as slow.
    */
   @Test
-  public void testTimeToReadyHistogramOnCreate() throws Exception {
-    TestSetup setup = createTestCoordinator();
-
-    com.codahale.metrics.Histogram histogram =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
-    long countBefore = histogram == null ? 0L : histogram.getCount();
-
+  public void testTimeToReadyMetricsOnCreate() throws Exception {
+    String testCluster = "testTimeToReadyMetricsOnCreate";
+    String connectorType = "testConnectorType";
     String datastreamName = "TestTimeToReadyStream";
-    Datastream stream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, datastreamName)[0];
-    stream.getSource().setConnectionString(DummyConnector.VALID_DUMMY_SOURCE);
-    stream.getDestination()
-        .setConnectionString(new KafkaDestination(setup._datastreamKafkaCluster.getKafkaCluster().getZkConnection(),
-            "TestTimeToReadyTopic", false).getDestinationURI());
-    CreateResponse createResponse = setup._resource.create(stream);
-    Assert.assertNull(createResponse.getError());
-    Assert.assertEquals(createResponse.getStatus(), HttpStatus.S_201_CREATED);
-
-    // Wait for the stream to reach READY status, which is when the histogram sample is recorded.
-    Assert.assertTrue(PollUtils.poll(() -> {
-      Datastream queried = setup._resource.get(datastreamName);
-      return queried != null && DatastreamStatus.READY.equals(queried.getStatus());
-    }, 200, WAIT_TIMEOUT_MS));
-
-    com.codahale.metrics.Histogram readyHistogram =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
-    Assert.assertNotNull(readyHistogram, "Coordinator.timeToReadyMs histogram should be registered after a stream goes READY");
-    Assert.assertTrue(PollUtils.poll(() -> readyHistogram.getCount() > countBefore, 100, WAIT_TIMEOUT_MS),
-        "timeToReadyMs histogram count did not increase after stream transitioned to READY");
-
-    long maxValue = readyHistogram.getSnapshot().getMax();
-    Assert.assertTrue(maxValue >= 0, "timeToReadyMs sample should be non-negative, got: " + maxValue);
-
-    setup._datastreamKafkaCluster.shutdown();
-  }
-
-  /**
-   * Verifies that resuming a datastream (STOPPED -> READY transition driven directly via the
-   * datastream resource / store) does NOT increment the Coordinator.timeToReadyMs histogram.
-   * The metric is intended to capture only the initial creation flow.
-   */
-  @Test
-  public void testTimeToReadyHistogramNotEmittedOnResume() throws Exception {
-    String testCluster = "testTimeToReadyHistogramNotEmittedOnResume";
-    String connectorType = "testConnectorType";
-    String datastreamName = "TestResumeStream";
-
-    Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster);
-    TestHookConnector connector = new TestHookConnector("connector1", connectorType);
-    coordinator.addConnector(connectorType, connector, new BroadcastStrategy(Optional.empty()), false,
-        new SourceBasedDeduper(), null);
-    coordinator.start();
-
-    ZkClient zkClient = new ZkClient(_zkConnectionString);
-    DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
-    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
-        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
-
-    // Capture histogram count after the initial creation has settled.
-    com.codahale.metrics.Histogram histogram =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
-    Assert.assertNotNull(histogram, "Histogram should exist after the initial create");
-    long countAfterCreate = histogram.getCount();
-
-    // Stop and then resume the datastream. The resume path bypasses the INITIALIZING -> READY
-    // transition in handleDatastreamAddOrDelete, so the histogram count must not change.
-    Datastream ds = DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName);
-    ds.setStatus(DatastreamStatus.STOPPED);
-    DatastreamTestUtils.updateDatastreams(zkClient, testCluster, ds);
-    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.STOPPED.equals(
-        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
-
-    ds.setStatus(DatastreamStatus.READY);
-    DatastreamTestUtils.updateDatastreams(zkClient, testCluster, ds);
-    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
-        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
-
-    // Give the coordinator event loop time to process anything it might (incorrectly) do.
-    Thread.sleep(500);
-    Assert.assertEquals(histogram.getCount(), countAfterCreate,
-        "timeToReadyMs histogram count must not increase on resume from STOPPED");
-
-    coordinator.stop();
-    coordinator.getDatastreamCache().getZkclient().close();
-    zkClient.close();
-  }
-
-  /**
-   * Verifies that the slowProvisioningCount counter increments when a datastream's
-   * INITIALIZING -> READY duration exceeds the configured threshold. A threshold of 0 ms
-   * guarantees the freshly-created datastream is classified as slow.
-   */
-  @Test
-  public void testSlowProvisioningCounterIncrementsWhenAboveThreshold() throws Exception {
-    String testCluster = "testSlowProvisioningCounterAboveThreshold";
-    String connectorType = "testConnectorType";
-    String datastreamName = "TestSlowStream";
 
     Properties override = new Properties();
     override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS, "0");
@@ -2602,20 +2514,33 @@ public class TestCoordinator {
         new SourceBasedDeduper(), null);
     coordinator.start();
 
-    com.codahale.metrics.Counter counterBefore =
+    Histogram histogramBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    long histogramCountBefore = histogramBefore == null ? 0L : histogramBefore.getCount();
+
+    Counter counterBefore =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
-    long countBefore = counterBefore == null ? 0L : counterBefore.getCount();
+    long counterCountBefore = counterBefore == null ? 0L : counterBefore.getCount();
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
     Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
         DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, WAIT_TIMEOUT_MS));
 
-    com.codahale.metrics.Counter readyCounter =
+    Histogram histogram =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+    Assert.assertNotNull(histogram,
+        "Coordinator.timeToReadyMs histogram should be registered after a stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, WAIT_TIMEOUT_MS),
+        "timeToReadyMs histogram count did not increase after stream transitioned to READY");
+    long maxValue = histogram.getSnapshot().getMax();
+    Assert.assertTrue(maxValue >= 0, "timeToReadyMs sample should be non-negative, got: " + maxValue);
+
+    Counter counter =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
-    Assert.assertNotNull(readyCounter,
+    Assert.assertNotNull(counter,
         "Coordinator.slowProvisioningCount counter should be registered after a stream goes READY");
-    Assert.assertTrue(PollUtils.poll(() -> readyCounter.getCount() > countBefore, 100, WAIT_TIMEOUT_MS),
+    Assert.assertTrue(PollUtils.poll(() -> counter.getCount() > counterCountBefore, 100, WAIT_TIMEOUT_MS),
         "slowProvisioningCount should increment when duration exceeds threshold");
 
     coordinator.stop();
@@ -2644,7 +2569,7 @@ public class TestCoordinator {
         new SourceBasedDeduper(), null);
     coordinator.start();
 
-    com.codahale.metrics.Counter counterBefore =
+    Counter counterBefore =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
     long countBefore = counterBefore == null ? 0L : counterBefore.getCount();
 
@@ -2656,7 +2581,7 @@ public class TestCoordinator {
     // Give the coordinator event loop time to do anything it might (incorrectly) do.
     Thread.sleep(500);
 
-    com.codahale.metrics.Counter readyCounter =
+    Counter readyCounter =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningCount");
     if (readyCounter != null) {
       Assert.assertEquals(readyCounter.getCount(), countBefore,

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2541,11 +2541,6 @@ public class TestCoordinator {
     zkClient.close();
   }
 
-  /**
-   * Verifies that the slowProvisioningCount counter does NOT increment when a datastream's
-   * INITIALIZING -> READY duration is below the configured threshold. Uses a 1 hour threshold
-   * so that the fast in-test provisioning never exceeds it.
-   */
   @Test
   public void testSlowProvisioningCounterDoesNotIncrementWhenBelowThreshold() throws Exception {
     String testCluster = "testSlowProvisioningCounterBelowThreshold";

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2540,6 +2540,7 @@ public class TestCoordinator {
     zkClient.close();
   }
 
+
   @Test
   public void testSlowProvisioningRateDoesNotIncrementWhenBelowThreshold() throws Exception {
     String testCluster = "testSlowProvisioningRateBelowThreshold";

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -65,6 +65,7 @@ import com.linkedin.datastream.common.PollUtils;
 import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.metrics.BrooklinCounterInfo;
 import com.linkedin.datastream.metrics.BrooklinGaugeInfo;
+import com.linkedin.datastream.metrics.BrooklinHistogramInfo;
 import com.linkedin.datastream.metrics.BrooklinMeterInfo;
 import com.linkedin.datastream.metrics.BrooklinMetricInfo;
 import com.linkedin.datastream.metrics.DynamicMetricsManager;
@@ -177,6 +178,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private static final int TOKEN_CLAIM_THREAD_POOL_SIZE = 16;
 
   private static final Duration ASSIGNMENT_TIMEOUT = Duration.ofSeconds(90);
+
+  // Histogram capturing the duration (ms) between datastream creation (system.creation.ms) and
+  // the INITIALIZING -> READY transition. Aggregate-only; alert reads max over the sliding window.
+  private static final String TIME_TO_READY_MS = "timeToReadyMs";
+  private static final long TIME_TO_READY_HISTOGRAM_WINDOW_MS = Duration.ofMinutes(15).toMillis();
 
   private static final AtomicLong PAUSED_DATASTREAMS_GROUPS = new AtomicLong(0L);
 
@@ -1345,6 +1351,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
             _log.warn("Failed to update datastream: {} after initializing. This datastream will not be scheduled for "
                 + "producing events ", ds.getName());
             shouldRetry = true;
+          } else {
+            recordTimeToReadyMs(ds);
           }
         } catch (Exception e) {
           _log.warn("Failed to update the destination of new datastream {}", ds, e);
@@ -1376,6 +1384,21 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
     _eventQueue.put(CoordinatorEvent.createLeaderDoAssignmentEvent(false));
     _log.info("END: Coordinator::handleDatastreamAddOrDelete.");
+  }
+
+  private void recordTimeToReadyMs(Datastream ds) {
+    String creationMsStr = Objects.requireNonNull(ds.getMetadata()).get(CREATION_MS);
+    if (creationMsStr == null) {
+      return;
+    }
+    try {
+      long timeToReadyMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
+      if (timeToReadyMs >= 0) {
+        _metrics.updateTimeToReadyHistogram(timeToReadyMs);
+      }
+    } catch (NumberFormatException e) {
+      _log.warn("Invalid {} for datastream {}: {}", CREATION_MS, ds.getName(), creationMsStr);
+    }
   }
 
   private void hardDeleteDatastream(Datastream ds, List<Datastream> activeStreams) {
@@ -2451,6 +2474,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       registerKeyedMeterMetrics();
       registerGaugeMetrics();
       registerCounterMetrics();
+      registerHistogramMetrics();
     }
 
     public void addMetricInfos(MetricsAware metricsAware) {
@@ -2493,6 +2517,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
     public void updateCounter(Counter metric, int value) {
       _dynamicMetricsManager.createOrUpdateCounter(MODULE, metric.getName(), value);
+    }
+
+    public void updateTimeToReadyHistogram(long valueMs) {
+      _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, null, TIME_TO_READY_MS,
+          TIME_TO_READY_HISTOGRAM_WINDOW_MS, valueMs);
     }
 
     public static KeyedMeter getKeyedMeter(EventType eventType) {
@@ -2581,6 +2610,13 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     private void registerCounterMetrics() {
       // These metrics are eagerly created
       Arrays.stream(Counter.values()).forEach(this::registerCounter);
+    }
+
+    private void registerHistogramMetrics() {
+      // The metric is created lazily on first update via createOrUpdateSlidingWindowHistogram.
+      // Registering the BrooklinHistogramInfo here is required for the external metrics bridge
+      // to pick up the metric name (see PR #945 precedent).
+      _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, TIME_TO_READY_MS)));
     }
 
     private void registerMeter(Meter metric) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1395,6 +1395,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       long timeToReadyMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
       if (timeToReadyMs >= 0) {
         _metrics.updateTimeToReadyHistogram(timeToReadyMs);
+        if (timeToReadyMs > _config.getSlowProvisioningThresholdMs()) {
+          _metrics.updateCounter(CoordinatorMetrics.Counter.SLOW_PROVISIONING_COUNT, 1);
+        }
         _log.info("Datastream {} reached READY in {} ms", ds.getName(), timeToReadyMs);
       }
     } catch (NumberFormatException e) {
@@ -2723,7 +2726,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
      * Coordinator metrics of type {@link com.codahale.metrics.Counter}
      */
     public enum Counter {
-      NUM_HEARTBEATS("numHeartbeats");
+      NUM_HEARTBEATS("numHeartbeats"),
+      SLOW_PROVISIONING_COUNT("slowProvisioningCount");
 
       private final String _name;
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -179,8 +179,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
   private static final Duration ASSIGNMENT_TIMEOUT = Duration.ofSeconds(90);
 
-  // Histogram capturing the duration (ms) between datastream creation (system.creation.ms) and
-  // the INITIALIZING -> READY transition. Aggregate-only; alert reads max over the sliding window.
+  // Histogram capturing the duration between datastream creation and the INITIALIZING -> READY transition.
   private static final String TIME_TO_READY_MS = "timeToReadyMs";
   private static final long TIME_TO_READY_HISTOGRAM_WINDOW_MS = Duration.ofMinutes(15).toMillis();
 
@@ -2619,7 +2618,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     private void registerHistogramMetrics() {
       // The metric is created lazily on first update via createOrUpdateSlidingWindowHistogram.
       // Registering the BrooklinHistogramInfo here is required for the external metrics bridge
-      // to pick up the metric name (see PR #945 precedent).
+      // to pick up the metric name
       _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, TIME_TO_READY_MS)));
     }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1395,6 +1395,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       long timeToReadyMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
       if (timeToReadyMs >= 0) {
         _metrics.updateTimeToReadyHistogram(timeToReadyMs);
+        _log.info("Datastream {} reached READY in {} ms", ds.getName(), timeToReadyMs);
       }
     } catch (NumberFormatException e) {
       _log.warn("Invalid {} for datastream {}: {}", CREATION_MS, ds.getName(), creationMsStr);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -180,8 +180,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private static final Duration ASSIGNMENT_TIMEOUT = Duration.ofSeconds(90);
 
   // Histogram capturing the duration between datastream creation and the INITIALIZING -> READY transition.
+  // With a 5-min sliding window and sparse provisioning events (typically minutes-to-hours apart),
+  // each event lands as an isolated ~5-min plateau in the exported .99thPercentile time series —
+  // effectively a per-event scatter view.
   private static final String TIME_TO_READY_MS = "timeToReadyMs";
-  private static final long TIME_TO_READY_HISTOGRAM_WINDOW_MS = Duration.ofMinutes(15).toMillis();
+  private static final long TIME_TO_READY_HISTOGRAM_WINDOW_MS = Duration.ofMinutes(5).toMillis();
 
   private static final AtomicLong PAUSED_DATASTREAMS_GROUPS = new AtomicLong(0L);
 
@@ -1385,6 +1388,19 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _log.info("END: Coordinator::handleDatastreamAddOrDelete.");
   }
 
+  /**
+   * Records the time from {@code system.creation.ms} to the {@code INITIALIZING -> READY}
+   * transition for a newly created datastream. Updates the {@code timeToReadyMs} histogram and,
+   * when the duration exceeds {@link CoordinatorConfig#getSlowProvisioningThresholdMs()},
+   * increments the {@code slowProvisioningRate} meter.
+   *
+   * <p> {@code system.creation.ms} is written in the request by Nuage before calling the create datastream API. As a
+   * fallback, it is written by the coordinator if the property is not already present via {@code putIfAbsent}
+   *
+   * <p>The {@link NumberFormatException} catch defends against externally-supplied or
+   * operator-edited values: because {@code CREATION_MS} is set via {@code putIfAbsent}, any
+   * earlier writer (for example, a buggy REST caller or a manual ZK edit) wins.
+   */
   private void recordTimeToReadyMs(Datastream ds) {
     String creationMsStr = Objects.requireNonNull(ds.getMetadata()).get(CREATION_MS);
     if (creationMsStr == null) {
@@ -1392,12 +1408,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
     try {
       long timeToReadyMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
+      _log.info("Datastream {} transitioned to READY in {} ms", ds.getName(), timeToReadyMs);
       if (timeToReadyMs >= 0) {
         _metrics.updateTimeToReadyHistogram(timeToReadyMs);
         if (timeToReadyMs > _config.getSlowProvisioningThresholdMs()) {
-          _metrics.updateCounter(CoordinatorMetrics.Counter.SLOW_PROVISIONING_COUNT, 1);
+          _metrics.updateMeter(CoordinatorMetrics.Meter.SLOW_PROVISIONING_RATE, 1);
         }
-        _log.info("Datastream {} reached READY in {} ms", ds.getName(), timeToReadyMs);
       }
     } catch (NumberFormatException e) {
       _log.warn("Invalid {} for datastream {}: {}", CREATION_MS, ds.getName(), creationMsStr);
@@ -2656,7 +2672,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       NUM_PARTITION_ASSIGNMENTS("numPartitionAssignments"),
       NUM_PARTITION_MOVEMENTS("numPartitionMovements"),
       NUM_ORPHAN_CONNECTOR_TASKS("numOrphanConnectorTasks"),
-      NUM_ORPHAN_CONNECTOR_TASK_LOCKS("numOrphanConnectorTaskLocks");
+      NUM_ORPHAN_CONNECTOR_TASK_LOCKS("numOrphanConnectorTaskLocks"),
+      SLOW_PROVISIONING_RATE("slowProvisioningRate");
 
       private final String _name;
 
@@ -2725,8 +2742,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
      * Coordinator metrics of type {@link com.codahale.metrics.Counter}
      */
     public enum Counter {
-      NUM_HEARTBEATS("numHeartbeats"),
-      SLOW_PROVISIONING_COUNT("slowProvisioningCount");
+      NUM_HEARTBEATS("numHeartbeats");
 
       private final String _name;
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -58,7 +58,7 @@ public final class CoordinatorConfig {
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS = 60 * 1000;
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS = 10 * 1000;
   public static final int DEFAULT_LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
-  public static final long DEFAULT_SLOW_PROVISIONING_THRESHOLD_MS = Duration.ofMinutes(10).toMillis();
+  public static final long DEFAULT_SLOW_PROVISIONING_THRESHOLD_MS = Duration.ofMinutes(8).toMillis();
 
   private final String _cluster;
   private final String _zkAddress;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -48,6 +48,8 @@ public final class CoordinatorConfig {
 
   public static final String CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING = PREFIX + "enableThroughputViolatingTopicsHandling";
   public static final String CONFIG_LOG_SIZE_LIMIT_IN_BYTES = PREFIX + "logSizeLimitInBytes";
+  // threshold above which a datastream's INITIALIZING -> READY duration is counted as a slow provisioning event
+  public static final String CONFIG_SLOW_PROVISIONING_THRESHOLD_MS = PREFIX + "slowProvisioningThresholdMs";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
@@ -56,6 +58,7 @@ public final class CoordinatorConfig {
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS = 60 * 1000;
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS = 10 * 1000;
   public static final int DEFAULT_LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
+  public static final long DEFAULT_SLOW_PROVISIONING_THRESHOLD_MS = Duration.ofMinutes(10).toMillis();
 
   private final String _cluster;
   private final String _zkAddress;
@@ -82,6 +85,7 @@ public final class CoordinatorConfig {
   private final long _markDatastreamsStoppedRetryPeriodMs;
   private final boolean _enableThroughputViolatingTopicsHandling;
   private final double _logSizeLimitInBytes;
+  private final long _slowProvisioningThresholdMs;
 
 
   /**
@@ -121,6 +125,8 @@ public final class CoordinatorConfig {
     _enableThroughputViolatingTopicsHandling = _properties.getBoolean(
         CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, false);
     _logSizeLimitInBytes = _properties.getDouble(CONFIG_LOG_SIZE_LIMIT_IN_BYTES, DEFAULT_LOG_SIZE_LIMIT_IN_BYTES);
+    _slowProvisioningThresholdMs = _properties.getLong(CONFIG_SLOW_PROVISIONING_THRESHOLD_MS,
+        DEFAULT_SLOW_PROVISIONING_THRESHOLD_MS);
   }
 
   public Properties getConfigProperties() {
@@ -219,5 +225,9 @@ public final class CoordinatorConfig {
 
   public double getLogSizeLimitInBytes() {
     return _logSizeLimitInBytes;
+  }
+
+  public long getSlowProvisioningThresholdMs() {
+    return _slowProvisioningThresholdMs;
   }
 }


### PR DESCRIPTION
## Summary

- **`timeToReadyMs` histogram (Coordinator):** records the duration between datastream creation (`system.creation.ms`) and the `INITIALIZING -> READY` transition. Uses a **5-minute sliding window reservoir**; exposed via the standard `BrooklinHistogramInfo` attributes. In the live RRD pipeline only `.50thPercentile` and `.99thPercentile` are emitted — for sparse provisioning events (typically minutes-to-hours apart) the `.99thPercentile` time series effectively becomes a per-event scatter view, with each event landing as an isolated ~5-min plateau.
- **`slowProvisioningRate` meter (Coordinator):** incremented whenever a datastream's time-to-ready exceeds a configurable threshold. Emitted as `.PerSecondRate` in RRD, matching the established Brooklin rate-metric convention (e.g., `eventProduceRate`, `errorRate`). Enables a simple `threshold > 0` AutoAlerts rule with no derivative arithmetic
- **New config `brooklin.server.coordinator.slowProvisioningThresholdMs`:** controls the threshold above which a provisioning is counted as slow. Default 10 minutes. Threshold lives in config, so brooklin-server can tune per fabric without a library bump.
- **Per-datastream log line on READY:** `"Datastream {name} transitioned to READY in {N} ms"` — useful for debugging individual provisionings.
- Resume-from-STOPPED path is explicitly excluded from the metrics — only the initial `INITIALIZING -> READY` transition is counted. The new resume regression test guards this.

## Querying & alerting

- **Per-event scatter view (30/90 days):** plot `Coordinator.timeToReadyMs.99thPercentile` over the desired range in MDM Explorer / inGraphs — each plateau ≈ one provisioning event's duration.
- **Alert when stream provisioning takes longer time:** Alert on slowProvisioningRate > 0       
                                                                                                            
## Testing Done                                                                                                                                                          
- [x] `testTimeToReadyMetricsOnCreate` — with threshold = 0 ms, asserts both the histogram count and meter count increment after the stream goes READY, and the histogram sample is non-negative
- [x] `testSlowProvisioningRateDoesNotIncrementWhenBelowThreshold` — with threshold = 1 h, asserts the meter count stays unchanged after the stream goes READY
- [x] `testTimeToReadyMetricsNotEmittedOnResume` — STOPPED → READY resher the histogram or the meter (regression net)
- [x] `mint build`