### PR TITLE
Checkstyle operator-wrap formatting: move binary operators to start of continuation line

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
@@ -122,8 +122,8 @@ public class ReflectionUtils {
 
   private static <S, T> boolean isCompatiblePrimitive(Class<S> type1, Class<T> type2) {
     for (Class<?>[] compatibleType : COMPATIBLE_TYPES) {
-      if ((type1.equals(compatibleType[0]) && type2.equals(compatibleType[1])) ||
-          (type1.equals(compatibleType[1]) && type2.equals(compatibleType[0]))) {
+      if ((type1.equals(compatibleType[0]) && type2.equals(compatibleType[1]))
+          || (type1.equals(compatibleType[1]) && type2.equals(compatibleType[0]))) {
         return true;
       }
     }
@@ -150,8 +150,8 @@ public class ReflectionUtils {
         if (paramTypes.length == argTypes.length) {
           boolean matched = true;
           for (int i = 0; i < paramTypes.length; i++) {
-            if (!paramTypes[i].isAssignableFrom(argTypes[i]) &&
-                !isCompatiblePrimitive(paramTypes[i], argTypes[i])) {
+            if (!paramTypes[i].isAssignableFrom(argTypes[i])
+                && !isCompatiblePrimitive(paramTypes[i], argTypes[i])) {
               matched = false;
               break;
             }

--- a/datastream-directory/src/main/java/com/linkedin/datastream/server/DirectoryTransportProvider.java
+++ b/datastream-directory/src/main/java/com/linkedin/datastream/server/DirectoryTransportProvider.java
@@ -69,9 +69,9 @@ public class DirectoryTransportProvider implements TransportProvider {
   }
 
   private static void copyPathToDir(Path sourcePath, Path destinationDir) {
-    ThrowingBinFunction<File, File> copyFn = Files.isDirectory(sourcePath) ?
-        FileUtils::copyDirectoryToDirectory :
-        FileUtils::copyFileToDirectory;
+    ThrowingBinFunction<File, File> copyFn = Files.isDirectory(sourcePath)
+        ? FileUtils::copyDirectoryToDirectory
+        : FileUtils::copyFileToDirectory;
 
     try {
       copyFn.apply(sourcePath.toFile(), destinationDir.toFile());

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaBasedConnectorTaskMetrics.java
@@ -125,12 +125,12 @@ public class KafkaBasedConnectorTaskMetrics extends CommonConnectorMetrics {
     AtomicLong numTopics = NUM_TOPICS_PER_METRIC_KEY.computeIfAbsent(_fullMetricsKey, k -> new AtomicLong(0));
     DYNAMIC_METRICS_MANAGER.registerGauge(_className, _key, NUM_TOPICS, numTopics::get);
 
-    _pollDurationMsMetric = enableAdditionalMetrics ?
-        DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, POLL_DURATION_MS, Histogram.class) : null;
-    _timeSpentBetweenPollsMsMetric = enableAdditionalMetrics ?
-        DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, TIME_SPENT_BETWEEN_POLLS_MS, Histogram.class) : null;
-    _perEventProcessingTimeNanosMetric = enableAdditionalMetrics ?
-        DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, PER_EVENT_PROCESSING_TIME_NANOS, Histogram.class) : null;
+    _pollDurationMsMetric = enableAdditionalMetrics
+        ? DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, POLL_DURATION_MS, Histogram.class) : null;
+    _timeSpentBetweenPollsMsMetric = enableAdditionalMetrics
+        ? DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, TIME_SPENT_BETWEEN_POLLS_MS, Histogram.class) : null;
+    _perEventProcessingTimeNanosMetric = enableAdditionalMetrics
+        ? DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, PER_EVENT_PROCESSING_TIME_NANOS, Histogram.class) : null;
 
     AtomicLong aggNumConfigPausedPartitions =
         AGGREGATED_NUM_CONFIG_PAUSED_PARTITIONS.computeIfAbsent(className, k -> new AtomicLong(0));

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnectorTask.java
@@ -179,8 +179,8 @@ public class KafkaMirrorMakerConnectorTask extends AbstractKafkaBasedConnectorTa
     VerifiableProperties connectorProperties = config.getConnectorProps();
     Properties topicManagerProperties = new Properties();
     String topicManagerFactoryName = DEFAULT_TOPIC_MANAGER_FACTORY;
-    if (null != connectorProperties &&
-        null != connectorProperties.getProperty(TOPIC_MANAGER_FACTORY)) {
+    if (null != connectorProperties
+        && null != connectorProperties.getProperty(TOPIC_MANAGER_FACTORY)) {
       topicManagerProperties = connectorProperties.getDomainProperties(DOMAIN_TOPIC_MANAGER);
       topicManagerFactoryName = connectorProperties.getProperty(TOPIC_MANAGER_FACTORY);
       // Propagate the destinationTopicPrefix config to the topic manager so that it can create destination topics

--- a/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
+++ b/datastream-server-api/src/main/java/com/linkedin/datastream/server/DatastreamProducerRecord.java
@@ -164,8 +164,8 @@ public class DatastreamProducerRecord {
     }
     DatastreamProducerRecord record = (DatastreamProducerRecord) o;
     return Objects.equals(_partition, record._partition) && Objects.equals(_partitionKey, record._partitionKey)
-        && Objects.equals(_events, record._events) && Objects.equals(_checkpoint, record._checkpoint) &&
-        Objects.equals(_destination, record._destination);
+        && Objects.equals(_events, record._events) && Objects.equals(_checkpoint, record._checkpoint)
+        && Objects.equals(_destination, record._destination);
   }
 
   @Override

--- a/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
+++ b/datastream-server-restli/src/main/java/com/linkedin/datastream/server/dms/DatastreamResources.java
@@ -240,8 +240,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
                   + " old: %s new: %s", key, oldDatastream, datastream));
         }
 
-        if (datastream.getMetadata().containsKey(NUM_TASKS) &&
-            !datastream.getMetadata().get(NUM_TASKS).equals(oldDatastream.getMetadata().get(NUM_TASKS))) {
+        if (datastream.getMetadata().containsKey(NUM_TASKS)
+            && !datastream.getMetadata().get(NUM_TASKS).equals(oldDatastream.getMetadata().get(NUM_TASKS))) {
           throw new DatastreamValidationException(String.format("Failed to update %s. Can't update numTasks."
               + " old: %s new: %s", key, oldDatastream, datastream));
         }
@@ -560,8 +560,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
           "Datastream to resume does not exist: " + datastreamName);
     }
 
-    if (!DatastreamStatus.PAUSED.equals(datastream.getStatus()) &&
-        !DatastreamStatus.STOPPED.equals(datastream.getStatus())) {
+    if (!DatastreamStatus.PAUSED.equals(datastream.getStatus())
+        && !DatastreamStatus.STOPPED.equals(datastream.getStatus())) {
       _errorLogger.logAndThrowRestLiServiceException(HttpStatus.S_405_METHOD_NOT_ALLOWED,
           "Datastream is not paused or stopped, cannot resume: " + datastreamName);
     }
@@ -571,8 +571,8 @@ public class DatastreamResources extends CollectionResourceTemplate<String, Data
     LOG.info("Resuming datastreams {}", datastreamsToResume);
     for (Datastream d : datastreamsToResume) {
       try {
-        if (DatastreamStatus.PAUSED.equals(datastream.getStatus()) ||
-            DatastreamStatus.STOPPED.equals(datastream.getStatus())) {
+        if (DatastreamStatus.PAUSED.equals(datastream.getStatus())
+            || DatastreamStatus.STOPPED.equals(datastream.getStatus())) {
           d.setStatus(DatastreamStatus.READY);
           _store.updateDatastream(d.getName(), d, true);
           // invoke post datastream state change action for recently resumed datastream

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -801,8 +801,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
 
     if (queueEvent) {
       _log.warn("Queuing onAssignmentChange event");
-      CoordinatorEvent event = isDatastreamUpdate ? CoordinatorEvent.createHandleDatastreamChangeEvent() :
-          CoordinatorEvent.createHandleAssignmentChangeEvent();
+      CoordinatorEvent event = isDatastreamUpdate ? CoordinatorEvent.createHandleDatastreamChangeEvent()
+          : CoordinatorEvent.createHandleAssignmentChangeEvent();
       queueHandleAssignmentOrDatastreamChangeEvent(event, false);
     }
   }
@@ -1098,8 +1098,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         if (retryAndSaveError) {
           err += " Queuing up a new onAssignmentChange event for retry.";
           _eventQueue.put(CoordinatorEvent.createHandleInstanceErrorEvent(ExceptionUtils.getRootCauseMessage(ex)));
-          CoordinatorEvent event = isDatastreamUpdate ? CoordinatorEvent.createHandleDatastreamChangeEvent() :
-              CoordinatorEvent.createHandleAssignmentChangeEvent();
+          CoordinatorEvent event = isDatastreamUpdate ? CoordinatorEvent.createHandleDatastreamChangeEvent()
+              : CoordinatorEvent.createHandleAssignmentChangeEvent();
           queueHandleAssignmentOrDatastreamChangeEvent(event, false);
         }
         _log.warn(err, ex);
@@ -1151,8 +1151,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     boolean customCheckpointing = _connectors.get(task.getConnectorType()).isCustomCheckpointing();
 
     Datastream datastream = task.getDatastreams().get(0);
-    if (datastream.hasMetadata() &&
-        Objects.requireNonNull(datastream.getMetadata()).containsKey(DatastreamMetadataConstants.CUSTOM_CHECKPOINT)) {
+    if (datastream.hasMetadata()
+        && Objects.requireNonNull(datastream.getMetadata()).containsKey(DatastreamMetadataConstants.CUSTOM_CHECKPOINT)) {
       customCheckpointing = Boolean.parseBoolean(
           datastream.getMetadata().get(DatastreamMetadataConstants.CUSTOM_CHECKPOINT));
       _log.info(String.format("Custom checkpointing overridden by metadata to be: %b for datastream: %s",
@@ -1638,8 +1638,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
         Thread.currentThread().getName(), streamNames);
     // Poll the zookeeper to ensure that hosts claimed assignment tokens for stopping streams
     Set<String> failedStreams = Collections.emptySet();
-    if (_config.getEnableAssignmentTokens() &&
-        !PollUtils.poll(() -> _adapter.getNumUnclaimedTokensForDatastreams(stoppingDatastreamGroups) == 0,
+    if (_config.getEnableAssignmentTokens()
+        && !PollUtils.poll(() -> _adapter.getNumUnclaimedTokensForDatastreams(stoppingDatastreamGroups) == 0,
             STOP_PROPAGATION_RETRY_MS, _config.getStopPropagationTimeoutMs())) {
       Map<String, List<AssignmentToken>> unclaimedTokens =
           _adapter.getUnclaimedAssignmentTokensForDatastreams(stoppingDatastreamGroups);
@@ -1654,8 +1654,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
             _config.getStopPropagationTimeoutMs(), failedStreams, hosts);
         _metrics.updateMeter(CoordinatorMetrics.Meter.NUM_FAILED_STOPS, failedStreams.size());
       } else if (!failedStreams.isEmpty()) {
-        _log.warn("Stop may have failed to propagate within {}ms for streams: {}. The newly elected leader was " +
-                "expecting the hosts {} to claim tokens but they didn't",
+        _log.warn("Stop may have failed to propagate within {}ms for streams: {}. The newly elected leader was "
+                + "expecting the hosts {} to claim tokens but they didn't",
             _config.getStopPropagationTimeoutMs(), failedStreams, hosts);
       }
       revokeUnclaimedAssignmentTokens(unclaimedTokens, stoppingDatastreamGroups);
@@ -1778,8 +1778,8 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
           DatastreamGroupPartitionsMetadata subscribes = connectorInstance.getDatastreamPartitions()
               .get(toProcessDatastream.getName())
               .orElseThrow(() ->
-                  new DatastreamTransientException("Subscribed partition is not ready yet for datastream " +
-                      toProcessDatastream.getName()));
+                  new DatastreamTransientException("Subscribed partition is not ready yet for datastream "
+                      + toProcessDatastream.getName()));
 
           assignmentByInstance = strategy.assignPartitions(assignmentByInstance, subscribes);
         } else {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamTaskImpl.java
@@ -183,8 +183,8 @@ public class DatastreamTaskImpl implements DatastreamTask {
     _dependencies = new ArrayList<>();
     if (!predecessor._partitionsV2.isEmpty()) {
       if (!predecessor.isLocked()) {
-        throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, " +
-            "the previous assignment has not been picked up");
+        throw new DatastreamTransientException("task " + predecessor.getDatastreamTaskName() + " is not locked, "
+            + "the previous assignment has not been picked up");
       }
       _dependencies.add(predecessor.getDatastreamTaskName());
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/BroadcastStrategy.java
@@ -123,9 +123,9 @@ public class BroadcastStrategy implements AssignmentStrategy {
   }
 
   private DatastreamTask getOrCreateDatastreamTask(List<DatastreamTask> reuseTasksPerDg, DatastreamGroup dg) {
-    return (!reuseTasksPerDg.isEmpty()) ?
-        reuseTasksPerDg.remove(reuseTasksPerDg.size() - 1) :
-        new DatastreamTaskImpl(dg.getDatastreams());
+    return (!reuseTasksPerDg.isEmpty())
+        ? reuseTasksPerDg.remove(reuseTasksPerDg.size() - 1)
+        : new DatastreamTaskImpl(dg.getDatastreams());
   }
 
   private int getNumTasks(DatastreamGroup dg, int numInstances) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
@@ -246,8 +246,8 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
       int maxPartitionsPerTask) {
     // conversion to long to avoid integer overflow
     if (numTasks * (long) maxPartitionsPerTask < numPartitions) {
-      String message = String.format("Not enough tasks to fit partitions. Datastream: %s, Number of tasks: %d, " +
-          "number of partitions: %d, max partitions per task: %d", datastream, numTasks, numPartitions,
+      String message = String.format("Not enough tasks to fit partitions. Datastream: %s, Number of tasks: %d, "
+          + "number of partitions: %d, max partitions per task: %d", datastream, numTasks, numPartitions,
           maxPartitionsPerTask);
       throw new DatastreamRuntimeException(message);
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -86,8 +86,8 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     LOG.info("Task capacity : {}MBps, task capacity utilization : {}%, Throughput info fetch timeout : {} ms, "
         + "throughput info fetch retry period : {} ms, throughput based partition assignment : {}, "
         + "partition num based task count estimation : {}", _taskCapacityMBps, _taskCapacityUtilizationPct,
-        _throughputInfoFetchTimeoutMs, _throughputInfoFetchRetryPeriodMs, _enableThroughputBasedPartitionAssignment ?
-            "enabled" : "disabled", _enablePartitionNumBasedTaskCountEstimation ? "enabled" : "disabled");
+        _throughputInfoFetchTimeoutMs, _throughputInfoFetchRetryPeriodMs, _enableThroughputBasedPartitionAssignment
+            ? "enabled" : "disabled", _enablePartitionNumBasedTaskCountEstimation ? "enabled" : "disabled");
     _assigner = new LoadBasedPartitionAssigner(defaultPartitionBytesInKBRate, defaultPartitionMsgsInRate);
   }
 

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedTaskCountEstimator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedTaskCountEstimator.java
@@ -83,8 +83,8 @@ public class LoadBasedTaskCountEstimator {
         assignedPartitions.size(), unassignedPartitions.size());
 
     double taskCapacityUtilizationCoefficient = _taskCapacityUtilizationPct / 100.0;
-    int taskCountEstimate = (int) Math.ceil((double) totalThroughput /
-        (_taskCapacityMBps * 1024 * taskCapacityUtilizationCoefficient));
+    int taskCountEstimate = (int) Math.ceil((double) totalThroughput
+        / (_taskCapacityMBps * 1024 * taskCapacityUtilizationCoefficient));
     taskCountEstimate = Math.min(allPartitions.size(), taskCountEstimate);
     LOG.info("Estimated number of tasks for datastream {} required to handle the throughput: {}", datastreamName, taskCountEstimate);
     return taskCountEstimate;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyMulticastStrategy.java
@@ -185,8 +185,8 @@ public class StickyMulticastStrategy implements AssignmentStrategy {
       while (pendingTasks > 0) {
         // round-robin to the instances
         for (String instance : instancesBySize) {
-          DatastreamTask task = unallocatedTasks.size() > 0 ? unallocatedTasks.remove(unallocatedTasks.size() - 1) :
-              new DatastreamTaskImpl(dg.getDatastreams());
+          DatastreamTask task = unallocatedTasks.size() > 0 ? unallocatedTasks.remove(unallocatedTasks.size() - 1)
+              : new DatastreamTaskImpl(dg.getDatastreams());
           newAssignment.get(instance).add(task);
           pendingTasks--;
           if (pendingTasks == 0) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -544,8 +544,8 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
   @Override
   protected int constructExpectedNumberOfTasks(DatastreamGroup dg, int totalInstances) {
     boolean enableElasticTaskAssignment = isElasticTaskAssignmentEnabled(dg);
-    int numTasks = enableElasticTaskAssignment ? getNumTasksFromCacheOrZK(dg.getTaskPrefix()) :
-        getNumTasks(dg, totalInstances);
+    int numTasks = enableElasticTaskAssignment ? getNumTasksFromCacheOrZK(dg.getTaskPrefix())
+        : getNumTasks(dg, totalInstances);
 
     // Case 1: If elastic task assignment is disabled set the expected number of tasks to numTasks.
     int expectedNumberOfTasks = numTasks;
@@ -618,8 +618,8 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
     LOG.info("Calculating number of tasks needed based on partitions per task: calculated->{}:config->{}, "
             + "fullness percentage: calculated->{}:config->{}", partitionsPerTask, _partitionsPerTask,
         partitionFullnessFactorPct, _partitionFullnessFactorPct);
-    int allowedPartitionsPerTask = (partitionsPerTask * partitionFullnessFactorPct) >= 100 ?
-        (partitionsPerTask * partitionFullnessFactorPct) / 100 : 1;
+    int allowedPartitionsPerTask = (partitionsPerTask * partitionFullnessFactorPct) >= 100
+        ? (partitionsPerTask * partitionFullnessFactorPct) / 100 : 1;
     int totalPartitions = datastreamPartitions.getPartitions().size();
     int numTasksNeeded = (totalPartitions / allowedPartitionsPerTask)
         + (((totalPartitions % allowedPartitionsPerTask) == 0) ? 0 : 1);

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/EmbeddedZookeeper.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/EmbeddedZookeeper.java
@@ -104,10 +104,10 @@ public class EmbeddedZookeeper {
     } catch (InterruptedException e) {
       throw new IOException(e);
     }
-    LOG.info("Zookeeper started with ..." +
-        "\n  Port: " + this._port +
-        "\n  Snapshot Dir Path: " + this._snapshotDirPath +
-        "\n  Log Dir Path: " + this._logDirPath);
+    LOG.info("Zookeeper started with ..."
+        + "\n  Port: " + this._port
+        + "\n  Snapshot Dir Path: " + this._snapshotDirPath
+        + "\n  Log Dir Path: " + this._logDirPath);
   }
 
   /**


### PR DESCRIPTION
## Summary
No behavior changes in any file. This PR contains formatting-only fixes for OperatorWrap violations reported by LinkedIn's internal Checkstyle configuration (a stricter superset of the OSS configuration). The rule is not currently enabled in OSS Brooklin's checkstyle.xml, so this PR resolves the latent violations without proposing a configuration change.

The updates only adjust whitespace, line breaks, and operator placement. Specifically, binary operators are moved to the beginning of continuation lines, as required by the rule, improving readability while producing identical bytecode.

## Testing Done
No change in logic, PR checks only