### PR TITLE
Fix flaky TestCoordinator.testLeaderDoAssignmentForNewlyElectedLeaderFailurePathVariation

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -4220,7 +4220,15 @@ public class TestCoordinator {
               protected synchronized void handleEvent(CoordinatorEvent event) {
                 CoordinatorEvent previousHead = peekCoordinatorEventBlockingQueue();
                 super.handleEvent(event);
-                PollUtils.poll(() -> peekCoordinatorEventBlockingQueue() != null, 50, 1000);
+                // On failure the LEADER_DO_ASSIGNMENT retry is re-queued asynchronously by
+                // scheduleLeaderDoAssignmentRetry() on a separate executor thread, so it may not be
+                // at the front of the queue the instant handleEvent() returns. Wait for the retry
+                // event to actually reach the front rather than merely waiting for the queue to be
+                // non-empty -- otherwise nextHead races with the async putFirst() and can observe an
+                // unrelated event (e.g. HANDLE_ASSIGNMENT_CHANGE), making this test flaky.
+                PollUtils.poll(
+                    () -> leaderDoAssignmentForNewlyElectedLeader.equals(peekCoordinatorEventBlockingQueue()),
+                    50, 1000);
                 CoordinatorEvent nextHead = peekCoordinatorEventBlockingQueue();
 
                 // recording previous and new heads of the CoordinatorEventBlockingQueue


### PR DESCRIPTION
## Summary
The test verifies that when a newly-elected leader's LEADER_DO_ASSIGNMENT handler fails during pre-assignment cleanup, the same event is re-queued to the front of the coordinator event queue for an immediate retry. It does so by overriding handleEvent() to record the head of the queue before and after each handled event.
The retry, however, is enqueued asynchronously: scheduleLeaderDoAssignmentRetry() submits the putFirst(LEADER_DO_ASSIGNMENT) to a scheduled executor (0 ms delay) on a separate thread, so the event is not guaranteed to be at the front of the queue the instant super.handleEvent() returns. The override waited only for the queue to be non-empty before sampling the head, so it raced the asynchronous putFirst() and occasionally observed an unrelated event that was already enqueued (e.g. HANDLE_ASSIGNMENT_CHANGE), failing with:
expected [type:LEADER_DO_ASSIGNMENT] but found [type:HANDLE_ASSIGNMENT_CHANGE] The race reproduces locally in isolation at roughly a 1-in-8 rate and surfaces more often under CI load.
Fix: wait for the retry event to actually reach the front of the queue (rather than merely waiting for the queue to be non-empty) before sampling the head. This is deterministic and preserves the test's intent -- if the retry is genuinely not re-queued, the poll times out and the assertion still fails. Verified by running the test 25 times with zero failures (previously ~12% flaky).

## Testing Done
Build passes