### PR TITLE
Add stream provisioning SLO metric

### DIFF
--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -52,6 +52,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
@@ -2509,9 +2510,13 @@ public class TestCoordinator {
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
     long histogramCountBefore = histogramBefore == null ? 0L : histogramBefore.getCount();
 
-    Meter meterBefore =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
-    long meterCountBefore = meterBefore == null ? 0L : meterBefore.getCount();
+    Counter totalBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisioned");
+    long totalCountBefore = totalBefore == null ? 0L : totalBefore.getCount();
+
+    Counter outsideSlaBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisionedOutsideSla");
+    long outsideSlaCountBefore = outsideSlaBefore == null ? 0L : outsideSlaBefore.getCount();
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
     DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
@@ -2527,12 +2532,21 @@ public class TestCoordinator {
     long maxValue = histogram.getSnapshot().getMax();
     Assert.assertTrue(maxValue >= 0, "timeToReadyMs sample should be non-negative, got: " + maxValue);
 
-    Meter meter =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
-    Assert.assertNotNull(meter,
-        "Coordinator.slowProvisioningRate meter should be registered after a stream goes READY");
-    Assert.assertTrue(PollUtils.poll(() -> meter.getCount() > meterCountBefore, 100, 30000),
-        "slowProvisioningRate should increment when duration exceeds threshold");
+    // The total provisioned counter must increment for every stream that reaches READY.
+    Counter total =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisioned");
+    Assert.assertNotNull(total,
+        "Coordinator.numStreamsProvisioned counter should be registered after a stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> total.getCount() > totalCountBefore, 100, 30000),
+        "numStreamsProvisioned should increment when a stream goes READY");
+
+    // With a threshold of 0, any positive provisioning duration is classified as outside SLA.
+    Counter outsideSla =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisionedOutsideSla");
+    Assert.assertNotNull(outsideSla,
+        "Coordinator.numStreamsProvisionedOutsideSla counter should be registered after a stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> outsideSla.getCount() > outsideSlaCountBefore, 100, 30000),
+        "numStreamsProvisionedOutsideSla should increment when duration exceeds threshold");
 
     coordinator.stop();
     coordinator.getDatastreamCache().getZkclient().close();
@@ -2541,8 +2555,8 @@ public class TestCoordinator {
 
 
   @Test
-  public void testSlowProvisioningRateDoesNotIncrementWhenBelowThreshold() throws Exception {
-    String testCluster = "testSlowProvisioningRateBelowThreshold";
+  public void testProvisioningSloCountsWithinSlaWhenBelowThreshold() throws Exception {
+    String testCluster = "testProvisioningSloWithinSla";
     String connectorType = "testConnectorType";
     String datastreamName = "TestFastStream";
 
@@ -2556,9 +2570,13 @@ public class TestCoordinator {
         new SourceBasedDeduper(), null);
     coordinator.start();
 
-    Meter meterBefore =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
-    long meterCountBefore = meterBefore == null ? 0L : meterBefore.getCount();
+    Counter withinSlaBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisionedWithinSla");
+    long withinSlaCountBefore = withinSlaBefore == null ? 0L : withinSlaBefore.getCount();
+
+    Counter outsideSlaBefore =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisionedOutsideSla");
+    long outsideSlaCountBefore = outsideSlaBefore == null ? 0L : outsideSlaBefore.getCount();
 
     Histogram histogramBefore =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
@@ -2570,18 +2588,26 @@ public class TestCoordinator {
         DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
 
     // Wait for the histogram to increment - this proves recordTimeToReadyMs has finished
-    // running, which means any meter increment (or non-increment) decision has been made.
+    // running, which means the within/outside SLA classification has been made.
     Histogram histogram =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
     Assert.assertNotNull(histogram, "Histogram should exist after stream goes READY");
     Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, 30000),
         "Histogram count did not increment - recordTimeToReadyMs may not have run yet");
 
-    Meter readyMeter =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
-    if (readyMeter != null) {
-      Assert.assertEquals(readyMeter.getCount(), meterCountBefore,
-          "slowProvisioningRate must not increment when duration is below threshold");
+    // With a 1-hour threshold the provisioning duration is below SLA, so the within-SLA counter
+    // increments and the outside-SLA counter must not.
+    Counter withinSla =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisionedWithinSla");
+    Assert.assertNotNull(withinSla, "numStreamsProvisionedWithinSla counter should exist after stream goes READY");
+    Assert.assertTrue(PollUtils.poll(() -> withinSla.getCount() > withinSlaCountBefore, 100, 30000),
+        "numStreamsProvisionedWithinSla should increment when duration is below threshold");
+
+    Counter outsideSla =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisionedOutsideSla");
+    if (outsideSla != null) {
+      Assert.assertEquals(outsideSla.getCount(), outsideSlaCountBefore,
+          "numStreamsProvisionedOutsideSla must not increment when duration is below threshold");
     }
 
     coordinator.stop();
@@ -2590,8 +2616,8 @@ public class TestCoordinator {
   }
 
   /**
-   * Resuming a datastream STOPPED -> READY must NOT update either the timeToReadyMs histogram or the
-   * slowProvisioningRate meter. Both metrics are intended to capture only the initial creation
+   * Resuming a datastream STOPPED -> READY must NOT update the timeToReadyMs histogram or any of the
+   * provisioning SLO counters. These metrics are intended to capture only the initial creation
    * flow's INITIALIZING -> READY transition.
    */
   @Test
@@ -2600,8 +2626,8 @@ public class TestCoordinator {
     String connectorType = "testConnectorType";
     String datastreamName = "TestResumeStream";
 
-    // Threshold of 0 ensures any positive duration would trigger the meter — so the assertion
-    // that the meter does NOT increase on resume is meaningful (it's not just below-threshold).
+    // Threshold of 0 ensures any positive duration would be classified as outside SLA — so the
+    // assertion that the counters do NOT increase on resume is meaningful (it's not just below-threshold).
     Properties override = new Properties();
     override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS, "0");
 
@@ -2620,11 +2646,15 @@ public class TestCoordinator {
     Histogram histogram =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
     Assert.assertNotNull(histogram, "Histogram should exist after the initial create");
-    Meter meter =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.slowProvisioningRate");
-    Assert.assertNotNull(meter, "Meter should exist after the initial create");
+    Counter total =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisioned");
+    Assert.assertNotNull(total, "numStreamsProvisioned counter should exist after the initial create");
+    Counter outsideSla =
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisionedOutsideSla");
+    Assert.assertNotNull(outsideSla, "numStreamsProvisionedOutsideSla counter should exist after the initial create");
     long histogramCountAfterCreate = histogram.getCount();
-    long meterCountAfterCreate = meter.getCount();
+    long totalCountAfterCreate = total.getCount();
+    long outsideSlaCountAfterCreate = outsideSla.getCount();
 
     // Stop and then resume the datastream. The resume path bypasses the INITIALIZING -> READY
     // transition in handleDatastreamAddOrDelete, so neither metric should change.
@@ -2643,8 +2673,10 @@ public class TestCoordinator {
     Thread.sleep(500);
     Assert.assertEquals(histogram.getCount(), histogramCountAfterCreate,
         "timeToReadyMs histogram count must not increase on resume from STOPPED");
-    Assert.assertEquals(meter.getCount(), meterCountAfterCreate,
-        "slowProvisioningRate meter count must not increase on resume from STOPPED");
+    Assert.assertEquals(total.getCount(), totalCountAfterCreate,
+        "numStreamsProvisioned counter must not increase on resume from STOPPED");
+    Assert.assertEquals(outsideSla.getCount(), outsideSlaCountAfterCreate,
+        "numStreamsProvisionedOutsideSla counter must not increase on resume from STOPPED");
 
     coordinator.stop();
     coordinator.getDatastreamCache().getZkclient().close();

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2492,10 +2492,10 @@ public class TestCoordinator {
   }
 
   @Test
-  public void testTimeToReadyMetricsOnCreate() throws Exception {
-    String testCluster = "testTimeToReadyMetricsOnCreate";
+  public void testStreamProvisioningTimeMetricsOnCreate() throws Exception {
+    String testCluster = "testStreamProvisioningTimeMetricsOnCreate";
     String connectorType = "testConnectorType";
-    String datastreamName = "TestTimeToReadyStream";
+    String datastreamName = "TestStreamProvisioningStream";
 
     Properties override = new Properties();
     override.put(CoordinatorConfig.CONFIG_PROVISIONING_SLA_THRESHOLD_MS, "0");
@@ -2507,7 +2507,7 @@ public class TestCoordinator {
     coordinator.start();
 
     Histogram histogramBefore =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.streamProvisioningTimeMs");
     long histogramCountBefore = histogramBefore == null ? 0L : histogramBefore.getCount();
 
     Counter totalBefore =
@@ -2524,13 +2524,13 @@ public class TestCoordinator {
         DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
 
     Histogram histogram =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.streamProvisioningTimeMs");
     Assert.assertNotNull(histogram,
-        "Coordinator.timeToReadyMs histogram should be registered after a stream goes READY");
+        "Coordinator.streamProvisioningTimeMs histogram should be registered after a stream goes READY");
     Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, 30000),
-        "timeToReadyMs histogram count did not increase after stream transitioned to READY");
+        "streamProvisioningTimeMs histogram count did not increase after stream transitioned to READY");
     long maxValue = histogram.getSnapshot().getMax();
-    Assert.assertTrue(maxValue >= 0, "timeToReadyMs sample should be non-negative, got: " + maxValue);
+    Assert.assertTrue(maxValue >= 0, "streamProvisioningTimeMs sample should be non-negative, got: " + maxValue);
 
     // The total provisioned counter must increment for every stream that reaches READY.
     Counter total =
@@ -2579,7 +2579,7 @@ public class TestCoordinator {
     long outsideSlaCountBefore = outsideSlaBefore == null ? 0L : outsideSlaBefore.getCount();
 
     Histogram histogramBefore =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.streamProvisioningTimeMs");
     long histogramCountBefore = histogramBefore == null ? 0L : histogramBefore.getCount();
 
     ZkClient zkClient = new ZkClient(_zkConnectionString);
@@ -2587,13 +2587,13 @@ public class TestCoordinator {
     Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
         DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
 
-    // Wait for the histogram to increment - this proves recordTimeToReadyMs has finished
+    // Wait for the histogram to increment - this proves recordStreamProvisioningTime has finished
     // running, which means the within/outside SLA classification has been made.
     Histogram histogram =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.streamProvisioningTimeMs");
     Assert.assertNotNull(histogram, "Histogram should exist after stream goes READY");
     Assert.assertTrue(PollUtils.poll(() -> histogram.getCount() > histogramCountBefore, 100, 30000),
-        "Histogram count did not increment - recordTimeToReadyMs may not have run yet");
+        "Histogram count did not increment - recordStreamProvisioningTime may not have run yet");
 
     // With a 1-hour threshold the provisioning duration is below SLA, so the within-SLA counter
     // increments and the outside-SLA counter must not.
@@ -2616,13 +2616,13 @@ public class TestCoordinator {
   }
 
   /**
-   * Resuming a datastream STOPPED -> READY must NOT update the timeToReadyMs histogram or any of the
+   * Resuming a datastream STOPPED -> READY must NOT update the streamProvisioningTimeMs histogram or any of the
    * provisioning SLO counters. These metrics are intended to capture only the initial creation
    * flow's INITIALIZING -> READY transition.
    */
   @Test
-  public void testTimeToReadyMetricsNotEmittedOnResume() throws Exception {
-    String testCluster = "testTimeToReadyMetricsNotEmittedOnResume";
+  public void testStreamProvisioningTimeMetricsNotEmittedOnResume() throws Exception {
+    String testCluster = "testStreamProvisioningTimeMetricsNotEmittedOnResume";
     String connectorType = "testConnectorType";
     String datastreamName = "TestResumeStream";
 
@@ -2644,7 +2644,7 @@ public class TestCoordinator {
 
     // Capture counts after the initial creation has settled.
     Histogram histogram =
-        DynamicMetricsManager.getInstance().getMetric("Coordinator.timeToReadyMs");
+        DynamicMetricsManager.getInstance().getMetric("Coordinator.streamProvisioningTimeMs");
     Assert.assertNotNull(histogram, "Histogram should exist after the initial create");
     Counter total =
         DynamicMetricsManager.getInstance().getMetric("Coordinator.numStreamsProvisioned");
@@ -2672,7 +2672,7 @@ public class TestCoordinator {
     // Give the coordinator event loop time to process anything it might (incorrectly) do.
     Thread.sleep(500);
     Assert.assertEquals(histogram.getCount(), histogramCountAfterCreate,
-        "timeToReadyMs histogram count must not increase on resume from STOPPED");
+        "streamProvisioningTimeMs histogram count must not increase on resume from STOPPED");
     Assert.assertEquals(total.getCount(), totalCountAfterCreate,
         "numStreamsProvisioned counter must not increase on resume from STOPPED");
     Assert.assertEquals(outsideSla.getCount(), outsideSlaCountAfterCreate,

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2683,6 +2683,54 @@ public class TestCoordinator {
     zkClient.close();
   }
 
+  /**
+   * The provisioning SLO counters are emitted both as an aggregate and keyed by connector name, so the
+   * SLO and its misses can be broken down per connector type. This asserts the per-connector keyed series
+   * (Coordinator.&lt;connectorName&gt;.numStreams...) increments alongside the aggregate.
+   */
+  @Test
+  public void testProvisioningSloCountersAreKeyedByConnector() throws Exception {
+    String testCluster = "testProvisioningSloKeyedByConnector";
+    String connectorType = "testConnectorType";
+    String datastreamName = "TestKeyedStream";
+
+    // Threshold of 0 classifies any positive duration as outside SLA.
+    Properties override = new Properties();
+    override.put(CoordinatorConfig.CONFIG_PROVISIONING_SLA_THRESHOLD_MS, "0");
+
+    Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, override);
+    TestHookConnector connector = new TestHookConnector("connector1", connectorType);
+    coordinator.addConnector(connectorType, connector, new BroadcastStrategy(Optional.empty()), false,
+        new SourceBasedDeduper(), null);
+    coordinator.start();
+
+    String keyedTotalName = "Coordinator." + connectorType + ".numStreamsProvisioned";
+    String keyedOutsideSlaName = "Coordinator." + connectorType + ".numStreamsProvisionedOutsideSla";
+    Counter keyedTotalBefore = DynamicMetricsManager.getInstance().getMetric(keyedTotalName);
+    long keyedTotalCountBefore = keyedTotalBefore == null ? 0L : keyedTotalBefore.getCount();
+
+    ZkClient zkClient = new ZkClient(_zkConnectionString);
+    DatastreamTestUtils.createAndStoreDatastreams(zkClient, testCluster, connectorType, datastreamName);
+    Assert.assertTrue(PollUtils.poll(() -> DatastreamStatus.READY.equals(
+        DatastreamTestUtils.getDatastream(zkClient, testCluster, datastreamName).getStatus()), 200, 30000));
+
+    // The per-connector total must increment for the stream that reached READY.
+    Assert.assertTrue(PollUtils.poll(() -> {
+      Counter c = DynamicMetricsManager.getInstance().getMetric(keyedTotalName);
+      return c != null && c.getCount() > keyedTotalCountBefore;
+    }, 100, 30000), keyedTotalName + " should increment when a stream from this connector goes READY");
+
+    // With threshold 0 the per-connector outside-SLA series must also be present and incremented.
+    Counter keyedOutsideSla = DynamicMetricsManager.getInstance().getMetric(keyedOutsideSlaName);
+    Assert.assertNotNull(keyedOutsideSla, keyedOutsideSlaName + " should be registered after the stream goes READY");
+    Assert.assertTrue(keyedOutsideSla.getCount() > 0,
+        keyedOutsideSlaName + " should increment when duration exceeds threshold");
+
+    coordinator.stop();
+    coordinator.getDatastreamCache().getZkclient().close();
+    zkClient.close();
+  }
+
   @Test
   public void testHeartbeat() throws Exception {
     // Use 1s heartbeat period for quicker execution

--- a/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
+++ b/datastream-server-restli/src/test/java/com/linkedin/datastream/server/TestCoordinator.java
@@ -2498,7 +2498,7 @@ public class TestCoordinator {
     String datastreamName = "TestTimeToReadyStream";
 
     Properties override = new Properties();
-    override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS, "0");
+    override.put(CoordinatorConfig.CONFIG_PROVISIONING_SLA_THRESHOLD_MS, "0");
 
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, override);
     TestHookConnector connector = new TestHookConnector("connector1", connectorType);
@@ -2561,7 +2561,7 @@ public class TestCoordinator {
     String datastreamName = "TestFastStream";
 
     Properties override = new Properties();
-    override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS,
+    override.put(CoordinatorConfig.CONFIG_PROVISIONING_SLA_THRESHOLD_MS,
         String.valueOf(Duration.ofHours(1).toMillis()));
 
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, override);
@@ -2629,7 +2629,7 @@ public class TestCoordinator {
     // Threshold of 0 ensures any positive duration would be classified as outside SLA — so the
     // assertion that the counters do NOT increase on resume is meaningful (it's not just below-threshold).
     Properties override = new Properties();
-    override.put(CoordinatorConfig.CONFIG_SLOW_PROVISIONING_THRESHOLD_MS, "0");
+    override.put(CoordinatorConfig.CONFIG_PROVISIONING_SLA_THRESHOLD_MS, "0");
 
     Coordinator coordinator = createCoordinator(_zkConnectionString, testCluster, override);
     TestHookConnector connector = new TestHookConnector("connector1", connectorType);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1406,8 +1406,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       if (streamProvisioningTimeMs >= 0) {
         _metrics.updateStreamProvisioningTimeHistogram(streamProvisioningTimeMs);
         // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.
-        // Each is emitted both as an aggregate and keyed by connector name, so the SLO and its misses can
-        // be broken down per connector type (for example Espresso vs TiDB).
+        // Each is emitted both as an aggregate and keyed by connector name
         String connectorName = ds.getConnectorName();
         _metrics.updateProvisioningSloCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED, connectorName);
         CoordinatorMetrics.Counter slaCounter = streamProvisioningTimeMs > _config.getProvisioningSlaThresholdMs()

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2541,7 +2541,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
     // Increments a provisioning SLO counter both as an aggregate (across all connectors) and, when the
     // connector name is known, keyed by connector. The keyed series enables a per-connector SLO and
-    // per-connector miss breakdown; the aggregate remains the headline SLO.
+    // per-connector miss breakdown.
     public void updateProvisioningSloCounter(Counter metric, String connectorName) {
       _dynamicMetricsManager.createOrUpdateCounter(MODULE, metric.getName(), 1);
       if (connectorName != null && !connectorName.isEmpty()) {
@@ -2777,9 +2777,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
      */
     public enum Counter {
       NUM_HEARTBEATS("numHeartbeats"),
-      // Provisioning SLO counters. All three are emitted together for every provisioned (READY)
-      // datastream in recordTimeToReadyMs: the total plus exactly one of within/outside SLA.
-      // The provisioning SLO is computed as numStreamsProvisionedWithinSla / numStreamsProvisioned.
+      // Provisioning SLO counters.
       NUM_STREAMS_PROVISIONED("numStreamsProvisioned"),
       NUM_STREAMS_PROVISIONED_WITHIN_SLA("numStreamsProvisionedWithinSla"),
       NUM_STREAMS_PROVISIONED_OUTSIDE_SLA("numStreamsProvisionedOutsideSla");

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1393,20 +1393,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
    * transition for a newly created datastream. Updates the {@code timeToReadyMs} histogram and the
    * provisioning SLO counters: {@code numStreamsProvisioned} (total) plus exactly one of
    * {@code numStreamsProvisionedWithinSla} / {@code numStreamsProvisionedOutsideSla} depending on
-   * whether the duration exceeds {@link CoordinatorConfig#getProvisioningSlaThresholdMs()}. The SLO
-   * is {@code numStreamsProvisionedWithinSla / numStreamsProvisioned}. Emitting the total here, at the
-   * same site and instant as the within/outside counter, keeps the numerator and denominator over an
-   * identical population so the ratio is free of create-vs-ready timing skew. Note that datastreams
-   * which never reach READY (stuck provisioning) are not counted here; those are covered separately by
-   * the non-ready datastream alerting, and are folded into the SLO as outside-SLA if/when they
-   * eventually become READY.
-   *
-   * <p> {@code system.creation.ms} is written in the request by Nuage before calling the create datastream API. As a
-   * fallback, it is written by the coordinator if the property is not already present via {@code putIfAbsent}
-   *
-   * <p>The {@link NumberFormatException} catch defends against externally-supplied or
-   * operator-edited values: because {@code CREATION_MS} is set via {@code putIfAbsent}, any
-   * earlier writer (for example, a buggy REST caller or a manual ZK edit) wins.
+   * whether the duration exceeds {@link CoordinatorConfig#getProvisioningSlaThresholdMs()}.
    */
   private void recordTimeToReadyMs(Datastream ds) {
     String creationMsStr = Objects.requireNonNull(ds.getMetadata()).get(CREATION_MS);
@@ -2671,14 +2658,19 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // Registering the BrooklinHistogramInfo here is required for the external metrics bridge
       // to pick up the metric name.
       //
-      // Advertise every attribute the histogram framework supports (all percentiles plus Count, Min,
-      // Max, Mean, StdDev) so the external bridge can export the full distribution rather than the
-      // default p50/p99 only. This is declaration-only and fail-safe: BrooklinHistogramInfo.SUPPORTED_ATTRIBUTES
-      // is the exact set the framework understands, so no unsupported attribute can be requested, and
-      // any attribute the bridge chooses not to export is simply ignored — nothing breaks and the
-      // underlying histogram values are unaffected.
+      // Advertise the subset of attributes we want exported (Count, Max, Mean and the p50/p95/p99
+      // percentiles) instead of the default p50/p99 only. This is declaration-only and fail-safe: every
+      // attribute below is a valid BrooklinHistogramInfo constant, so no unsupported attribute can be
+      // requested, and any attribute the bridge chooses not to export is simply ignored. Nothing breaks
+      // and the underlying histogram values are unaffected.
       _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, TIME_TO_READY_MS),
-          Optional.of(new ArrayList<>(BrooklinHistogramInfo.SUPPORTED_ATTRIBUTES))));
+          Optional.of(Arrays.asList(
+              BrooklinHistogramInfo.COUNT,
+              BrooklinHistogramInfo.MAX,
+              BrooklinHistogramInfo.MEAN,
+              BrooklinHistogramInfo.PERCENTILE_50,
+              BrooklinHistogramInfo.PERCENTILE_95,
+              BrooklinHistogramInfo.PERCENTILE_99))));
     }
 
     private void registerMeter(Meter metric) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2657,12 +2657,6 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // The metric is created lazily on first update via createOrUpdateSlidingWindowHistogram.
       // Registering the BrooklinHistogramInfo here is required for the external metrics bridge
       // to pick up the metric name.
-      //
-      // Advertise the subset of attributes we want exported (Count, Max, Mean and the p50/p95/p99
-      // percentiles) instead of the default p50/p99 only. This is declaration-only and fail-safe: every
-      // attribute below is a valid BrooklinHistogramInfo constant, so no unsupported attribute can be
-      // requested, and any attribute the bridge chooses not to export is simply ignored. Nothing breaks
-      // and the underlying histogram values are unaffected.
       _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, TIME_TO_READY_MS),
           Optional.of(Arrays.asList(
               BrooklinHistogramInfo.COUNT,

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1390,9 +1390,16 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
   /**
    * Records the time from {@code system.creation.ms} to the {@code INITIALIZING -> READY}
-   * transition for a newly created datastream. Updates the {@code timeToReadyMs} histogram and,
-   * when the duration exceeds {@link CoordinatorConfig#getSlowProvisioningThresholdMs()},
-   * increments the {@code slowProvisioningRate} meter.
+   * transition for a newly created datastream. Updates the {@code timeToReadyMs} histogram and the
+   * provisioning SLO counters: {@code numStreamsProvisioned} (total) plus exactly one of
+   * {@code numStreamsProvisionedWithinSla} / {@code numStreamsProvisionedOutsideSla} depending on
+   * whether the duration exceeds {@link CoordinatorConfig#getSlowProvisioningThresholdMs()}. The SLO
+   * is {@code numStreamsProvisionedWithinSla / numStreamsProvisioned}. Emitting the total here, at the
+   * same site and instant as the within/outside counter, keeps the numerator and denominator over an
+   * identical population so the ratio is free of create-vs-ready timing skew. Note that datastreams
+   * which never reach READY (stuck provisioning) are not counted here; those are covered separately by
+   * the non-ready datastream alerting, and are folded into the SLO as outside-SLA if/when they
+   * eventually become READY.
    *
    * <p> {@code system.creation.ms} is written in the request by Nuage before calling the create datastream API. As a
    * fallback, it is written by the coordinator if the property is not already present via {@code putIfAbsent}
@@ -1411,8 +1418,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       _log.info("Datastream {} transitioned to READY in {} ms", ds.getName(), timeToReadyMs);
       if (timeToReadyMs >= 0) {
         _metrics.updateTimeToReadyHistogram(timeToReadyMs);
+        // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.
+        _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED, 1);
         if (timeToReadyMs > _config.getSlowProvisioningThresholdMs()) {
-          _metrics.updateMeter(CoordinatorMetrics.Meter.SLOW_PROVISIONING_RATE, 1);
+          _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_OUTSIDE_SLA, 1);
+        } else {
+          _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_WITHIN_SLA, 1);
         }
       }
     } catch (NumberFormatException e) {
@@ -2634,8 +2645,16 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     private void registerHistogramMetrics() {
       // The metric is created lazily on first update via createOrUpdateSlidingWindowHistogram.
       // Registering the BrooklinHistogramInfo here is required for the external metrics bridge
-      // to pick up the metric name
-      _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, TIME_TO_READY_MS)));
+      // to pick up the metric name.
+      //
+      // Advertise every attribute the histogram framework supports (all percentiles plus Count, Min,
+      // Max, Mean, StdDev) so the external bridge can export the full distribution rather than the
+      // default p50/p99 only. This is declaration-only and fail-safe: BrooklinHistogramInfo.SUPPORTED_ATTRIBUTES
+      // is the exact set the framework understands, so no unsupported attribute can be requested, and
+      // any attribute the bridge chooses not to export is simply ignored — nothing breaks and the
+      // underlying histogram values are unaffected.
+      _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, TIME_TO_READY_MS),
+          Optional.of(new ArrayList<>(BrooklinHistogramInfo.SUPPORTED_ATTRIBUTES))));
     }
 
     private void registerMeter(Meter metric) {
@@ -2672,8 +2691,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       NUM_PARTITION_ASSIGNMENTS("numPartitionAssignments"),
       NUM_PARTITION_MOVEMENTS("numPartitionMovements"),
       NUM_ORPHAN_CONNECTOR_TASKS("numOrphanConnectorTasks"),
-      NUM_ORPHAN_CONNECTOR_TASK_LOCKS("numOrphanConnectorTaskLocks"),
-      SLOW_PROVISIONING_RATE("slowProvisioningRate");
+      NUM_ORPHAN_CONNECTOR_TASK_LOCKS("numOrphanConnectorTaskLocks");
 
       private final String _name;
 
@@ -2742,7 +2760,13 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
      * Coordinator metrics of type {@link com.codahale.metrics.Counter}
      */
     public enum Counter {
-      NUM_HEARTBEATS("numHeartbeats");
+      NUM_HEARTBEATS("numHeartbeats"),
+      // Provisioning SLO counters. All three are emitted together for every provisioned (READY)
+      // datastream in recordTimeToReadyMs: the total plus exactly one of within/outside SLA.
+      // The provisioning SLO is computed as numStreamsProvisionedWithinSla / numStreamsProvisioned.
+      NUM_STREAMS_PROVISIONED("numStreamsProvisioned"),
+      NUM_STREAMS_PROVISIONED_WITHIN_SLA("numStreamsProvisionedWithinSla"),
+      NUM_STREAMS_PROVISIONED_OUTSIDE_SLA("numStreamsProvisionedOutsideSla");
 
       private final String _name;
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1393,7 +1393,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
    * transition for a newly created datastream. Updates the {@code timeToReadyMs} histogram and the
    * provisioning SLO counters: {@code numStreamsProvisioned} (total) plus exactly one of
    * {@code numStreamsProvisionedWithinSla} / {@code numStreamsProvisionedOutsideSla} depending on
-   * whether the duration exceeds {@link CoordinatorConfig#getSlowProvisioningThresholdMs()}. The SLO
+   * whether the duration exceeds {@link CoordinatorConfig#getProvisioningSlaThresholdMs()}. The SLO
    * is {@code numStreamsProvisionedWithinSla / numStreamsProvisioned}. Emitting the total here, at the
    * same site and instant as the within/outside counter, keeps the numerator and denominator over an
    * identical population so the ratio is free of create-vs-ready timing skew. Note that datastreams
@@ -1420,7 +1420,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         _metrics.updateTimeToReadyHistogram(timeToReadyMs);
         // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.
         _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED, 1);
-        if (timeToReadyMs > _config.getSlowProvisioningThresholdMs()) {
+        if (timeToReadyMs > _config.getProvisioningSlaThresholdMs()) {
           _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_OUTSIDE_SLA, 1);
         } else {
           _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_WITHIN_SLA, 1);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1419,12 +1419,14 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       if (timeToReadyMs >= 0) {
         _metrics.updateTimeToReadyHistogram(timeToReadyMs);
         // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.
-        _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED, 1);
-        if (timeToReadyMs > _config.getProvisioningSlaThresholdMs()) {
-          _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_OUTSIDE_SLA, 1);
-        } else {
-          _metrics.updateCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_WITHIN_SLA, 1);
-        }
+        // Each is emitted both as an aggregate and keyed by connector name, so the SLO and its misses can
+        // be broken down per connector type (for example Espresso vs TiDB).
+        String connectorName = ds.getConnectorName();
+        _metrics.updateProvisioningSloCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED, connectorName);
+        CoordinatorMetrics.Counter slaCounter = timeToReadyMs > _config.getProvisioningSlaThresholdMs()
+            ? CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_OUTSIDE_SLA
+            : CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_WITHIN_SLA;
+        _metrics.updateProvisioningSloCounter(slaCounter, connectorName);
       }
     } catch (NumberFormatException e) {
       _log.warn("Invalid {} for datastream {}: {}", CREATION_MS, ds.getName(), creationMsStr);
@@ -2504,6 +2506,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       registerKeyedMeterMetrics();
       registerGaugeMetrics();
       registerCounterMetrics();
+      registerKeyedCounterMetrics();
       registerHistogramMetrics();
     }
 
@@ -2547,6 +2550,16 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
     public void updateCounter(Counter metric, int value) {
       _dynamicMetricsManager.createOrUpdateCounter(MODULE, metric.getName(), value);
+    }
+
+    // Increments a provisioning SLO counter both as an aggregate (across all connectors) and, when the
+    // connector name is known, keyed by connector. The keyed series enables a per-connector SLO and
+    // per-connector miss breakdown; the aggregate remains the headline SLO.
+    public void updateProvisioningSloCounter(Counter metric, String connectorName) {
+      _dynamicMetricsManager.createOrUpdateCounter(MODULE, metric.getName(), 1);
+      if (connectorName != null && !connectorName.isEmpty()) {
+        _dynamicMetricsManager.createOrUpdateCounter(MODULE, connectorName, metric.getName(), 1);
+      }
     }
 
     public void updateTimeToReadyHistogram(long valueMs) {
@@ -2640,6 +2653,17 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     private void registerCounterMetrics() {
       // These metrics are eagerly created
       Arrays.stream(Counter.values()).forEach(this::registerCounter);
+    }
+
+    private void registerKeyedCounterMetrics() {
+      // The per-connector provisioning SLO counters are created lazily on first update via the keyed
+      // createOrUpdateCounter (key = connector name). Register regex-based BrooklinCounterInfo objects so
+      // the external metrics bridge picks up the Coordinator.<connectorName>.<counter> series for each
+      // connector. The aggregate (unkeyed) counters are covered separately by registerCounter.
+      String prefix = _coordinator.getDynamicMetricPrefixRegex();
+      _metricInfos.add(new BrooklinCounterInfo(prefix + Counter.NUM_STREAMS_PROVISIONED.getName()));
+      _metricInfos.add(new BrooklinCounterInfo(prefix + Counter.NUM_STREAMS_PROVISIONED_WITHIN_SLA.getName()));
+      _metricInfos.add(new BrooklinCounterInfo(prefix + Counter.NUM_STREAMS_PROVISIONED_OUTSIDE_SLA.getName()));
     }
 
     private void registerHistogramMetrics() {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -183,8 +183,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   // With a 5-min sliding window and sparse provisioning events (typically minutes-to-hours apart),
   // each event lands as an isolated ~5-min plateau in the exported .99thPercentile time series —
   // effectively a per-event scatter view.
-  private static final String TIME_TO_READY_MS = "timeToReadyMs";
-  private static final long TIME_TO_READY_HISTOGRAM_WINDOW_MS = Duration.ofMinutes(5).toMillis();
+  private static final String STREAM_PROVISIONING_TIME_MS = "streamProvisioningTimeMs";
+  private static final long STREAM_PROVISIONING_TIME_HISTOGRAM_WINDOW_MS = Duration.ofMinutes(5).toMillis();
 
   private static final AtomicLong PAUSED_DATASTREAMS_GROUPS = new AtomicLong(0L);
 
@@ -1354,7 +1354,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
                 + "producing events ", ds.getName());
             shouldRetry = true;
           } else {
-            recordTimeToReadyMs(ds);
+            recordStreamProvisioningTime(ds);
           }
         } catch (Exception e) {
           _log.warn("Failed to update the destination of new datastream {}", ds, e);
@@ -1390,27 +1390,27 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
   /**
    * Records the time from {@code system.creation.ms} to the {@code INITIALIZING -> READY}
-   * transition for a newly created datastream. Updates the {@code timeToReadyMs} histogram and the
+   * transition for a newly created datastream. Updates the {@code streamProvisioningTimeMs} histogram and the
    * provisioning SLO counters: {@code numStreamsProvisioned} (total) plus exactly one of
    * {@code numStreamsProvisionedWithinSla} / {@code numStreamsProvisionedOutsideSla} depending on
    * whether the duration exceeds {@link CoordinatorConfig#getProvisioningSlaThresholdMs()}.
    */
-  private void recordTimeToReadyMs(Datastream ds) {
+  private void recordStreamProvisioningTime(Datastream ds) {
     String creationMsStr = Objects.requireNonNull(ds.getMetadata()).get(CREATION_MS);
     if (creationMsStr == null) {
       return;
     }
     try {
-      long timeToReadyMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
-      _log.info("Datastream {} transitioned to READY in {} ms", ds.getName(), timeToReadyMs);
-      if (timeToReadyMs >= 0) {
-        _metrics.updateTimeToReadyHistogram(timeToReadyMs);
+      long streamProvisioningTimeMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
+      _log.info("Datastream {} transitioned to READY in {} ms", ds.getName(), streamProvisioningTimeMs);
+      if (streamProvisioningTimeMs >= 0) {
+        _metrics.updateStreamProvisioningTimeHistogram(streamProvisioningTimeMs);
         // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.
         // Each is emitted both as an aggregate and keyed by connector name, so the SLO and its misses can
         // be broken down per connector type (for example Espresso vs TiDB).
         String connectorName = ds.getConnectorName();
         _metrics.updateProvisioningSloCounter(CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED, connectorName);
-        CoordinatorMetrics.Counter slaCounter = timeToReadyMs > _config.getProvisioningSlaThresholdMs()
+        CoordinatorMetrics.Counter slaCounter = streamProvisioningTimeMs > _config.getProvisioningSlaThresholdMs()
             ? CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_OUTSIDE_SLA
             : CoordinatorMetrics.Counter.NUM_STREAMS_PROVISIONED_WITHIN_SLA;
         _metrics.updateProvisioningSloCounter(slaCounter, connectorName);
@@ -2549,9 +2549,9 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       }
     }
 
-    public void updateTimeToReadyHistogram(long valueMs) {
-      _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, null, TIME_TO_READY_MS,
-          TIME_TO_READY_HISTOGRAM_WINDOW_MS, valueMs);
+    public void updateStreamProvisioningTimeHistogram(long valueMs) {
+      _dynamicMetricsManager.createOrUpdateSlidingWindowHistogram(MODULE, null, STREAM_PROVISIONING_TIME_MS,
+          STREAM_PROVISIONING_TIME_HISTOGRAM_WINDOW_MS, valueMs);
     }
 
     public static KeyedMeter getKeyedMeter(EventType eventType) {
@@ -2657,7 +2657,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       // The metric is created lazily on first update via createOrUpdateSlidingWindowHistogram.
       // Registering the BrooklinHistogramInfo here is required for the external metrics bridge
       // to pick up the metric name.
-      _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, TIME_TO_READY_MS),
+      _metricInfos.add(new BrooklinHistogramInfo(_coordinator.buildMetricName(MODULE, STREAM_PROVISIONING_TIME_MS),
           Optional.of(Arrays.asList(
               BrooklinHistogramInfo.COUNT,
               BrooklinHistogramInfo.MAX,

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -48,8 +48,9 @@ public final class CoordinatorConfig {
 
   public static final String CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING = PREFIX + "enableThroughputViolatingTopicsHandling";
   public static final String CONFIG_LOG_SIZE_LIMIT_IN_BYTES = PREFIX + "logSizeLimitInBytes";
-  // threshold above which a datastream's INITIALIZING -> READY duration is counted as a slow provisioning event
-  public static final String CONFIG_SLOW_PROVISIONING_THRESHOLD_MS = PREFIX + "slowProvisioningThresholdMs";
+  // SLA threshold for stream provisioning: a datastream's INITIALIZING -> READY duration at or below this
+  // is counted as within SLA, above it as outside SLA
+  public static final String CONFIG_PROVISIONING_SLA_THRESHOLD_MS = PREFIX + "provisioningSlaThresholdMs";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
@@ -58,7 +59,7 @@ public final class CoordinatorConfig {
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS = 60 * 1000;
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS = 10 * 1000;
   public static final int DEFAULT_LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
-  public static final long DEFAULT_SLOW_PROVISIONING_THRESHOLD_MS = Duration.ofMinutes(8).toMillis();
+  public static final long DEFAULT_PROVISIONING_SLA_THRESHOLD_MS = Duration.ofMinutes(8).toMillis();
 
   private final String _cluster;
   private final String _zkAddress;
@@ -85,7 +86,7 @@ public final class CoordinatorConfig {
   private final long _markDatastreamsStoppedRetryPeriodMs;
   private final boolean _enableThroughputViolatingTopicsHandling;
   private final double _logSizeLimitInBytes;
-  private final long _slowProvisioningThresholdMs;
+  private final long _provisioningSlaThresholdMs;
 
 
   /**
@@ -125,8 +126,8 @@ public final class CoordinatorConfig {
     _enableThroughputViolatingTopicsHandling = _properties.getBoolean(
         CONFIG_ENABLE_THROUGHPUT_VIOLATING_TOPICS_HANDLING, false);
     _logSizeLimitInBytes = _properties.getDouble(CONFIG_LOG_SIZE_LIMIT_IN_BYTES, DEFAULT_LOG_SIZE_LIMIT_IN_BYTES);
-    _slowProvisioningThresholdMs = _properties.getLong(CONFIG_SLOW_PROVISIONING_THRESHOLD_MS,
-        DEFAULT_SLOW_PROVISIONING_THRESHOLD_MS);
+    _provisioningSlaThresholdMs = _properties.getLong(CONFIG_PROVISIONING_SLA_THRESHOLD_MS,
+        DEFAULT_PROVISIONING_SLA_THRESHOLD_MS);
   }
 
   public Properties getConfigProperties() {
@@ -227,7 +228,7 @@ public final class CoordinatorConfig {
     return _logSizeLimitInBytes;
   }
 
-  public long getSlowProvisioningThresholdMs() {
-    return _slowProvisioningThresholdMs;
+  public long getProvisioningSlaThresholdMs() {
+    return _provisioningSlaThresholdMs;
   }
 }


### PR DESCRIPTION
## Summary

- **Three provisioning SLO counters (Coordinator).** `recordStreamProvisioningTime` now emits, atomically at the `INITIALIZING -> READY` transition, `numStreamsProvisioned` (total) plus exactly one of `numStreamsProvisionedWithinSla` / `numStreamsProvisionedOutsideSla`, classified by the `brooklin.server.coordinator.provisioningSlaThresholdMs` threshold.
- **Per-connector breakdown.** Each counter is emitted both as an aggregate and keyed by connector name, so the SLO and its misses can be split per connector type. The keyed series render as `Coordinator.<connectorName>.numStreamsProvisioned` (and the within/outside SLA variants). 
- **Renamed the threshold config** from `slowProvisioningThresholdMs` to `provisioningSlaThresholdMs` to match the within/outside SLA framing. 
- **Removed the `slowProvisioningRate` meter.** `numStreamsProvisionedOutsideSla` replaces it. A Counter exposes `Count` in RRD, whereas the meter only exposed `PerSecondRate`. The outside-SLA counter is also the source for the slow-provisioning alert.
- **Enriched the `streamProvisioningTimeMs` histogram** to emit critical attributes (`Count`, `Max`, `Mean`, PERCENTILE_50, PERCENTILE_95, PERCENTILE_99.

## SLO definition

Provisioning SLO, computed over a reporting window:

```
SLO = numStreamsProvisionedWithinSla / numStreamsProvisioned
```

This measures, out of the datastreams that finished provisioning (reached READY), the fraction that did so within the threshold. All three counters are updated at the same moment, when a stream reaches READY, so the numerator and denominator always move together.

The same ratio can be computed per connector from the keyed series, for example `Coordinator.Espresso.numStreamsProvisionedWithinSla / Coordinator.Espresso.numStreamsProvisioned`. The per-connector miss count (`numStreamsProvisionedOutsideSla`) is meaningful at any volume and is the simplest way to attribute SLA misses to a connector.

## Why the denominator is provisioned (READY) streams, not create requests

We could instead use every create request as the denominator for SLO calculation but it has potential for lot of irregularities:

A create request is counted the moment a stream is created. But that same stream only counts as within SLA once it reaches READY, which is minutes later. In the gap between the two, the stream is in the denominator with nothing in the numerator, so the ratio drops even though nothing is wrong.

Example: the last 46 streams were all within SLA, so the SLO reads 46/46 = 100%. A new, healthy stream is created at 12:00 and reaches READY at 12:05. Between 12:00 and 12:05 the SLO shows 46/47 = 97.9%. At 12:05 it jumps back to 47/47 = 100%. That dip was not a breach. It only meant a stream was still being provisioned.

This causes two problems.

1. **The SLO graph dips when nothing is wrong.** Every time a stream is being provisioned, the SLO line drops for a few minutes and then recovers on its own. Someone looking at the dashboard sees the SLO fall below target and assumes something broke, when a stream was simply still in progress. These dips carry no real meaning, and an SLO chart that drops for reasons unrelated to the SLO is worse than no chart. This is the main reason we avoid the create-request denominator.

2. **Alerts fire falsely.** If we page when the ratio drops, a normal in-progress stream sets off the alert. One workaround is to alert only after the dip has lasted several minutes, long enough for a healthy stream to finish. That helps but does not fully solve it: it delays every real alert, and it still misfires when two streams are provisioned at overlapping times, because their dips add up and last longer than the wait. It also does nothing for problem 1, since the graph still dips.

There is also a smaller issue: a create request is counted before it is validated, so the count includes requests rejected for bad input or because the stream already exists. Those are never provisioned, so they do not belong in a provisioning SLO.

**What we do instead.** Count both the numerator and the denominator at the same moment, when the stream reaches READY. `numStreamsProvisioned` and `numStreamsProvisionedWithinSla` move together, so the ratio only changes when a stream actually finishes. Every point on the graph is a real result, and the SLO never dips while a stream is still provisioning.

**Caveat: Stuck streams** A stream that gets stuck and is deleted before it ever reaches READY is not counted in the SLO. This is fine: stuck streams are already caught by the existing alert on non-ready datastreams, which pages when a stream stays not-ready past 15 minutes. If a stuck stream is later fixed and reaches READY, it then counts as outside SLA.

## Alerting

- **Slow provisioning:** alert when `numStreamsProvisionedOutsideSla` goes up. This only happens after a stream has reached READY and was measured over the threshold, so a single increment is a real breach, not a false signal.
- **Stuck provisioning:** already covered by the existing alert on non-ready datastreams (pages when a stream stays not-ready past 15 minutes), so the SLO does not need to detect it.

## Testing Done

- [x] `testStreamProvisioningTimeMetricsOnCreate` (threshold 0): asserts the histogram count, `numStreamsProvisioned`, and `numStreamsProvisionedOutsideSla` all increment after the stream goes READY.
- [x] `testProvisioningSloCountsWithinSlaWhenBelowThreshold` (threshold 1 hour): asserts `numStreamsProvisionedWithinSla` increments and `numStreamsProvisionedOutsideSla` does not.
- [x] `testStreamProvisioningTimeMetricsNotEmittedOnResume` (threshold 0): asserts the histogram and counters do not change on a STOPPED to READY resume.
- [x] `testProvisioningSloCountersAreKeyedByConnector` (threshold 0): asserts the per-connector keyed series (`Coordinator.<connectorName>.numStreamsProvisioned` and the outside-SLA variant) increment alongside the aggregate.
- [x] `:datastream-server:checkstyleMain` and `:datastream-server-restli:checkstyleTest` pass.
- [x] `compileJava` and `compileTestJava` pass.


## Notes for Reviewer
- Intentionally kept the validation threshold to 8 minutes for now. Adding the validation time in the provisioning time will be taken up in a separate PR, will update the threshold to 10 mins with that change.
