### PR TITLE
Add create-validation time to stream provisioning metric

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -90,6 +90,13 @@ public class DatastreamMetadataConstants {
   public static final String CREATION_MS = "system.creation.ms";
 
   /**
+   * Time spent running create validation in the resource provider, in milliseconds. Added to the
+   * stream provisioning time alongside {@link #CREATION_MS}. Absent for streams created before this
+   * property existed, in which case it is treated as zero.
+   */
+  public static final String CREATE_VALIDATION_TIME_MS = "system.createValidationTime.ms";
+
+  /**
    * Position at which the ingestion should start for the datastream.
    */
   public static final String START_POSITION = "system.start.position";

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -90,9 +90,7 @@ public class DatastreamMetadataConstants {
   public static final String CREATION_MS = "system.creation.ms";
 
   /**
-   * Time spent running create validation in the resource provider, in milliseconds. Added to the
-   * stream provisioning time alongside {@link #CREATION_MS}. Absent for streams created before this
-   * property existed, in which case it is treated as zero.
+   * Time spent running create validation in milliseconds.
    */
   public static final String CREATE_VALIDATION_TIME_MS = "system.createValidationTime.ms";
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1427,11 +1427,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     try {
       long streamProvisioningTimeMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
 
-      // Include the create-validation time (set by the resource provider via
-      // system.createValidationTime.ms) so the provisioning metric reflects validation time plus
-      // creation time. Read it from the metadata: add the value when present and greater than 0,
-      // otherwise add 0. This keeps the creation-time measurement intact for streams created before
-      // this property existed.
+      // Include the create-validation time in the stream provisioning time
       long createValidationTimeMs = 0L;
       String validationMsStr = ds.getMetadata().get(CREATE_VALIDATION_TIME_MS);
       if (validationMsStr != null) {
@@ -1446,8 +1442,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       }
       streamProvisioningTimeMs += createValidationTimeMs;
 
-      _log.info("Datastream {} transitioned to READY in {} ms (creation + create-validation)",
-          ds.getName(), streamProvisioningTimeMs);
+      _log.info("Total stream provisioning time for Datastream {} - {} ms", ds.getName(), streamProvisioningTimeMs);
       if (streamProvisioningTimeMs >= 0) {
         _metrics.updateStreamProvisioningTimeHistogram(streamProvisioningTimeMs);
         // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -86,6 +86,7 @@ import com.linkedin.datastream.server.providers.CheckpointProvider;
 import com.linkedin.datastream.server.providers.ZookeeperCheckpointProvider;
 import com.linkedin.datastream.server.zk.ZkAdapter;
 
+import static com.linkedin.datastream.common.DatastreamMetadataConstants.CREATE_VALIDATION_TIME_MS;
 import static com.linkedin.datastream.common.DatastreamMetadataConstants.CREATION_MS;
 import static com.linkedin.datastream.common.DatastreamMetadataConstants.SYSTEM_DESTINATION_PREFIX;
 import static com.linkedin.datastream.common.DatastreamMetadataConstants.THROUGHPUT_VIOLATING_TOPICS;
@@ -1425,7 +1426,25 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     }
     try {
       long streamProvisioningTimeMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
-      _log.info("Datastream {} transitioned to READY in {} ms", ds.getName(), streamProvisioningTimeMs);
+
+      // Include the create-validation time (set by the resource provider via
+      // system.createValidationTime.ms) so the provisioning metric reflects validation time plus
+      // creation time. Absent or malformed is treated as 0, keeping the creation-time measurement
+      // intact for streams created before this property existed.
+      String validationMsStr = ds.getMetadata().get(CREATE_VALIDATION_TIME_MS);
+      if (validationMsStr != null) {
+        try {
+          long createValidationTimeMs = Long.parseLong(validationMsStr);
+          if (createValidationTimeMs > 0) {
+            streamProvisioningTimeMs += createValidationTimeMs;
+          }
+        } catch (NumberFormatException e) {
+          _log.warn("Invalid {} for datastream {}: {}", CREATE_VALIDATION_TIME_MS, ds.getName(), validationMsStr);
+        }
+      }
+
+      _log.info("Datastream {} transitioned to READY in {} ms (creation + create-validation)",
+          ds.getName(), streamProvisioningTimeMs);
       if (streamProvisioningTimeMs >= 0) {
         _metrics.updateStreamProvisioningTimeHistogram(streamProvisioningTimeMs);
         // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1429,19 +1429,22 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
       // Include the create-validation time (set by the resource provider via
       // system.createValidationTime.ms) so the provisioning metric reflects validation time plus
-      // creation time. Absent or malformed is treated as 0, keeping the creation-time measurement
-      // intact for streams created before this property existed.
+      // creation time. Read it from the metadata: add the value when present and greater than 0,
+      // otherwise add 0. This keeps the creation-time measurement intact for streams created before
+      // this property existed.
+      long createValidationTimeMs = 0L;
       String validationMsStr = ds.getMetadata().get(CREATE_VALIDATION_TIME_MS);
       if (validationMsStr != null) {
         try {
-          long createValidationTimeMs = Long.parseLong(validationMsStr);
-          if (createValidationTimeMs > 0) {
-            streamProvisioningTimeMs += createValidationTimeMs;
+          long parsedValidationTimeMs = Long.parseLong(validationMsStr);
+          if (parsedValidationTimeMs > 0) {
+            createValidationTimeMs = parsedValidationTimeMs;
           }
         } catch (NumberFormatException e) {
           _log.warn("Invalid {} for datastream {}: {}", CREATE_VALIDATION_TIME_MS, ds.getName(), validationMsStr);
         }
       }
+      streamProvisioningTimeMs += createValidationTimeMs;
 
       _log.info("Datastream {} transitioned to READY in {} ms (creation + create-validation)",
           ds.getName(), streamProvisioningTimeMs);

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1428,19 +1428,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       long streamProvisioningTimeMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
 
       // Include the create-validation time in the stream provisioning time
-      long createValidationTimeMs = 0L;
-      String validationMsStr = ds.getMetadata().get(CREATE_VALIDATION_TIME_MS);
-      if (validationMsStr != null) {
-        try {
-          long parsedValidationTimeMs = Long.parseLong(validationMsStr);
-          if (parsedValidationTimeMs > 0) {
-            createValidationTimeMs = parsedValidationTimeMs;
-          }
-        } catch (NumberFormatException e) {
-          _log.warn("Invalid {} for datastream {}: {}", CREATE_VALIDATION_TIME_MS, ds.getName(), validationMsStr);
-        }
-      }
-      streamProvisioningTimeMs += createValidationTimeMs;
+      streamProvisioningTimeMs += getCreateValidationTimeMs(ds);
 
       _log.info("Total stream provisioning time for Datastream {} - {} ms", ds.getName(), streamProvisioningTimeMs);
       if (streamProvisioningTimeMs >= 0) {
@@ -1456,6 +1444,25 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       }
     } catch (NumberFormatException e) {
       _log.warn("Invalid {} for datastream {}: {}", CREATION_MS, ds.getName(), creationMsStr);
+    }
+  }
+
+  /**
+   * Returns the create-validation time in milliseconds that is recorded in the
+   * datastream metadata under {@code system.createValidationTime.ms}, or 0 when the property is
+   * absent, not positive, or not a valid long.
+   */
+  @VisibleForTesting
+  static long getCreateValidationTimeMs(Datastream ds) {
+    String validationMsStr = Objects.requireNonNull(ds.getMetadata()).get(CREATE_VALIDATION_TIME_MS);
+    if (validationMsStr == null) {
+      return 0L;
+    }
+    try {
+      long createValidationTimeMs = Long.parseLong(validationMsStr);
+      return createValidationTimeMs > 0 ? createValidationTimeMs : 0L;
+    } catch (NumberFormatException e) {
+      return 0L;
     }
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1425,12 +1425,13 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       return;
     }
     try {
-      long streamProvisioningTimeMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
+      long creationTimeMs = System.currentTimeMillis() - Long.parseLong(creationMsStr);
+      long createValidationTimeMs = getCreateValidationTimeMs(ds);
+      // Total stream provisioning time is the creation time plus the create-validation time.
+      long streamProvisioningTimeMs = creationTimeMs + createValidationTimeMs;
 
-      // Include the create-validation time in the stream provisioning time
-      streamProvisioningTimeMs += getCreateValidationTimeMs(ds);
-
-      _log.info("Total stream provisioning time for Datastream {} - {} ms", ds.getName(), streamProvisioningTimeMs);
+      _log.info("Stream provisioning time for Datastream {} - {} ms (creation {} ms + create-validation {} ms)",
+          ds.getName(), streamProvisioningTimeMs, creationTimeMs, createValidationTimeMs);
       if (streamProvisioningTimeMs >= 0) {
         _metrics.updateStreamProvisioningTimeHistogram(streamProvisioningTimeMs);
         // Emit the SLO counters atomically: the total provisioned and exactly one of within/outside SLA.

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -59,7 +59,7 @@ public final class CoordinatorConfig {
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_TIMEOUT_MS = 60 * 1000;
   public static final int DEFAULT_MARK_DATASTREMS_STOPPED_RETRY_PERIOD_MS = 10 * 1000;
   public static final int DEFAULT_LOG_SIZE_LIMIT_IN_BYTES = 1024 * 1024;
-  public static final long DEFAULT_PROVISIONING_SLA_THRESHOLD_MS = Duration.ofMinutes(8).toMillis();
+  public static final long DEFAULT_PROVISIONING_SLA_THRESHOLD_MS = Duration.ofMinutes(10).toMillis();
 
   private final String _cluster;
   private final String _zkAddress;

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
@@ -5,6 +5,7 @@
  */
 package com.linkedin.datastream.server;
 
+import java.time.Duration;
 import java.util.Properties;
 
 import org.testng.Assert;
@@ -58,6 +59,19 @@ public class TestCoordinatorConfig {
     CoordinatorConfig config = createCoordinatorConfig(props);
     Assert.assertEquals(CoordinatorConfig.DEFAULT_TASK_STOP_CHECK_RETRY_PERIOD_MS, config.getTaskStopCheckRetryPeriodMs());
     Assert.assertEquals(CoordinatorConfig.DEFAULT_TASK_STOP_CHECK_TIMEOUT_MS, config.getTaskStopCheckTimeoutMs());
+  }
+
+  @Test
+  public void testProvisioningSlaThresholdConfig() {
+    Properties props = new Properties();
+    CoordinatorConfig config = createCoordinatorConfig(props);
+    Assert.assertEquals(config.getProvisioningSlaThresholdMs(),
+        CoordinatorConfig.DEFAULT_PROVISIONING_SLA_THRESHOLD_MS);
+    Assert.assertEquals(config.getProvisioningSlaThresholdMs(), Duration.ofMinutes(10).toMillis());
+
+    props.put(CoordinatorConfig.CONFIG_PROVISIONING_SLA_THRESHOLD_MS, "1000");
+    CoordinatorConfig overridden = createCoordinatorConfig(props);
+    Assert.assertEquals(overridden.getProvisioningSlaThresholdMs(), 1000L);
   }
 
   @Test

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorStandalone.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorStandalone.java
@@ -1,0 +1,58 @@
+/**
+ *  Copyright 2019 LinkedIn Corporation. All rights reserved.
+ *  Licensed under the BSD 2-Clause License. See the LICENSE file in the project root for license information.
+ *  See the NOTICE file in the project root for additional information regarding copyright ownership.
+ */
+package com.linkedin.datastream.server;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.linkedin.data.template.StringMap;
+import com.linkedin.datastream.common.Datastream;
+
+import static com.linkedin.datastream.common.DatastreamMetadataConstants.CREATE_VALIDATION_TIME_MS;
+
+
+/**
+ * Unit tests for {@link Coordinator} that run standalone, without an embedded cluster. The full
+ * integration-style test lives in {@code TestCoordinator} in the datastream-server-restli module.
+ */
+@Test
+public class TestCoordinatorStandalone {
+
+  private static Datastream datastreamWithValidationTime(String createValidationTimeMs) {
+    Datastream ds = new Datastream();
+    StringMap metadata = new StringMap();
+    if (createValidationTimeMs != null) {
+      metadata.put(CREATE_VALIDATION_TIME_MS, createValidationTimeMs);
+    }
+    ds.setMetadata(metadata);
+    return ds;
+  }
+
+  @Test
+  public void testGetCreateValidationTimeMsPresent() {
+    // Present and positive -> included as-is
+    Assert.assertEquals(Coordinator.getCreateValidationTimeMs(datastreamWithValidationTime("1500")), 1500L);
+  }
+
+  @Test
+  public void testGetCreateValidationTimeMsAbsent() {
+    // Property not set -> excluded (0)
+    Assert.assertEquals(Coordinator.getCreateValidationTimeMs(datastreamWithValidationTime(null)), 0L);
+  }
+
+  @Test
+  public void testGetCreateValidationTimeMsNonPositive() {
+    // Zero or negative -> excluded (0)
+    Assert.assertEquals(Coordinator.getCreateValidationTimeMs(datastreamWithValidationTime("0")), 0L);
+    Assert.assertEquals(Coordinator.getCreateValidationTimeMs(datastreamWithValidationTime("-5")), 0L);
+  }
+
+  @Test
+  public void testGetCreateValidationTimeMsMalformed() {
+    // Not a valid long -> excluded (0)
+    Assert.assertEquals(Coordinator.getCreateValidationTimeMs(datastreamWithValidationTime("not-a-number")), 0L);
+  }
+}


### PR DESCRIPTION
## Summary

- `recordStreamProvisioningTime` now adds the create-validation time to the provisioning duration. The value comes from the datastream metadata property `system.createValidationTime.ms`. Provisioning time becomes `(now - system.creation.ms) + system.createValidationTime.ms`, so the `streamProvisioningTimeMs` histogram and the within/outside SLA counters reflect validation time plus creation time.
- Absent or malformed `system.createValidationTime.ms` is treated as 0, so streams created before the property existed keep computing `now - system.creation.ms` exactly as before.
- Raise the default provisioning SLA threshold (`brooklin.server.coordinator.provisioningSlaThresholdMs`) from 8 to 10 minutes.
- Add `CREATE_VALIDATION_TIME_MS` to `DatastreamMetadataConstants`.

## Testing Done

- Added `TestCoordinatorStandalone` covering `getCreateValidationTimeMs`: present-and-positive (included), absent, non-positive, and malformed (all excluded as 0).
- Added `testProvisioningSlaThresholdConfig` to `TestCoordinatorConfig`: default is 10 minutes and the config override is honored.
- `./gradlew :datastream-server:test` passes.

## Notes for Reviewers

The new unit tests live in a new `TestCoordinatorStandalone` class rather than the existing `TestCoordinator`, for following reasons:

- Module. The code under test (`Coordinator.getCreateValidationTimeMs`) is in `datastream-server`, but the existing `TestCoordinator` is in `datastream-server-restli`. A unit test belongs in the same module as the code so `./gradlew :datastream-server:test` covers it.
- Type. The existing `TestCoordinator` is an integration test that stands up an embedded cluster. This is a pure, cluster-free unit test and does not belong in that test suite.
- No existing home. `datastream-server` had no Coordinator unit-test class, and the name cannot be `TestCoordinator` because that fully-qualified name is already used by the restli test. `TestCoordinatorStandalone` is the general home for cluster-free Coordinator unit tests.
