### PR TITLE
Fix duplicate JsonUtils() constructor causing build failure

### DIFF
--- a/datastream-common/src/main/java/com/linkedin/datastream/common/JsonUtils.java
+++ b/datastream-common/src/main/java/com/linkedin/datastream/common/JsonUtils.java
@@ -33,9 +33,6 @@ import com.fasterxml.jackson.databind.SerializerProvider;
  */
 public final class JsonUtils {
 
-  private JsonUtils() {
-  }
-
   private static final Logger LOG = LoggerFactory.getLogger(JsonUtils.class.getName());
 
   private static final ObjectMapper MAPPER = newObjectMapper();


### PR DESCRIPTION
## Summary
Two parallel PRs (#1038 'Checkstyle class-design cleanup' and #1040 'Centralize ObjectMapper construction via JsonUtils.newObjectMapper()') each independently added a private no-arg constructor to JsonUtils, merging into master with two definitions of the same constructor. This broke compilation of datastream-common with:
error: constructor JsonUtils() is already defined in class JsonUtils Removed the duplicate, keeping the field declarations before the single remaining private constructor.

## Testing Done
PR checks