### PR TITLE
Fix CDC+BST grace period test broken by isCdcBstSource narrowing

### DIFF
--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestEventProducer.java
@@ -353,13 +353,14 @@ public class TestEventProducer {
 
   @Test
   public void testCommitToAckMetricRedirectedToSlaIneligibleDuringGracePeriod() {
-    // CDC source + freshly created stream → grace gate engaged. Commit-to-ack histogram should redirect
+    // CDC+BST source + freshly created stream → grace gate engaged. Commit-to-ack histogram should redirect
     // to the SLA-ineligible variant and both within/outside counters should remain suppressed —
     // same suppression semantics as the existing eventsLatencyMs path.
     Datastream datastream = DatastreamTestUtils.createDatastreams(DummyConnector.CONNECTOR_TYPE, "ds-cdc-commit-grace")[0];
     datastream.getSource().setConnectionString("mysql:/myhost/testDatabase/myTable");
     datastream.getMetadata().put(DatastreamMetadataConstants.CREATION_MS,
         String.valueOf(System.currentTimeMillis()));
+    datastream.getMetadata().put(DatastreamMetadataConstants.CDC_BOOTSTRAP_REQUIRED_KEY, "true");
 
     Properties props = new Properties();
     props.put("newStreamGracePeriodMs", "7200000");


### PR DESCRIPTION
## Summary
- Add missing cdcBootstrapRequired=true flag to testCommitToAckMetricRedirectedToSlaIneligibleDuringGracePeriod
- Test was written when isCdcSource() returned true for any single-slash URI
- After narrowing to isCdcBstSource() (requires cdcBootstrapRequired=true), grace gate no longer engages without the flag causing build failure


## Testing Done
- [x] All 41 TestEventProducer tests pass locally"