### PR TITLE
  Add periodic EOB completion check to Coordinator for bootstrap datastreams

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -143,4 +143,11 @@ public class DatastreamMetadataConstants {
    */
   public static final String CDC_BOOTSTRAP_REQUIRED_KEY = "system.cdcBootstrapRequired";
 
+  /**
+   * Set to "true" by the Coordinator when all tasks for a bootstrap datastream have reached
+   * {@link com.linkedin.datastream.server.DatastreamTaskStatus.Code#COMPLETE} status, indicating
+   * that End-of-Bootstrap (EOB) events have been successfully produced to all destination partitions.
+   */
+  public static final String IS_EOB_COMPLETE = "system.isEOBComplete";
+
 }

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -6,6 +6,7 @@
 package com.linkedin.datastream.server;
 
 import java.io.IOException;
+import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.time.Duration;
@@ -4643,5 +4644,402 @@ public class TestCoordinator {
     } finally {
       setAssignmentTimeout(originalTimeout);
     }
+  }
+
+  // ---- maybeMarkEOBCompleteForBootstrapDatastreams tests ----
+
+  /**
+   * In-memory ZkAdapter stub used by EOB unit tests. Avoids real ZK connections and
+   * works around Mockito cglib incompatibility with newer JDKs. Tracks updateDatastream
+   * calls and task state in memory.
+   */
+  private static class EobTestZkAdapter extends ZkAdapter {
+    private boolean _leader;
+    final List<Datastream> updatedDatastreams = new ArrayList<>();
+    // per-task in-memory state store (keyed by taskId + "." + stateKey)
+    private final Map<String, String> _taskState = new HashMap<>();
+
+    EobTestZkAdapter(boolean leader) {
+      super("localhost:2181", "testEOBCluster", "", ZkClient.DEFAULT_SESSION_TIMEOUT,
+          ZkClient.DEFAULT_CONNECTION_TIMEOUT, 1000, 1024 * 1024, null);
+      _leader = leader;
+    }
+
+    @Override
+    public synchronized boolean isLeader() {
+      return _leader;
+    }
+
+    @Override
+    public boolean updateDatastream(Datastream datastream) {
+      updatedDatastreams.add(datastream);
+      return true;
+    }
+
+    @Override
+    public Map<String, Set<DatastreamTask>> getAllAssignedDatastreamTasks() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public String getDatastreamTaskStateForKey(DatastreamTask task, String key) {
+      return _taskState.get(task.getDatastreamTaskName() + "." + key);
+    }
+
+    @Override
+    public void setDatastreamTaskStateForKey(DatastreamTask task, String key, String value) {
+      _taskState.put(task.getDatastreamTaskName() + "." + key, value);
+    }
+  }
+
+  /** Creates a DatastreamTaskImpl with in-memory state (no real ZK). Each call gets a unique task id. */
+  private static DatastreamTaskImpl makeTask(String taskPrefix, List<Datastream> datastreams,
+      EobTestZkAdapter zkAdapter) {
+    DatastreamTaskImpl task = new DatastreamTaskImpl();
+    task.setTaskPrefix(taskPrefix);
+    task.setId(UUID.randomUUID().toString());
+    task.setDatastreams(datastreams);
+    task.setZkAdapter(zkAdapter);
+    return task;
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_nonBootstrapStreamSkipped() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "live-stream";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "live-stream", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = Collections.singletonMap("i001",
+        Collections.singleton(task));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertTrue(stubAdapter.updatedDatastreams.isEmpty());
+    Assert.assertNull(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE));
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_tasksNotComplete_noUpdate() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "mydb-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "mydb-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task1 = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task1.setStatus(DatastreamTaskStatus.ok());
+    DatastreamTaskImpl task2 = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task2.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
+    assignment.put("i001", new HashSet<>(Arrays.asList(task1, task2)));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertTrue(stubAdapter.updatedDatastreams.isEmpty());
+    Assert.assertNull(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE));
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_allTasksComplete_setsFlag() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "mydb-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "mydb-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task1 = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task1.setStatus(DatastreamTaskStatus.complete());
+    DatastreamTaskImpl task2 = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task2.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
+    assignment.put("i001", new HashSet<>(Arrays.asList(task1, task2)));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertEquals(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE), "true");
+    Assert.assertEquals(stubAdapter.updatedDatastreams.size(), 1);
+    Assert.assertEquals(stubAdapter.updatedDatastreams.get(0), ds);
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_alreadyMarked_skipped() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "mydb-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "mydb-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    ds.getMetadata().put(DatastreamMetadataConstants.IS_EOB_COMPLETE, "true");
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = Collections.singletonMap("i001",
+        Collections.singleton(task));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertTrue(stubAdapter.updatedDatastreams.isEmpty());
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_tasksAcrossInstances_allComplete() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "entity-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl taskOnInstance1 = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    taskOnInstance1.setStatus(DatastreamTaskStatus.complete());
+    DatastreamTaskImpl taskOnInstance2 = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    taskOnInstance2.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
+    assignment.put("i001", Collections.singleton(taskOnInstance1));
+    assignment.put("i002", Collections.singleton(taskOnInstance2));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertEquals(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE), "true");
+    Assert.assertEquals(stubAdapter.updatedDatastreams.size(), 1);
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_dedupedStreams_flagSetOnAll() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "entity-bst-20240101";
+    Datastream ds1 = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101", "source");
+    ds1.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    Datastream ds2 = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101-deduped", "source");
+    ds2.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Arrays.asList(ds1, ds2));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task = makeTask(taskPrefix, Arrays.asList(ds1, ds2), stubAdapter);
+    task.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = Collections.singletonMap("i001",
+        Collections.singleton(task));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertEquals(ds1.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE), "true");
+    Assert.assertEquals(ds2.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE), "true");
+    Assert.assertEquals(stubAdapter.updatedDatastreams.size(), 2);
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_connectorNotInAllowlist_skipped() throws Exception {
+    String connectorType = "filteredConnector";
+    String taskPrefix = "entity-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = Collections.singletonMap("i001",
+        Collections.singleton(task));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter,
+        "EspressoBootstrapConnector,TiDBBootstrapConnector");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertTrue(stubAdapter.updatedDatastreams.isEmpty());
+    Assert.assertNull(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE));
+  }
+
+  @Test
+  public void testMaybeMarkEOBComplete_connectorInAllowlist_setsFlag() throws Exception {
+    String connectorType = "EspressoBootstrapConnector";
+    String taskPrefix = "entity-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    task.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = Collections.singletonMap("i001",
+        Collections.singleton(task));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter,
+        "EspressoBootstrapConnector,TiDBBootstrapConnector");
+
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertEquals(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE), "true");
+    Assert.assertEquals(stubAdapter.updatedDatastreams.size(), 1);
+  }
+
+  @Test
+  public void testPeriodicEobCheck_nonLeader_noWork() throws Exception {
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(false);
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+
+    coordinator.periodicEobCheck();
+
+    Assert.assertTrue(stubAdapter.updatedDatastreams.isEmpty());
+  }
+
+  // ---- no tasks assigned yet → bootstrap hasn't started, skip ----
+  @Test
+  public void testMaybeMarkEOBComplete_noTasksAssigned_skipped() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "entity-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    // No tasks assigned — empty assignment map
+    Map<String, Set<DatastreamTask>> assignment = Collections.emptyMap();
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertTrue(stubAdapter.updatedDatastreams.isEmpty());
+    Assert.assertNull(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE));
+  }
+
+  // ---- task with null status → not considered COMPLETE → no flag set ----
+  @Test
+  public void testMaybeMarkEOBComplete_taskWithNullStatus_noUpdate() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "entity-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+    DatastreamTaskImpl task = makeTask(taskPrefix, Collections.singletonList(ds), stubAdapter);
+    // deliberately leave status as null (not set)
+
+    Map<String, Set<DatastreamTask>> assignment = Collections.singletonMap("i001",
+        Collections.singleton(task));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    Assert.assertTrue(stubAdapter.updatedDatastreams.isEmpty());
+    Assert.assertNull(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE));
+  }
+
+  // ---- updateDatastream returns false → warning logged, no crash, flag not persisted ----
+  @Test
+  public void testMaybeMarkEOBComplete_updateFails_noException() throws Exception {
+    String connectorType = "testConnector";
+    String taskPrefix = "entity-bst-20240101";
+    Datastream ds = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-20240101", "source");
+    ds.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, taskPrefix);
+    DatastreamGroup group = new DatastreamGroup(Collections.singletonList(ds));
+
+    // Stub that always returns false from updateDatastream
+    EobTestZkAdapter failingAdapter = new EobTestZkAdapter(true) {
+      @Override
+      public boolean updateDatastream(Datastream datastream) {
+        return false;
+      }
+    };
+
+    DatastreamTaskImpl task = makeTask(taskPrefix, Collections.singletonList(ds), failingAdapter);
+    task.setStatus(DatastreamTaskStatus.complete());
+
+    Map<String, Set<DatastreamTask>> assignment = Collections.singletonMap("i001",
+        Collections.singleton(task));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(failingAdapter, "");
+    // Should not throw even though updateDatastream returns false
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment, Collections.singletonList(group));
+
+    // Metadata is updated in-memory but ZK persist failed — no exception thrown
+    Assert.assertEquals(ds.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE), "true");
+    Assert.assertTrue(failingAdapter.updatedDatastreams.isEmpty());
+  }
+
+  // ---- multiple bootstrap groups: only the complete one gets flagged ----
+  @Test
+  public void testMaybeMarkEOBComplete_multipleGroups_onlyCompleteOneMarked() throws Exception {
+    String connectorType = "testConnector";
+
+    String prefixComplete = "entity-bst-complete";
+    Datastream dsComplete = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-complete", "source1");
+    dsComplete.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, prefixComplete);
+    DatastreamGroup completeGroup = new DatastreamGroup(Collections.singletonList(dsComplete));
+
+    String prefixRunning = "entity-bst-running";
+    Datastream dsRunning = DatastreamTestUtils.createDatastream(connectorType, "entity-bst-running", "source2");
+    dsRunning.getMetadata().put(DatastreamMetadataConstants.TASK_PREFIX, prefixRunning);
+    DatastreamGroup runningGroup = new DatastreamGroup(Collections.singletonList(dsRunning));
+
+    EobTestZkAdapter stubAdapter = new EobTestZkAdapter(true);
+
+    DatastreamTaskImpl completeTask = makeTask(prefixComplete, Collections.singletonList(dsComplete), stubAdapter);
+    completeTask.setStatus(DatastreamTaskStatus.complete());
+
+    DatastreamTaskImpl runningTask = makeTask(prefixRunning, Collections.singletonList(dsRunning), stubAdapter);
+    runningTask.setStatus(DatastreamTaskStatus.ok());
+
+    Map<String, Set<DatastreamTask>> assignment = new HashMap<>();
+    assignment.put("i001", new HashSet<>(Arrays.asList(completeTask, runningTask)));
+
+    Coordinator coordinator = buildCoordinatorWithStubAdapter(stubAdapter, "");
+    coordinator.maybeMarkEOBCompleteForBootstrapDatastreams(assignment,
+        Arrays.asList(completeGroup, runningGroup));
+
+    Assert.assertEquals(dsComplete.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE), "true");
+    Assert.assertNull(dsRunning.getMetadata().get(DatastreamMetadataConstants.IS_EOB_COMPLETE));
+    Assert.assertEquals(stubAdapter.updatedDatastreams.size(), 1);
+    Assert.assertEquals(stubAdapter.updatedDatastreams.get(0), dsComplete);
+  }
+
+  private static Coordinator buildCoordinatorWithStubAdapter(EobTestZkAdapter stubAdapter,
+      String connectorNamesFilter) throws Exception {
+    Properties props = new Properties();
+    props.put(CoordinatorConfig.CONFIG_CLUSTER, "testEOBCluster");
+    props.put(CoordinatorConfig.CONFIG_ZK_ADDRESS, "localhost:2181");
+    props.put(CoordinatorConfig.CONFIG_ZK_SESSION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_SESSION_TIMEOUT));
+    props.put(CoordinatorConfig.CONFIG_ZK_CONNECTION_TIMEOUT, String.valueOf(ZkClient.DEFAULT_CONNECTION_TIMEOUT));
+    if (!connectorNamesFilter.isEmpty()) {
+      props.put(CoordinatorConfig.CONFIG_EOB_CHECK_CONNECTOR_NAMES, connectorNamesFilter);
+    }
+
+    Constructor<Coordinator> ctor = Coordinator.class.getDeclaredConstructor(CachedDatastreamReader.class,
+        Properties.class);
+    ctor.setAccessible(true);
+    // Pass null for CachedDatastreamReader — not used by maybeMarkEOBCompleteForBootstrapDatastreams.
+    Coordinator coordinator = ctor.newInstance(null, props);
+    Field adapterField = Coordinator.class.getDeclaredField("_adapter");
+    adapterField.setAccessible(true);
+    adapterField.set(coordinator, stubAdapter);
+    return coordinator;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -85,6 +85,7 @@ import com.linkedin.datastream.server.providers.ZookeeperCheckpointProvider;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 
 import static com.linkedin.datastream.common.DatastreamMetadataConstants.CREATION_MS;
