### PR TITLE
Add generic DatastreamLifecycleListener extension point for DMS lifecycle events

### DIFF
--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/lifecycle/DatastreamLifecycleEventType.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/lifecycle/DatastreamLifecycleEventType.java
@@ -1,0 +1,25 @@
+/**
+ *  Copyright 2024 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server.api.lifecycle;
+
+/**
+ * The set of datastream lifecycle transitions surfaced to a {@link DatastreamLifecycleListener}. Each value
+ * corresponds to a mutating operation exposed by the Datastream Management Service (DMS) REST layer.
+ */
+public enum DatastreamLifecycleEventType {
+  /** A new datastream was created. */
+  CREATE,
+  /** An existing datastream definition was updated. */
+  UPDATE,
+  /** A datastream was deleted (status moved to {@code DELETING}). */
+  DELETE,
+  /** A datastream was paused (status moved to {@code PAUSED}). */
+  PAUSE,
+  /** A datastream was resumed (status moved back to {@code READY}). */
+  RESUME,
+  /** A datastream was stopped (status moved to {@code STOPPED}). */
+  STOP
+}

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/lifecycle/DatastreamLifecycleListener.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/api/lifecycle/DatastreamLifecycleListener.java
@@ -1,0 +1,34 @@
+/**
+ *  Copyright 2024 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server.api.lifecycle;
+
+import com.linkedin.datastream.common.Datastream;
+
+/**
+ * Optional observability extension point notified of datastream lifecycle transitions driven through the
+ * Datastream Management Service (DMS) REST layer: creation, update, deletion, and pause/resume/stop status
+ * changes.
+ *
+ * <p>Implementations are typically used to emit an audit/event stream (for example to a metrics or events
+ * pipeline). The DMS invokes the listener on a best-effort basis <em>after</em> the corresponding change has
+ * been persisted. Implementations therefore:
+ * <ul>
+ *   <li>must be non-blocking (offload any I/O to their own executor), and</li>
+ *   <li>must not throw — the DMS guards against listener failures, but a listener should never assume its
+ *       failure will affect, or be affected by, the outcome of the REST request.</li>
+ * </ul>
+ *
+ * <p>The default behaviour when no listener is configured is a no-op.
+ */
+public interface DatastreamLifecycleListener {
+  /**
+   * Invoked after a datastream lifecycle transition has been persisted.
+   *
+   * @param eventType the type of lifecycle transition
+   * @param datastream the affected datastream, reflecting its post-transition state
+   */
+  void onDatastreamLifecycleEvent(DatastreamLifecycleEventType eventType, Datastream datastream);
+}

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -50,6 +50,7 @@ import com.linkedin.datastream.server.DatastreamServer;
 import com.linkedin.datastream.server.ErrorLogger;
 import com.linkedin.datastream.server.HostTargetAssignment;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+import com.linkedin.datastream.server.api.lifecycle.DatastreamLifecycleEventType;
 import com.linkedin.datastream.server.api.security.AuthorizationException;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.ActionResult;
@@ -323,6 +324,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
         // invoke post datastream state change action for recently updated datastream
         invokePostDSStateChangeAction(datastreamMap.get(key));
+        notifyDatastreamLifecycle(DatastreamLifecycleEventType.UPDATE, datastreamMap.get(key));
       }
       _coordinator.broadcastDatastreamUpdate();
     } catch (DatastreamException e) {
@@ -381,6 +383,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           _store.updateDatastream(d.getName(), d, true);
           // invoke post datastream state change action for recently paused datastream
           invokePostDSStateChangeAction(d);
+          notifyDatastreamLifecycle(DatastreamLifecycleEventType.PAUSE, d);
         } else {
           LOG.warn("Cannot pause datastream {}, as it is not in READY state. State: {}", d, datastream.getStatus());
         }
@@ -536,6 +539,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       // set the status as STOPPED as the original status would be READY, PAUSED or STOPPING
       ds.setStatus(DatastreamStatus.STOPPED);
       invokePostDSStateChangeAction(ds);
