### PR TITLE
ci: declare minimum token permissions for build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds `permissions: contents: read` to the Build workflow.

The workflow checks out the repository and runs a build script. It does not interact with the GitHub API in any way that requires write access, so scoping the token to read-only follows the principle of least privilege.

This reduces the blast radius if a compromised dependency or action tries to use the token for unauthorized operations.