### PR TITLE
Bump jacksonVersion 2.10.0 to 2.18.8 

### DIFF
--- a/gradle/dependency-versions.gradle
+++ b/gradle/dependency-versions.gradle
@@ -9,7 +9,7 @@ ext {
     checkstyleVersion = "10.12.7"
     guavaVersion = "25.0-jre"
     intellijAnnotationsVersion = "12.0"
-    jacksonVersion = "2.10.0"
+    jacksonVersion = "2.18.8"
     jsr305Version = "3.0.2"
     kafkaVersion = "2.4.1.66"
     log4j2Version = "2.20.0"


### PR DESCRIPTION
## Summary
* All three jackson-{annotations,core,databind} declarations in build.gradle already share this single $jacksonVersion property, so the bump propagates uniformly.
* No source changes needed: the offending Jackson APIs used by datastream-common's JsonUtils, AvroEncodingException, etc. are API-compatible between 2.10 and 2.18.

## Testing Done
PR checks