+import static com.linkedin.datastream.common.DatastreamMetadataConstants.IS_EOB_COMPLETE;
 import static com.linkedin.datastream.common.DatastreamMetadataConstants.SYSTEM_DESTINATION_PREFIX;
 import static com.linkedin.datastream.common.DatastreamMetadataConstants.THROUGHPUT_VIOLATING_TOPICS;
 import static com.linkedin.datastream.common.DatastreamMetadataConstants.TTL_MS;
@@ -207,6 +208,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   // where no events can be handled if coordinator locks up. This can happen because
   // handleEvent is synchronized and downstream code can misbehave.
   private final Duration _heartbeatPeriod;
+  private final Duration _eobCheckPeriod;
+  private final Set<String> _eobCheckConnectorNames;
 
   private final Logger _log = LoggerFactory.getLogger(Coordinator.class.getName());
 
@@ -259,6 +262,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     _config = config;
     _clusterName = _config.getCluster();
     _heartbeatPeriod = Duration.ofMillis(config.getHeartbeatPeriodMs());
+    _eobCheckPeriod = Duration.ofMillis(config.getEobCheckPeriodMs());
+    _eobCheckConnectorNames = config.getEobCheckConnectorNames();
 
     _adapter = createZkAdapter();
     _eventQueue = new CoordinatorEventBlockingQueue(Coordinator.class.getSimpleName());
