### PR TITLE
Checkstyle class-design cleanup: add private utility ctors, mark final, drop redundant modifiers, add missing @Override

### DIFF
--- a/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/BaseRestClientFactory.java
@@ -152,7 +152,7 @@ public final class BaseRestClientFactory<T> {
    * shutdown, hence it is okay for us to make the threads daemon.
    */
   private class DaemonNamedThreadFactory extends NamedThreadFactory {
-    public DaemonNamedThreadFactory(String name) {
+    DaemonNamedThreadFactory(String name) {
       super(name + " " + StringUtils.substringAfterLast(_logger.getName(), "."));
     }
 

--- a/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/datastream/DatastreamRestClientFactory.java
@@ -23,6 +23,10 @@ import com.linkedin.restli.client.RestClient;
  * DatastreamRestClient, without doing a major refactoring of the code.
  */
 public final class DatastreamRestClientFactory {
+
+  private DatastreamRestClientFactory() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamRestClientFactory.class);
   private static final BaseRestClientFactory<DatastreamRestClient> FACTORY =
       new BaseRestClientFactory<>(DatastreamRestClient.class, LOG);

--- a/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
+++ b/datastream-client/src/main/java/com/linkedin/diagnostics/ServerComponentHealthRestClientFactory.java
@@ -21,6 +21,10 @@ import com.linkedin.restli.client.RestClient;
  * Factory class for obtaining {@link ServerComponentHealthRestClient} objects.
  */
 public final class ServerComponentHealthRestClientFactory {
+
+  private ServerComponentHealthRestClientFactory() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(DatastreamRestClientFactory.class);
   private static final BaseRestClientFactory<ServerComponentHealthRestClient> FACTORY =
       new BaseRestClientFactory<>(ServerComponentHealthRestClient.class, LOG);

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/AvroMessageEncoderUtil.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/AvroMessageEncoderUtil.java
@@ -25,7 +25,7 @@ import org.apache.commons.lang.Validate;
 /**
  * Utility class to simplify Avro message encoding
  */
-public class AvroMessageEncoderUtil {
+public final class AvroMessageEncoderUtil {
 
   private AvroMessageEncoderUtil() {
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/AvroMessageEncoderUtil.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/AvroMessageEncoderUtil.java
@@ -26,6 +26,10 @@ import org.apache.commons.lang.Validate;
  * Utility class to simplify Avro message encoding
  */
 public class AvroMessageEncoderUtil {
+
+  private AvroMessageEncoderUtil() {
+  }
+
   public static final byte MAGIC_BYTE = 0x0;
 
   /**

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
@@ -10,6 +10,9 @@ package com.linkedin.datastream.common;
  */
 public class BrooklinEnvelopeMetadataConstants {
 
+  private BrooklinEnvelopeMetadataConstants() {
+  }
+
   /**
    * Codes to identify the different data change operations
    */

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/BrooklinEnvelopeMetadataConstants.java
@@ -8,7 +8,7 @@ package com.linkedin.datastream.common;
 /**
  * Constants used in the metadata field of {@link BrooklinEnvelope}
  */
-public class BrooklinEnvelopeMetadataConstants {
+public final class BrooklinEnvelopeMetadataConstants {
 
   private BrooklinEnvelopeMetadataConstants() {
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -8,7 +8,7 @@ package com.linkedin.datastream.common;
 /**
  * Various well known config keys used in datastream metadata.
  */
-public class DatastreamMetadataConstants {
+public final class DatastreamMetadataConstants {
 
   private DatastreamMetadataConstants() {
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/DatastreamMetadataConstants.java
@@ -10,6 +10,9 @@ package com.linkedin.datastream.common;
  */
 public class DatastreamMetadataConstants {
 
+  private DatastreamMetadataConstants() {
+  }
+
   /**
    * Represents whether the datastream has an User managed destination (a.k.a BYOT - Bring your own topic)
    */

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/JsonUtils.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/JsonUtils.java
@@ -32,6 +32,10 @@ import com.fasterxml.jackson.databind.SerializerProvider;
  * for checking the
  */
 public final class JsonUtils {
+
+  private JsonUtils() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class.getName());
 
   private static final ObjectMapper MAPPER = new ObjectMapper();

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
@@ -19,6 +19,10 @@ import org.slf4j.LoggerFactory;
  * Utility class to simplify usage of Java reflection.
  */
 public class ReflectionUtils {
+
+  private ReflectionUtils() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(ReflectionUtils.class);
 
   private static final Class<?>[][] COMPATIBLE_TYPES = {

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/ReflectionUtils.java
@@ -18,7 +18,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Utility class to simplify usage of Java reflection.
  */
-public class ReflectionUtils {
+public final class ReflectionUtils {
 
   private ReflectionUtils() {
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/common/databases/dbreader/DatabaseChunkedReaderMetrics.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/databases/dbreader/DatabaseChunkedReaderMetrics.java
@@ -52,7 +52,7 @@ class DatabaseChunkedReaderMetrics extends BrooklinMetrics {
    * @param source Aggregate metrics for source .i.e. at the Database table level
    * @param key Metrics at the reader level, identified by key
    */
-  public DatabaseChunkedReaderMetrics(String source, String key) {
+  DatabaseChunkedReaderMetrics(String source, String key) {
     super(CLASS_NAME, key);
     _source = source;
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/connectors/CommonConnectorMetrics.java
@@ -68,7 +68,7 @@ public class CommonConnectorMetrics {
     final Meter _aggregatedErrorRate;
     final Meter _aggregatedProcessingAboveThreshold;
 
-    public EventProcMetrics(String className, String key) {
+    EventProcMetrics(String className, String key) {
       super(className, key);
       _lastEventReceivedTime = Instant.now();
       _eventsProcessedRate = DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, EVENTS_PROCESSED_RATE,
@@ -139,7 +139,7 @@ public class CommonConnectorMetrics {
     final Counter _aggregatedClientPollOverTimeout;
     final Counter _aggregatedClientPollIntervalOverSessionTimeout;
 
-    public PollMetrics(String className, String key) {
+    PollMetrics(String className, String key) {
       super(className, key);
       _numPolls = DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, NUM_POLLS, Meter.class);
       _eventCountsPerPoll = DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, EVENT_COUNTS_PER_POLL,
@@ -203,7 +203,7 @@ public class CommonConnectorMetrics {
     private final AtomicLong _numPartitions;
     private final AtomicLong _numStuckPartitions;
 
-    public PartitionMetrics(String className, String key) {
+    PartitionMetrics(String className, String key) {
       super(className, key);
       _fullMetricsKey = MetricRegistry.name(_className, _key);
       _rebalanceRate = DYNAMIC_METRICS_MANAGER.registerMetric(_className, _key, REBALANCE_RATE, Meter.class);

--- a/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaDatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaDatastreamMetadataConstants.java
@@ -10,6 +10,9 @@ package com.linkedin.datastream.kafka;
  */
 public class KafkaDatastreamMetadataConstants {
 
+  private KafkaDatastreamMetadataConstants() {
+  }
+
   // Can be used by the transport provider to send to a particular Kafka cluster
   public static final String DESTINATION_KAFKA_BROKERS = "system.destination.KafkaBrokers";
 

--- a/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaDatastreamMetadataConstants.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/kafka/KafkaDatastreamMetadataConstants.java
@@ -8,7 +8,7 @@ package com.linkedin.datastream.kafka;
 /**
  * Metadata constants that are specific to Kafka (or Kafka MirrorMaker) datastreams.
  */
-public class KafkaDatastreamMetadataConstants {
+public final class KafkaDatastreamMetadataConstants {
 
   private KafkaDatastreamMetadataConstants() {
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/DynamicMetricsManager.java
@@ -28,7 +28,7 @@ import com.codahale.metrics.Timer;
 /**
  * Manages dynamic metrics and supports creating/updating metrics on the fly.
  */
-public class DynamicMetricsManager {
+public final class DynamicMetricsManager {
   static final String NO_KEY_PLACEHOLDER = "NO_KEY";
   private static final Logger LOG = LoggerFactory.getLogger(DynamicMetricsManager.class);
   private static DynamicMetricsManager _instance = null;

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/JmxReporterFactory.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/JmxReporterFactory.java
@@ -22,6 +22,10 @@ import com.codahale.metrics.jmx.ObjectNameFactory;
  * names are decided according to {@link BrooklinObjectNameFactory}.
  */
 public class JmxReporterFactory {
+
+  private JmxReporterFactory() {
+  }
+
   private static final ObjectNameFactory OBJECT_NAME_FACTORY = new BrooklinObjectNameFactory();
 
   /**

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/JmxReporterFactory.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/JmxReporterFactory.java
@@ -21,7 +21,7 @@ import com.codahale.metrics.jmx.ObjectNameFactory;
  * A factory for {@link JmxReporter} objects that generates metrics whose
  * names are decided according to {@link BrooklinObjectNameFactory}.
  */
-public class JmxReporterFactory {
+public final class JmxReporterFactory {
 
   private JmxReporterFactory() {
   }

--- a/datastream-common/src/main/java/com/linkedin/datastream/metrics/ResettableGauge.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/metrics/ResettableGauge.java
@@ -18,10 +18,10 @@ import com.codahale.metrics.Gauge;
 class ResettableGauge<T> implements Gauge<T> {
   private Supplier<T> _supplier;
 
-  public ResettableGauge() {
+  ResettableGauge() {
   }
 
-  public ResettableGauge(Supplier<T> supplier) {
+  ResettableGauge(Supplier<T> supplier) {
     _supplier = supplier;
   }
 

--- a/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
+++ b/datastream-file-connector/src/main/java/com/linkedin/datastream/connectors/file/FileProcessor.java
@@ -50,7 +50,7 @@ class FileProcessor implements Runnable {
   private boolean _cancelRequested;
   private boolean _isStopped;
 
-  public FileProcessor(DatastreamTask datastreamTask, DatastreamEventProducer producer) throws FileNotFoundException {
+  FileProcessor(DatastreamTask datastreamTask, DatastreamEventProducer producer) throws FileNotFoundException {
     _task = datastreamTask;
     _fileName = datastreamTask.getDatastreamSource().getConnectionString();
     _positionKey = new FilePositionKey(_task.getTaskPrefix(), _task.getDatastreamTaskName(), Instant.now(), _fileName);

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/AbstractKafkaConnector.java
@@ -789,6 +789,7 @@ public abstract class AbstractKafkaConnector implements Connector, DiagnosticsAw
   /**
    * {@inheritDoc}
    */
+  @Override
   public List<String> getActiveTasks() {
     List<DatastreamTask> tasks = new ArrayList<>();
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorDiagUtils.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorDiagUtils.java
@@ -22,7 +22,7 @@ import com.linkedin.datastream.common.JsonUtils;
 /**
  * Utility class for Kafka based connectors
  */
-public class KafkaConnectorDiagUtils {
+public final class KafkaConnectorDiagUtils {
 
   private KafkaConnectorDiagUtils() {
   }

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorDiagUtils.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/KafkaConnectorDiagUtils.java
@@ -23,6 +23,10 @@ import com.linkedin.datastream.common.JsonUtils;
  * Utility class for Kafka based connectors
  */
 public class KafkaConnectorDiagUtils {
+
+  private KafkaConnectorDiagUtils() {
+  }
+
   /**
    * Reduce/Merge the KafkaTopicPartitionStatsResponse responses of a collection of host/instance into one response
    */

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerConnector.java
@@ -268,7 +268,7 @@ public class KafkaMirrorMakerConnector extends AbstractKafkaConnector {
    *  PartitionDiscoveryThread listens to Kafka partitions periodically using the _consumer.listTopic()
    *  to fetch the latest subscribed partitions for a given datastreamGroup
    */
-  class PartitionDiscoveryThread extends Thread {
+  final class PartitionDiscoveryThread extends Thread {
     // The datastream group that this partitionDiscoveryThread is responsible to handle
     private final DatastreamGroup _datastreamGroup;
 

--- a/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerDatastreamMetadata.java
+++ b/datastream-kafka-connector/src/main/java/com/linkedin/datastream/connectors/kafka/mirrormaker/KafkaMirrorMakerDatastreamMetadata.java
@@ -15,6 +15,9 @@ import com.linkedin.datastream.common.Datastream;
  */
 public final class KafkaMirrorMakerDatastreamMetadata {
 
+  private KafkaMirrorMakerDatastreamMetadata() {
+  }
+
   public static final String IDENTITY_PARTITIONING_ENABLED = "system.destination.identityPartitioningEnabled";
 
   /**

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderUtils.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderUtils.java
@@ -17,7 +17,7 @@ import com.linkedin.datastream.common.Datastream;
 /**
  * Utility methods for {@link KafkaTransportProvider}
  */
-public class KafkaTransportProviderUtils {
+public final class KafkaTransportProviderUtils {
 
   private KafkaTransportProviderUtils() {
   }

--- a/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderUtils.java
+++ b/datastream-kafka/src/main/java/com/linkedin/datastream/kafka/KafkaTransportProviderUtils.java
@@ -18,6 +18,10 @@ import com.linkedin.datastream.common.Datastream;
  * Utility methods for {@link KafkaTransportProvider}
  */
 public class KafkaTransportProviderUtils {
+
+  private KafkaTransportProviderUtils() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(KafkaTransportProviderUtils.class.getName());
   // Mapping destination URI to topic name
   private final static Map<String, String> URI_TOPICS = new ConcurrentHashMap<>();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -2482,7 +2482,7 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     private final List<BrooklinMetricInfo> _metricInfos;
     private final DynamicMetricsManager _dynamicMetricsManager;
 
-    public CoordinatorMetrics(Coordinator coordinator) {
+    CoordinatorMetrics(Coordinator coordinator) {
       _coordinator = coordinator;
       _metricInfos = new ArrayList<>();
       _dynamicMetricsManager = DynamicMetricsManager.getInstance();

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServerConfigurationConstants.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/DatastreamServerConfigurationConstants.java
@@ -10,6 +10,9 @@ package com.linkedin.datastream.server;
  */
 public final class DatastreamServerConfigurationConstants {
 
+  private DatastreamServerConfigurationConstants() {
+  }
+
   public static final String CONFIG_PREFIX = "brooklin.server.";
   public static final String CONFIG_CONNECTOR_NAMES = CONFIG_PREFIX + "connectorNames";
   public static final String CONFIG_HTTP_PORT = CONFIG_PREFIX + "httpPort";

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/StickyPartitionAssignmentStrategy.java
@@ -778,7 +778,7 @@ public class StickyPartitionAssignmentStrategy extends StickyMulticastStrategy i
     private final int _actualPartitionsPerTask;
     private final boolean _needsAdjustment;
 
-    public ElasticTaskAssignmentInfo(int actualPartitionsPerTask, boolean needsAdjustment) {
+    ElasticTaskAssignmentInfo(int actualPartitionsPerTask, boolean needsAdjustment) {
       _actualPartitionsPerTask = actualPartitionsPerTask;
       _needsAdjustment = needsAdjustment;
     }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -1699,7 +1699,7 @@ public class ZkAdapter {
     /**
      * Sets up a watch on the {@code /{cluster}/dms} tree, so it can be notified of future changes.
      */
-    public ZkBackedDMSDatastreamList() {
+    ZkBackedDMSDatastreamList() {
       _path = KeyBuilder.datastreams(_cluster);
       _zkclient.ensurePath(KeyBuilder.datastreams(_cluster));
       LOG.info("ZkBackedDMSDatastreamList::Subscribing to the changes under the path " + _path);
@@ -1768,7 +1768,7 @@ public class ZkAdapter {
      * Sets up a watch on the {@code /{cluster}/liveinstances} tree, so it can be notified
      * of future changes.
      */
-    public ZkBackedLiveInstanceListProvider() {
+    ZkBackedLiveInstanceListProvider() {
       _path = KeyBuilder.liveInstances(_cluster);
       _zkclient.ensurePath(_path);
       LOG.info("ZkBackedLiveInstanceListProvider::Subscribing to the under the path " + _path);
@@ -1850,7 +1850,7 @@ public class ZkAdapter {
      * Constructor
      * @param instanceName Instance for which the datastream task assignment is to be watched.
      */
-    public ZkBackedTaskListProvider(String cluster, String instanceName) {
+    ZkBackedTaskListProvider(String cluster, String instanceName) {
       _path = KeyBuilder.instanceAssignments(cluster, instanceName);
       LOG.info("ZkBackedTaskListProvider::Subscribing to the changes under the path " + _path);
       _zkclient.subscribeChildChanges(_path, this);
@@ -1901,7 +1901,7 @@ public class ZkAdapter {
     /**
      * Constructor
      */
-    public ZkTargetAssignmentProvider(Set<String> connectorTypes) {
+    ZkTargetAssignmentProvider(Set<String> connectorTypes) {
       for (String connectorType : connectorTypes) {
         String path = KeyBuilder.getTargetAssignmentBase(_cluster, connectorType);
         _zkclient.subscribeDataChanges(path, this);
@@ -1956,7 +1956,7 @@ public class ZkAdapter {
         new ThreadFactoryBuilder().setDaemon(true).setNameFormat("SessionExpiryScheduler-%d").build());
     private Future<?> _zkSessionExpiryFuture = CompletableFuture.completedFuture("completed");
 
-    public ZkStateChangeListener() {
+    ZkStateChangeListener() {
       _zkclient.subscribeStateChanges(this);
     }
 

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/server/EmbeddedDatastreamCluster.java
@@ -28,7 +28,7 @@ import com.linkedin.datastream.testutil.EmbeddedZookeeper;
 /**
  * Provides a Datastream cluster, including a ZooKeeper cluster and Kafka cluster (if necessary), for testing purposes.
  */
-public class EmbeddedDatastreamCluster {
+public final class EmbeddedDatastreamCluster {
 
   public static final String CONFIG_ZK_CONNECT = "zookeeper.connect";
   public static final String BOOTSTRAP_SERVERS_CONFIG = "bootstrap.servers";

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -27,7 +27,7 @@ import com.linkedin.datastream.server.zk.KeyBuilder;
 /**
  * Utility class for writing tests that deal with Datastream objects.
  */
-public class DatastreamTestUtils {
+public final class DatastreamTestUtils {
 
   private DatastreamTestUtils() {
   }

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/DatastreamTestUtils.java
@@ -28,6 +28,10 @@ import com.linkedin.datastream.server.zk.KeyBuilder;
  * Utility class for writing tests that deal with Datastream objects.
  */
 public class DatastreamTestUtils {
+
+  private DatastreamTestUtils() {
+  }
+
   /**
    * Creates variable number of Datastreams from a list of names with
    * fields populated with default values except for name and connector type.

--- a/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
+++ b/datastream-testcommon/src/main/java/com/linkedin/datastream/testutil/MetricsTestUtils.java
@@ -35,7 +35,7 @@ import com.linkedin.datastream.metrics.MetricsAware;
  * Test utilities for verifying metrics
  * @see MetricsAware
  */
-public class MetricsTestUtils {
+public final class MetricsTestUtils {
   // Mapping of BrooklinMetricInfo sub-types -> com.codahale.metrics types
   private static final Map<Class<? extends BrooklinMetricInfo>, Class<? extends Metric>> METRICS_TYPE_MAPPING = ImmutableMap.of(
       BrooklinCounterInfo.class, Counter.class,

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/DatastreamRestClientCli.java
@@ -35,7 +35,7 @@ import com.linkedin.datastream.common.JsonUtils;
 /**
  * The main class containing the entry point of the Datastream REST client command line utility
  */
-public class DatastreamRestClientCli {
+public final class DatastreamRestClientCli {
 
   private DatastreamRestClientCli() {
   }

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
@@ -8,7 +8,7 @@ package com.linkedin.datastream.tools;
 /**
  * String constants for options used with {@link DatastreamRestClientCli}
  */
-public class OptionConstants {
+public final class OptionConstants {
 
   private OptionConstants() {
   }

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionConstants.java
@@ -10,6 +10,9 @@ package com.linkedin.datastream.tools;
  */
 public class OptionConstants {
 
+  private OptionConstants() {
+  }
+
   public static final String OPT_SHORT_MGMT_URI = "u";
   public static final String OPT_LONG_MGMT_URI = "uri";
   public static final String OPT_ARG_MGMT_URI = "MANAGEMENT_URI";

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionUtils.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionUtils.java
@@ -11,7 +11,7 @@ import org.apache.commons.lang3.StringUtils;
 /**
  * Utility class for creating command line {@link Option}s
  */
-public class OptionUtils {
+public final class OptionUtils {
 
   private OptionUtils() {
   }

--- a/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionUtils.java
+++ b/datastream-tools/src/main/java/com/linkedin/datastream/tools/OptionUtils.java
@@ -13,6 +13,9 @@ import org.apache.commons.lang3.StringUtils;
  */
 public class OptionUtils {
 
+  private OptionUtils() {
+  }
+
   /**
    * Create a command line option
    * @param shortOpt short representation of the option

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/AvroUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/AvroUtils.java
@@ -31,7 +31,7 @@ import org.apache.avro.specific.SpecificRecord;
 /**
  * Utility methods for encoding/decoding data into/from Avro.
  */
-public class AvroUtils {
+public final class AvroUtils {
 
   private AvroUtils() {
   }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/AvroUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/AvroUtils.java
@@ -33,6 +33,9 @@ import org.apache.avro.specific.SpecificRecord;
  */
 public class AvroUtils {
 
+  private AvroUtils() {
+  }
+
   /**
    * Encode an Avro record into byte array
    *

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
@@ -17,7 +17,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Class that contains the helper utility methods for File system operations.
  */
-public class FileUtils {
+public final class FileUtils {
 
   private FileUtils() {
   }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/FileUtils.java
@@ -19,6 +19,9 @@ import org.slf4j.LoggerFactory;
  */
 public class FileUtils {
 
+  private FileUtils() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(FileUtils.class.getName());
 
   /**

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/FutureUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/FutureUtils.java
@@ -22,7 +22,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 /**
  * Utilities to work with {@link Future}
  */
-public class FutureUtils {
+public final class FutureUtils {
 
   private static final int EXECUTOR_CORE_POOL_SIZE = 4;
   private static final ScheduledExecutorService SCHEDULED_EXECUTOR_SERVICE = Executors.newScheduledThreadPool(

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
@@ -21,6 +21,10 @@ import org.slf4j.LoggerFactory;
  * Util class for logging-related methods
  */
 public class LogUtils {
+
+  private LogUtils() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(LogUtils.class.getName());
   private static final double BUFFER_1KB =  1024;
 

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/LogUtils.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Util class for logging-related methods
  */
-public class LogUtils {
+public final class LogUtils {
 
   private LogUtils() {
   }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
@@ -12,7 +12,7 @@ import java.net.ServerSocket;
 /**
  * Class that contains the helper utility methods for Network operations.
  */
-public class NetworkUtils {
+public final class NetworkUtils {
 
   private NetworkUtils() {
   }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/NetworkUtils.java
@@ -14,6 +14,9 @@ import java.net.ServerSocket;
  */
 public class NetworkUtils {
 
+  private NetworkUtils() {
+  }
+
   /**
    * Get the next available port that can be used for opening a socket connection.
    */

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/PollUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/PollUtils.java
@@ -16,6 +16,9 @@ import java.util.function.BooleanSupplier;
  */
 public final class PollUtils {
 
+  private PollUtils() {
+  }
+
   /**
    * Interruptable version of {@link java.util.function.Supplier} for use with Poll functions
    *

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/RestliUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/RestliUtils.java
@@ -16,6 +16,10 @@ import com.linkedin.restli.server.PagingContext;
  * Utility class to simplify usage of Restli.
  */
 public final class RestliUtils {
+
+  private RestliUtils() {
+  }
+
   private static final String URI_SCHEME = "http://";
   private static final String URI_SCHEME_SSL = "https://";
 

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/RetryUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/RetryUtils.java
@@ -17,6 +17,9 @@ import org.slf4j.LoggerFactory;
  */
 public class RetryUtils {
 
+  private RetryUtils() {
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(RetryUtils.class.getName());
 
   /**
@@ -45,7 +48,7 @@ public class RetryUtils {
     private U _value;
     private Exception _lastException;
 
-    public ExceptionTrackingMethodCaller(Supplier<U> func) {
+    ExceptionTrackingMethodCaller(Supplier<U> func) {
       _func = func;
     }
 

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/RetryUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/RetryUtils.java
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
 /**
  * Utilities for retrying function invocations
  */
-public class RetryUtils {
+public final class RetryUtils {
 
   private RetryUtils() {
   }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadTerminationMonitor.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadTerminationMonitor.java
@@ -24,7 +24,7 @@ import com.linkedin.datastream.metrics.DynamicMetricsManager;
  * reports abnormal terminations and reports them as metric.
  * However, it doesn't attempt to recover the condition.
  */
-public class ThreadTerminationMonitor {
+public final class ThreadTerminationMonitor {
 
   private ThreadTerminationMonitor() {
   }

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadTerminationMonitor.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadTerminationMonitor.java
@@ -26,6 +26,9 @@ import com.linkedin.datastream.metrics.DynamicMetricsManager;
  */
 public class ThreadTerminationMonitor {
 
+  private ThreadTerminationMonitor() {
+  }
+
   private static final String ABNORMAL_TERMINATIONS = "abnormalTerminations";
 
   private static final String MODULE = ThreadTerminationMonitor.class.getSimpleName();

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadUtils.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/ThreadUtils.java
@@ -16,6 +16,10 @@ import org.slf4j.Logger;
  * Utility methods for dealing with threading-related concerns.
  */
 public final class ThreadUtils {
+
+  private ThreadUtils() {
+  }
+
   /**
    * Gracefully shutdown an executor service and force terminate if the worker threads
    * do not exit within the specified time out. Adapted from JDK javadoc:

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/TopicPartitionUtil.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/TopicPartitionUtil.java
@@ -13,6 +13,9 @@ import org.apache.kafka.common.TopicPartition;
  */
 public class TopicPartitionUtil {
 
+  private TopicPartitionUtil() {
+  }
+
   /**
    * Create a topic partition instance from String
    */

--- a/datastream-utils/src/main/java/com/linkedin/datastream/common/TopicPartitionUtil.java
+++ b/datastream-utils/src/main/java/com/linkedin/datastream/common/TopicPartitionUtil.java
@@ -11,7 +11,7 @@ import org.apache.kafka.common.TopicPartition;
 /**
  * Utility class for converting String to TopicPartitions
  */
-public class TopicPartitionUtil {
+public final class TopicPartitionUtil {
 
   private TopicPartitionUtil() {
   }


### PR DESCRIPTION
## Summary
No behavior changes in any file. All fixes are declaration-level no-ops that make existing intent explicit without changing runtime behavior.

* HideUtilityClassConstructorCheck (26): Added explicit private constructors to utility classes to prevent accidental instantiation, matching their existing all-static design.
* FinalClassCheck (6): Marked classes (and one nested class) as final where they were already effectively non-subclassable due to private constructors.
* RedundantModifierCheck (16): Removed redundant public modifiers from constructors of private or package-private nested types, since their visibility is already constrained by the enclosing type.
* MissingOverrideCheck (1): Added a missing @Override annotation to AbstractKafkaConnector#getActiveTasks(), aligning with its existing inherited Javadoc.



## Testing Done
No logic change. PR checks only