+      notifyDatastreamLifecycle(DatastreamLifecycleEventType.STOP, ds);
     });
 
     return new ActionResult<>(HttpStatus.S_200_OK);
@@ -577,6 +581,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           _store.updateDatastream(d.getName(), d, true);
           // invoke post datastream state change action for recently resumed datastream
           invokePostDSStateChangeAction(d);
+          notifyDatastreamLifecycle(DatastreamLifecycleEventType.RESUME, d);
         } else {
           LOG.warn("Will not resume datastream {}, as it is not already in PAUSED/STOPPED state", d);
         }
@@ -780,6 +785,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
       // original Datastream instance then invoke post datastream state change action for recently deleted datastream
       datastream.setStatus(DatastreamStatus.DELETING);
       invokePostDSStateChangeAction(datastream);
+      notifyDatastreamLifecycle(DatastreamLifecycleEventType.DELETE, datastream);
 
       return new UpdateResponse(HttpStatus.S_200_OK);
     } catch (Exception e) {
@@ -962,6 +968,7 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
 
       // invoke post datastream state change action for recently created datastream
       invokePostDSStateChangeAction(datastream);
+      notifyDatastreamLifecycle(DatastreamLifecycleEventType.CREATE, datastream);
 
       return new CreateResponse(datastream.getName(), HttpStatus.S_201_CREATED);
     } catch (IllegalArgumentException e) {
@@ -998,6 +1005,20 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
     } catch (DatastreamException e) {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_500_INTERNAL_SERVER_ERROR,
           "Failed to perform post datastream state change action datastream=" + datastream, e);
+    }
+  }
+
+  /**
+   * Best-effort notification of the configured {@link com.linkedin.datastream.server.api.lifecycle.DatastreamLifecycleListener}
+   * after a datastream lifecycle transition has been persisted. Listener failures are swallowed and never
+   * affect the outcome of the REST request.
+   */
+  private void notifyDatastreamLifecycle(DatastreamLifecycleEventType eventType, Datastream datastream) {
+    try {
+      _coordinator.getDatastreamLifecycleListener().onDatastreamLifecycleEvent(eventType, datastream);
+    } catch (Exception e) {
+      LOG.warn("Datastream lifecycle listener failed for eventType={} datastream={}", eventType,
+          datastream == null ? null : datastream.getName(), e);
     }
   }
 

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -6,6 +6,8 @@
 package com.linkedin.datastream.server.dms;
 
 import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -46,6 +48,7 @@ import com.linkedin.datastream.server.DatastreamTask;
 import com.linkedin.datastream.server.DummyTransportProviderAdminFactory;
 import com.linkedin.datastream.server.EmbeddedDatastreamCluster;
 import com.linkedin.datastream.server.TestDatastreamServer;
+import com.linkedin.datastream.server.api.lifecycle.DatastreamLifecycleEventType;
 import com.linkedin.restli.common.HttpStatus;
 import com.linkedin.restli.server.ActionResult;
 import com.linkedin.restli.server.BatchUpdateRequest;