@@ -324,6 +329,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     // Queue up one heartbeat per period with a initial delay of 3 periods
     _scheduledExecutor.scheduleAtFixedRate(() -> _eventQueue.put(CoordinatorEvent.HEARTBEAT_EVENT),
         _heartbeatPeriod.toMillis() * 3, _heartbeatPeriod.toMillis(), TimeUnit.MILLISECONDS);
+
+    // Periodically check whether all tasks for any bootstrap datastream have completed EOB and
+    // stamp system.isEOBComplete=true if so. Runs only on the leader — non-leaders skip cheaply.
+    _scheduledExecutor.scheduleAtFixedRate(this::periodicEobCheck,
+        _eobCheckPeriod.toMillis(), _eobCheckPeriod.toMillis(), TimeUnit.MILLISECONDS);
   }
 
   protected synchronized void createEventThread() {
@@ -1498,6 +1508,94 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         .collect(Collectors.toList());
   }
 
+  /**
+   * Periodic background check scheduled on all instances. Only the leader does real work — all
+   * others return immediately. Reads the full task assignment from ZooKeeper and delegates to
+   * {@link #maybeMarkEOBCompleteForBootstrapDatastreams}.
+   */
+  @VisibleForTesting
+  void periodicEobCheck() {
+    if (!_adapter.isLeader()) {
+      return;
+    }
+    try {
+      Map<String, Set<DatastreamTask>> assignment = _adapter.getAllAssignedDatastreamTasks();
+      List<DatastreamGroup> datastreamGroups = fetchDatastreamGroups();
+      maybeMarkEOBCompleteForBootstrapDatastreams(assignment, datastreamGroups);
+    } catch (Exception e) {
+      _log.warn("periodicEobCheck: unexpected error, will retry on next cycle.", e);
+    }
+  }
+
+  /**
+   * For each bootstrap {@link DatastreamGroup}, check whether all currently-assigned tasks across
+   * all instances have reached {@link DatastreamTaskStatus.Code#COMPLETE}. If so, and the
+   * {@link DatastreamMetadataConstants#IS_EOB_COMPLETE} flag is not yet set, persist it on every
+   * datastream in the group (covering deduped streams that share the same task prefix).
+   *
+   * <p>A datastream group is considered a bootstrap group when its name contains {@code "bst-"}.
+   * This check runs on the leader only, inside {@link #handleLeaderDoAssignment}, so it has a
+   * consistent view of the full cluster assignment.
+   */
+  @VisibleForTesting
+  void maybeMarkEOBCompleteForBootstrapDatastreams(Map<String, Set<DatastreamTask>> assignmentByInstance,
+      List<DatastreamGroup> datastreamGroups) {
+
+    // Flatten all tasks across all instances, grouped by task prefix.
+    Map<String, List<DatastreamTask>> tasksByPrefix = assignmentByInstance.values()
+        .stream()
+        .flatMap(Set::stream)
+        .collect(Collectors.groupingBy(DatastreamTask::getTaskPrefix));
+
+    for (DatastreamGroup group : datastreamGroups) {
+      Datastream representative = group.getDatastreams().get(0);
+
+      // Bootstrap datastreams are identified by the "bst-" prefix in their name.
+      if (!representative.getName().contains("bst-")) {
+        continue;
+      }
+
+      // If a connector allowlist is configured, skip connectors not in the list.
+      if (!_eobCheckConnectorNames.isEmpty()
+          && !_eobCheckConnectorNames.contains(representative.getConnectorName())) {
+        continue;
+      }
+
+      // Skip if already marked complete.
+      if ("true".equals(representative.getMetadata().get(IS_EOB_COMPLETE))) {
+        continue;
+      }
+
+      String taskPrefix = DatastreamUtils.getTaskPrefix(representative);
+      List<DatastreamTask> tasks = tasksByPrefix.get(taskPrefix);
+
+      // No tasks assigned yet — bootstrap hasn't started.
+      if (tasks == null || tasks.isEmpty()) {
+        continue;
+      }
+
+      boolean allComplete = tasks.stream()
+          .allMatch(t -> t.getStatus() != null
+              && DatastreamTaskStatus.Code.COMPLETE.equals(t.getStatus().getCode()));
+
+      if (!allComplete) {
+        continue;
+      }
+
+      _log.info("All {} task(s) for bootstrap datastream group {} are COMPLETE. Marking {} = true.",
+          tasks.size(), group.getTaskPrefix(), IS_EOB_COMPLETE);
+
+      // Update every datastream in the group (covers deduped streams sharing the same task prefix).
+      for (Datastream ds : group.getDatastreams()) {
+        ds.getMetadata().put(IS_EOB_COMPLETE, "true");
+        if (!_adapter.updateDatastream(ds)) {
+          _log.warn("Failed to persist {} = true for datastream {}. Will retry on next assignment cycle.",
+              IS_EOB_COMPLETE, ds.getName());
+        }
+      }
+    }
+  }
+
   /*
    * If isNewlyElectedLeader is set to true, it cleans up the orphan connector tasks not assigned to
    * any instance after old unused tasks are cleaned up.
@@ -1527,6 +1625,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
       // Map between instance to tasks assigned to the instance.
       previousAssignmentByInstance = _adapter.getAllAssignedDatastreamTasks();
+
+      // Mark EOB complete on bootstrap datastreams where all tasks have finished.
+      maybeMarkEOBCompleteForBootstrapDatastreams(previousAssignmentByInstance, datastreamGroups);
 
       // Map between Instance and the tasks
       newAssignmentsByInstance = performAssignment(liveInstances, previousAssignmentByInstance, datastreamGroups);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -6,7 +6,11 @@
 package com.linkedin.datastream.server;
 
 import java.time.Duration;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
 import java.util.Properties;
+import java.util.Set;
 
 import com.linkedin.datastream.common.VerifiableProperties;
 import com.linkedin.datastream.common.zk.ZkClient;
@@ -48,8 +52,13 @@ public final class CoordinatorConfig {
 
   public static final String CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING = PREFIX + "enableThroughputViolatingTopicsHandling";
   public static final String CONFIG_LOG_SIZE_LIMIT_IN_BYTES = PREFIX + "logSizeLimitInBytes";
+  // how often the leader checks whether all tasks for a bootstrap datastream have completed EOB
+  public static final String CONFIG_EOB_CHECK_PERIOD_MS = PREFIX + "eobCheckPeriodMs";
+  // comma-separated connector names for which EOB completion should be checked; empty means all connectors
+  public static final String CONFIG_EOB_CHECK_CONNECTOR_NAMES = PREFIX + "eobCheckConnectorNames";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
+  public static final long DEFAULT_EOB_CHECK_PERIOD_MS = Duration.ofMinutes(1).toMillis();
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
   public static final long DEFAULT_TASK_STOP_CHECK_TIMEOUT_MS = 60 * 1000;
   public static final long DEFAULT_TASK_STOP_CHECK_RETRY_PERIOD_MS = 10 * 1000;
@@ -82,6 +91,8 @@ public final class CoordinatorConfig {
   private final long _markDatastreamsStoppedRetryPeriodMs;
   private final boolean _enableThroughputViolatingTopicsHandling;
   private final double _logSizeLimitInBytes;
+  private final long _eobCheckPeriodMs;
+  private final Set<String> _eobCheckConnectorNames;
 
 
   /**
@@ -121,6 +132,10 @@ public final class CoordinatorConfig {
     _enableThroughputViolatingTopicsHandling = _properties.getBoolean(
         CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, false);
     _logSizeLimitInBytes = _properties.getDouble(CONFIG_LOG_SIZE_LIMIT_IN_BYTES, DEFAULT_LOG_SIZE_LIMIT_IN_BYTES);
+    _eobCheckPeriodMs = _properties.getLong(CONFIG_EOB_CHECK_PERIOD_MS, DEFAULT_EOB_CHECK_PERIOD_MS);
+    String connectorNamesRaw = _properties.getString(CONFIG_EOB_CHECK_CONNECTOR_NAMES, "").trim();
+    _eobCheckConnectorNames = connectorNamesRaw.isEmpty() ? Collections.emptySet()
+        : new HashSet<>(Arrays.asList(connectorNamesRaw.split("\\s*,\\s*")));
   }
 
   public Properties getConfigProperties() {
@@ -219,5 +234,17 @@ public final class CoordinatorConfig {
 
   public double getLogSizeLimitInBytes() {
     return _logSizeLimitInBytes;
+  }
+
+  public long getEobCheckPeriodMs() {
+    return _eobCheckPeriodMs;
+  }
+
+  /**
+   * Returns the set of connector names for which EOB completion should be checked.
+   * An empty set means all connectors are eligible.
+   */
+  public Set<String> getEobCheckConnectorNames() {
+    return _eobCheckConnectorNames;
   }
 }


### PR DESCRIPTION
## Summary
- Added `periodicEobCheck` scheduled task in `Coordinator` that runs on the leader and checks whether all tasks for bootstrap datastreams have reached `COMPLETE` status
- Added `maybeMarkEOBCompleteForBootstrapDatastreams` which stamps `system.isEOBComplete=true` on all datastreams in the group (including deduped streams) when all tasks are complete
- Added `IS_EOB_COMPLETE` constant to `DatastreamMetadataConstants`
- Added `eobCheckPeriodMs` and `eobCheckConnectorNames` config to `CoordinatorConfig` with defaults (1 min period, all connectors)
- Added unit tests covering happy path, edge cases (no tasks, null status, update failure, multiple groups, connector allowlist, non-leader)


## Testing Done
- [x] Unit tests added for all edge cases in `TestCoordinator`
- [ ] Integration tests pass
- [ ] Manual testing performed