### PR TITLE
Address security-scan findings from CodeQL java-security-extended suite and the Semgrep/CodeQL findings

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/AvroMessageEncoderUtil.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/AvroMessageEncoderUtil.java
@@ -97,6 +97,11 @@ public class AvroMessageEncoderUtil {
 
   private static byte[] md5(byte[] bytes) {
     try {
+      // MD5 here is a non-cryptographic fingerprint embedded in the encoded message envelope (the
+      // schema-id hash prepended to the payload), not a security signature. Changing the algorithm
+      // would alter the on-wire format and break decoding of previously encoded data, so it must
+      // remain MD5 for wire compatibility. The Semgrep use-of-md5 finding is not applicable here.
+      // nosemgrep: java.lang.security.audit.crypto.use-of-md5.use-of-md5
       MessageDigest digest = MessageDigest.getInstance("md5");
       return digest.digest(bytes);
     } catch (NoSuchAlgorithmException e) {

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/GroupIdConstructor.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/GroupIdConstructor.java
@@ -130,6 +130,12 @@ public interface GroupIdConstructor {
    */
   default String hashGroupId(String groupId) {
     try {
+      // MD5 here is a non-cryptographic identity hash used to derive a stable, compact Kafka
+      // consumer group.id (clusterName + "." + hashGroupId(taskPrefix)), not a security signature.
+      // Changing the algorithm would change every existing consumer group's id and reset committed
+      // offsets, so it must remain MD5 for offset compatibility. The Semgrep use-of-md5 finding is
+      // not applicable to this non-cryptographic use.
+      // nosemgrep: java.lang.security.audit.crypto.use-of-md5.use-of-md5
       MessageDigest digest = MessageDigest.getInstance("MD5");
       byte[] hashedBytes = digest.digest(groupId.getBytes(StandardCharsets.UTF_8));
       return DatatypeConverter.printHexBinary(hashedBytes).toLowerCase();

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestAssignmentTaskMapLogger.java
@@ -138,7 +138,10 @@ public class TestAssignmentTaskMapLogger {
    */
   private String createCustomSizeString(double size) {
     StringBuilder sb = new StringBuilder();
-    for (int i = 0; i < size; i++) {
+    // Convert the (double) target size to an int up front; comparing the int loop counter directly
+    // against a double widens the counter on every iteration and can lose precision for large sizes.
+    int length = (int) size;
+    for (int i = 0; i < length; i++) {
       sb.append('A');
     }
     return sb.toString();

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
@@ -7,7 +7,8 @@ package com.linkedin.datastream.common;
 
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.util.Random;
+import java.io.IOException;
+import java.nio.file.Files;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -17,8 +18,6 @@ import org.slf4j.LoggerFactory;
  * Class that contains the helper utility methods for File system operations.
  */
 public class FileUtils {
-
-  private static final Random RANDOM = new Random();
 
   private static final Logger LOG = LoggerFactory.getLogger(FileUtils.class.getName());
 
@@ -31,14 +30,19 @@ public class FileUtils {
    *   Object referencing the directory that is created.
    */
   public static File constructRandomDirectoryInTempDir(String dirPrefix) {
-    File file = new File(System.getProperty("java.io.tmpdir"), dirPrefix + RANDOM.nextInt(10000000));
-    if (!file.mkdirs()) {
-      String errorMessage = "could not create temp directory: " + file.getAbsolutePath();
-      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, null);
+    try {
+      // Files.createTempDirectory atomically creates the directory with owner-only permissions
+      // (0700 on POSIX), avoiding the local information-disclosure risk (CWE-379) of a predictably
+      // named, world-readable directory under the shared system temp dir. The prefix may not
+      // contain path separators, so flatten them.
+      File file = Files.createTempDirectory(dirPrefix.replace('/', '-') + '-').toFile();
+      file.deleteOnExit();
+      return file;
+    } catch (IOException e) {
+      String errorMessage = "could not create temp directory with prefix: " + dirPrefix;
+      ErrorLogger.logAndThrowDatastreamRuntimeException(LOG, errorMessage, e);
+      throw new IllegalStateException(errorMessage, e); // unreachable: logAndThrow always throws
     }
-
-    file.deleteOnExit();
-    return file;
   }
 
   /**

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
@@ -19,6 +19,11 @@ public class NetworkUtils {
    */
   public synchronized static int getAvailablePort() {
     try {
+      // This ServerSocket is bound to an ephemeral port (port 0) solely to discover a free port
+      // number and is closed immediately via try-with-resources; no data is ever transmitted over
+      // it, so transport encryption does not apply. The Semgrep unencrypted-socket rule is a false
+      // positive for this port-discovery idiom.
+      // nosemgrep: java.lang.security.audit.crypto.unencrypted-socket.unencrypted-socket
       try (ServerSocket socket = new ServerSocket(0)) {
         socket.setReuseAddress(true);
         return socket.getLocalPort();


### PR DESCRIPTION

## Summary
Reviewed OSS Brooklin against the CodeQL java-security-extended suite and the Semgrep/CodeQL findings.
Fixes the genuine, low-risk issues with code changes and documents/suppresses the false-positive and compatibility-bound findings with justifications in code. Fixed:
- FileUtils.constructRandomDirectoryInTempDir created a predictably named directory under the shared system temp dir via new File(java.io.tmpdir, prefix + random) + mkdirs(), which is world-readable and racy (CWE-379, local information disclosure). Replaced with Files.createTempDirectory(), which atomically creates the directory with owner-only permissions. Callers (EmbeddedZookeeper, EmbeddedKafkaCluster) only use the returned path, so behavior is preserved; the now-unused Random field/import is removed.
- TestAssignmentTaskMapLogger.createCustomSizeString compared an int loop counter directly against a double bound (java/comparison-with-wider-type); the target size is now converted to int. Documented / suppressed with justification (false positive or compatibility-bound):
- NetworkUtils.getAvailablePort (Semgrep unencrypted-socket): the ServerSocket is bound to an ephemeral port only to discover a free port number and is closed immediately; no data is ever transmitted, so transport encryption does not apply. False positive.
- GroupIdConstructor.hashGroupId and AvroMessageEncoderUtil.md5 (Semgrep use-of-md5, java/potentially-weak-cryptographic-algorithm): MD5 is used as a non-cryptographic identity hash, not a security signature. The group-id hash determines the live Kafka consumer group.id and the schema-id hash is embedded in the on-wire message envelope; changing the algorithm would reset consumer offsets and break decoding of existing data. Must remain MD5 for compatibility. Each suppressed site carries an explanatory comment and a // nosemgrep directive so the rationale travels with the code (and the brooklin-server in-tree port stays clean). Verified on JDK 8: TestAssignmentTaskMapLogger and TestZkClient (which exercises the changed FileUtils via EmbeddedZookeeper) pass; checkstyle passes for the touched modules.

## Testing Done
Build passes