@@ -283,6 +286,80 @@ public class TestDatastreamResources {
     Assert.assertEquals(ds.getStatus(), DatastreamStatus.STOPPED);
     // postDatastreamStateChangeAction should be invoked for status STOPPING and STOPPED
     Assert.assertEquals(connector.getPostDSStatechangeActionInvokeCount(), 3);
+  }
+
+  @Test
+  public void testDatastreamLifecycleListenerNotifiedForAllTransitions() {
+    DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+    Coordinator coordinator = _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator();
+
+    // Record (eventType, datastreamName) pairs as the REST verbs fire the listener synchronously.
+    List<String> recorded = Collections.synchronizedList(new ArrayList<>());
+    coordinator.setDatastreamLifecycleListener((eventType, datastream) ->
+        recorded.add(eventType + ":" + datastream.getName()));
+
+    Datastream datastreamToCreate = generateDatastream(0);
+    String datastreamName = datastreamToCreate.getName();
+    datastreamToCreate.setDestination(new DatastreamDestination());
+    Objects.requireNonNull(datastreamToCreate.getDestination())
+        .setConnectionString("kafka://" + _datastreamKafkaCluster.getZkConnection() + "/testDestination");
+    datastreamToCreate.getDestination().setPartitions(1);
+
+    // CREATE
+    Assert.assertNull(resource.create(datastreamToCreate).getError());
+    PollUtils.poll(() -> resource.get(datastreamName).getStatus() == DatastreamStatus.READY, 100, 10000);
+
+    PathKeys pathKey = Mockito.mock(PathKeys.class);
+    Mockito.when(pathKey.getAsString(DatastreamResources.KEY_NAME)).thenReturn(datastreamName);
+
+    // PAUSE -> RESUME -> STOP -> DELETE
+    Assert.assertEquals(resource.pause(pathKey, false).getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(resource.resume(pathKey, false).getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(resource.stop(pathKey, false).getStatus(), HttpStatus.S_200_OK);
+    Assert.assertEquals(resource.delete(datastreamName).getStatus(), HttpStatus.S_200_OK);
+
+    // Exactly one lifecycle event per verb, in order, all for this datastream. STOP fires once (on the
+    // confirmed STOPPED transition), not for the intermediate STOPPING transition.
+    Assert.assertEquals(recorded, Arrays.asList(
+        DatastreamLifecycleEventType.CREATE + ":" + datastreamName,
+        DatastreamLifecycleEventType.PAUSE + ":" + datastreamName,
+        DatastreamLifecycleEventType.RESUME + ":" + datastreamName,
+        DatastreamLifecycleEventType.STOP + ":" + datastreamName,
+        DatastreamLifecycleEventType.DELETE + ":" + datastreamName));
+  }
+
+  @Test
+  public void testDatastreamLifecycleListenerFailureDoesNotBreakRequest() {
+    DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+    Coordinator coordinator = _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator();
+
+    // A listener that always throws must never affect the outcome of the REST request.
+    coordinator.setDatastreamLifecycleListener((eventType, datastream) -> {
+      throw new RuntimeException("boom");
+    });
+
+    Datastream datastreamToCreate = generateDatastream(0);
+    String datastreamName = datastreamToCreate.getName();
+    datastreamToCreate.setDestination(new DatastreamDestination());
+    Objects.requireNonNull(datastreamToCreate.getDestination())
+        .setConnectionString("kafka://" + _datastreamKafkaCluster.getZkConnection() + "/testDestination");
+    datastreamToCreate.getDestination().setPartitions(1);
+
+    CreateResponse response = resource.create(datastreamToCreate);
+    Assert.assertNull(response.getError());
+    Assert.assertEquals(response.getStatus(), HttpStatus.S_201_CREATED);
+    Assert.assertEquals(resource.delete(datastreamName).getStatus(), HttpStatus.S_200_OK);
+  }
+
+  @Test
+  public void testDefaultDatastreamLifecycleListenerIsNonNullNoOp() {
+    Coordinator coordinator = _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator();
+    Assert.assertNotNull(coordinator.getDatastreamLifecycleListener());
+    // No-op default tolerates invocation and a null reset (which restores the no-op).
+    coordinator.getDatastreamLifecycleListener()
+        .onDatastreamLifecycleEvent(DatastreamLifecycleEventType.CREATE, generateDatastream(0));
+    coordinator.setDatastreamLifecycleListener(null);
+    Assert.assertNotNull(coordinator.getDatastreamLifecycleListener());
   }
 
   @Test

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/dms/TestDatastreamResources.java
@@ -363,6 +363,26 @@ public class TestDatastreamResources {
   }
 
   @Test
+  public void testDatastreamLifecycleListenerNotifiedForUpdate() {
+    DatastreamResources resource = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
+    Coordinator coordinator = _datastreamKafkaCluster.getPrimaryDatastreamServer().getCoordinator();
+
+    // Create the datastream first, then register the listener so only the UPDATE event is recorded.
+    Datastream datastream = createAndWaitUntilInitialized(resource, generateDatastream(0));
+    String datastreamName = datastream.getName();
+
+    List<String> recorded = Collections.synchronizedList(new ArrayList<>());
+    coordinator.setDatastreamLifecycleListener((eventType, ds) -> recorded.add(eventType + ":" + ds.getName()));
+
+    // A metadata-only update is permitted by the DummyConnector and drives the UPDATE lifecycle event.
+    datastream.getMetadata().put("key", "value");
+    Assert.assertEquals(resource.update(datastreamName, datastream).getStatus(), HttpStatus.S_200_OK);
+
+    Assert.assertEquals(recorded, Collections.singletonList(
+        DatastreamLifecycleEventType.UPDATE + ":" + datastreamName));
+  }
+
+  @Test
   public void testSimultaneousStopDatastreamRequests() {
     DatastreamResources resource1 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());
     DatastreamResources resource2 = new DatastreamResources(_datastreamKafkaCluster.getPrimaryDatastreamServer());

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -75,6 +75,7 @@ import com.linkedin.datastream.serde.SerDeSet;
 import com.linkedin.datastream.server.api.connector.Connector;
 import com.linkedin.datastream.server.api.connector.DatastreamDeduper;
 import com.linkedin.datastream.server.api.connector.DatastreamValidationException;
+import com.linkedin.datastream.server.api.lifecycle.DatastreamLifecycleListener;
 import com.linkedin.datastream.server.api.security.AuthorizationException;
 import com.linkedin.datastream.server.api.security.Authorizer;
 import com.linkedin.datastream.server.api.serde.SerdeAdmin;
@@ -226,6 +227,11 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
   private final Map<String, SerdeAdmin> _serdeAdmins = new HashMap<>();
   private final Map<String, Authorizer> _authorizers = new HashMap<>();
+
+  // Optional observability listener notified of datastream lifecycle transitions (create/update/delete/
+  // pause/resume/stop). Defaults to a no-op; typically set once during server bootstrap.
+  private volatile DatastreamLifecycleListener _datastreamLifecycleListener = (eventType, datastream) -> { };
+
   private volatile boolean _shutdown = false;
   // TODO we have _shutdown, eventThread and now _coordinatorEventThreadExiting, for some distinct usage,
   //  we should revisit and refactor to have less variation
@@ -474,6 +480,23 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
   public String getInstanceName() {
     return _adapter.getInstanceName();
+  }
+
+  /**
+   * Set the {@link DatastreamLifecycleListener} notified of datastream lifecycle transitions. Optional;
+   * when not set (or set to {@code null}), lifecycle notifications are a no-op. Typically invoked once
+   * during server bootstrap.
+   * @param listener the listener to notify, or {@code null} to disable notifications
+   */
+  public void setDatastreamLifecycleListener(DatastreamLifecycleListener listener) {
+    _datastreamLifecycleListener = listener == null ? (eventType, datastream) -> { } : listener;
+  }
+
+  /**
+   * @return the configured {@link DatastreamLifecycleListener}; never {@code null} (a no-op by default)
+   */
+  public DatastreamLifecycleListener getDatastreamLifecycleListener() {
+    return _datastreamLifecycleListener;
   }
 
   public Collection<DatastreamTask> getDatastreamTasks() {


### PR DESCRIPTION
## Summary
Introduce an optional, best-effort DatastreamLifecycleListener notified after datastream lifecycle transitions are persisted through the DMS REST layer: create, update, delete, and pause/resume/stop status changes.
The listener is held on the Coordinator (default no-op) and invoked from DatastreamResources at a single, well-defined point per REST verb. STOP is emitted once, on the confirmed STOPPED transition, rather than for the intermediate STOPPING transition. Listener invocations are guarded: a listener failure is caught and logged and never affects the outcome of the REST request. This is a generic observability seam with no external dependencies; a downstream service can register an implementation to emit an audit/event stream of datastream lifecycle changes.


## Testing Done
unit test