### PR TITLE
Add observability logs for load-based partition assignment

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssigner.java
@@ -48,6 +48,7 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
   private static final DynamicMetricsManager DYNAMIC_METRICS_MANAGER = DynamicMetricsManager.getInstance();
   private static final String MIN_PARTITIONS_ACROSS_TASKS = "minPartitionsAcrossTasks";
   private static final String MAX_PARTITIONS_ACROSS_TASKS = "maxPartitionsAcrossTasks";
+  private static final int KEY_SAMPLE_SIZE = 10;
 
   private final int _defaultPartitionBytesInKBRate;
   private final int _defaultPartitionMsgsInRate;
@@ -121,9 +122,12 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
 
     ArrayList<String> recognizedPartitions = new ArrayList<>(); // partitions with throughput info
     ArrayList<String> unrecognizedPartitions = new ArrayList<>(); // partitions without throughput info
+    int partitionLevelMatchCount = 0; // partitions matched by an exact partition-level throughput key
+    int topicLevelFallbackMatchCount = 0; // partitions matched only via the topic-level throughput fallback
     for (String partition : unassignedPartitions) {
       if (partitionInfoMap.containsKey(partition)) {
         recognizedPartitions.add(partition);
+        partitionLevelMatchCount++;
       } else {
         // If the partition level information is not found, try finding topic level information. It is always better
         // than no information about the partition. Update the map with that information so that it can be used in later
@@ -132,10 +136,36 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
         if (partitionInfoMap.containsKey(topic)) {
           partitionInfoMap.put(partition, partitionInfoMap.get(topic));
           recognizedPartitions.add(partition);
+          topicLevelFallbackMatchCount++;
         } else {
           unrecognizedPartitions.add(partition);
         }
       }
+    }
+
+    // Throughput coverage determines whether partitions are load-balanced by byte rate (recognized) or placed
+    // round-robin (unrecognized). A high recognized ratio indicates the throughput provider returned usable data.
+    // topicLevelFallback isolates partitions recognized only via the per-topic fallback rung.
+    LOG.info("Throughput coverage for datastream={}: unassignedPartitions={}, recognized={} "
+            + "(partitionLevel={}, topicLevelFallback={}), unrecognized(round-robin)={}, providerPartitionEntries={}",
+        datastreamGroupName, unassignedPartitions.size(), recognizedPartitions.size(), partitionLevelMatchCount,
+        topicLevelFallbackMatchCount, unrecognizedPartitions.size(), throughputInfo.getPartitionInfoMap().size());
+
+    // When the provider returned data but some partitions still matched no throughput key, log a bounded sample of
+    // unmatched partition names alongside a sample of provider keys. Comparing the two formats surfaces key mismatches
+    // (e.g. a source keying partitions differently from the actual partition names) that would otherwise silently fall
+    // back to round-robin.
+    if (!unrecognizedPartitions.isEmpty() && !throughputInfo.getPartitionInfoMap().isEmpty()) {
+      List<String> unmatchedPartitionSample = unrecognizedPartitions.stream()
+          .limit(KEY_SAMPLE_SIZE)
+          .collect(Collectors.toList());
+      List<String> providerKeySample = throughputInfo.getPartitionInfoMap().keySet().stream()
+          .limit(KEY_SAMPLE_SIZE)
+          .collect(Collectors.toList());
+      LOG.info("Throughput key match diagnostics for datastream={}: {}/{} partitions matched no provider key. "
+              + "Sample unmatched partitions (max {}): {}. Sample provider keys (max {}): {}. Compare the two "
+              + "formats to spot throughput key mismatches.", datastreamGroupName, unrecognizedPartitions.size(),
+          unassignedPartitions.size(), KEY_SAMPLE_SIZE, unmatchedPartitionSample, KEY_SAMPLE_SIZE, providerKeySample);
     }
 
     LOG.info("Sorting recognized partitions on byte rate");
@@ -213,6 +243,20 @@ public class LoadBasedPartitionAssigner implements MetricsAware {
     metrics.maxPartitionsAcrossTasks(stats.getMax());
     LOG.info("Assignment stats for {}. Min partitions across tasks: {}, max partitions across tasks: {}", taskPrefix,
         stats.getMin(), stats.getMax());
+
+    // Log the resulting per-task load (throughput) distribution. This is the primary signal that load-based
+    // assignment balanced throughput across tasks: when balancing works, min/max/avg task throughput are close and
+    // maxMinusMin is small. Unlike the partition-count stats above, this reflects byte rate, which is what the
+    // algorithm actually balances on. Note: this covers throughput-recognized partitions; round-robin partitions
+    // with unknown throughput are not included here.
+    if (!taskThroughputMap.isEmpty()) {
+      IntSummaryStatistics throughputStats = taskThroughputMap.values().stream()
+          .collect(Collectors.summarizingInt(Integer::intValue));
+      LOG.info("Load balance stats for {} across {} tasks. Task throughput (KBps) -> min: {}, max: {}, avg: {}, "
+              + "total: {}, maxMinusMin: {}", taskPrefix, throughputStats.getCount(), throughputStats.getMin(),
+          throughputStats.getMax(), String.format("%.1f", throughputStats.getAverage()), throughputStats.getSum(),
+          throughputStats.getMax() - throughputStats.getMin());
+    }
 
     LOG.info("END: assignPartitions for datastream={}", datastreamGroupName);
     return newAssignments;

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/assignment/LoadBasedPartitionAssignmentStrategy.java
@@ -127,10 +127,20 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
     unassignedPartitions.removeAll(assignedPartitions);
 
     ClusterThroughputInfo clusterThroughputInfo = new ClusterThroughputInfo(StringUtils.EMPTY, Collections.emptyMap());
+    // Throughput info is fetched (and true load-based, throughput-balanced assignment performed) only on the initial
+    // assignment for the datastream group, i.e. when no partitions are currently assigned (STOPPED -> READY
+    // transition, first assignment, or restart). On incremental assignments (partitions already assigned) throughput
+    // is NOT refetched, so newly unassigned partitions are placed round-robin rather than balanced by byte rate.
     if (assignedPartitions.isEmpty()) {
+      LOG.info("Initial assignment for datastream {}: no partitions currently assigned, {} unassigned partitions, "
+              + "{} tasks. Fetching throughput info to perform load-based (throughput-balanced) partition assignment.",
+          datastreamGroupName, unassignedPartitions.size(), taskCount);
       try {
         // Attempting to retrieve partition throughput info on initial assignment
         clusterThroughputInfo = fetchPartitionThroughputInfo(datastreamGroup);
+        LOG.info("Fetched throughput info for datastream {} from provider {}: clusterName={}, partitionEntries={}",
+            datastreamGroupName, _throughputProvider.getClass().getSimpleName(),
+            clusterThroughputInfo.getClusterName(), clusterThroughputInfo.getPartitionInfoMap().size());
       } catch (RetriesExhaustedException ex) {
         LOG.warn("Attempts to fetch partition throughput timed out");
         LOG.info("Throughput information unavailable during initial assignment. Falling back to sticky partition assignment");
@@ -164,6 +174,13 @@ public class LoadBasedPartitionAssignmentStrategy extends StickyPartitionAssignm
       if (numTasksNeeded > taskCount) {
         updateNumTasksAndForceTaskCreation(datastreamPartitions, numTasksNeeded, taskCount);
       }
+    } else {
+      // Incremental assignment: throughput info is not refetched, so clusterThroughputInfo stays empty and the
+      // assigner treats every unassigned partition as unrecognized (round-robin), not throughput-balanced.
+      LOG.info("Incremental assignment for datastream {}: {} partitions already assigned, {} unassigned partitions. "
+              + "Throughput info is NOT refetched on incremental assignments; the {} unassigned partitions will be "
+              + "placed round-robin (not throughput-balanced).", datastreamGroupName, assignedPartitions.size(),
+          unassignedPartitions.size(), unassignedPartitions.size());
     }
 
     // Doing assignment

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.5.22"
+  version = "5.5.23-dsawner1-SNAPSHOT"
 }
 
 subprojects {

--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.5.23-dsawner1-SNAPSHOT"
+  version = "5.5.25"
 }
 
 subprojects {


### PR DESCRIPTION
## Summary

Adds INFO logs at the critical decision points of throughput-based partition assignment to verify that load balancing is actually working — i.e. distinguish **true load-based (throughput-balanced) assignment** from **round-robin fallback**, and observe whether the resulting per-task load is balanced.

Today the assigner logs `min/max partitions across tasks`, but load-based assignment intentionally makes partition **counts** uneven while balancing **byte rate**, so those counts do not prove balance. There is also no signal for whether throughput data was actually used, or whether an assignment fell back to round-robin.

## Changes (logging only — no behavior change)

**`LoadBasedPartitionAssignmentStrategy`**
- Log whether an assignment is **initial** (throughput fetched → true load-based balancing) or **incremental** (throughput not refetched → newly unassigned partitions placed round-robin). Throughput is only fetched when no partitions are currently assigned (STOPPED → READY, first assignment, or restart).
- After a successful fetch, log throughput-provider coverage: provider class, cluster name, and number of partition entries returned.

**`LoadBasedPartitionAssigner`**
- Log throughput coverage: `recognized` partitions split into partition-level vs topic-level fallback, vs `unrecognized` (round-robin) partitions, plus provider entry count.
- Log the resulting per-task throughput distribution (`min/max/avg/total/maxMinusMin` in KBps) — the direct signal that byte-rate load is balanced across tasks.

Together these answer: which assignment mode ran → did the provider return data → how many partitions got real rates vs round-robin → is the resulting per-task load even.

## Testing Done
- `./gradlew :datastream-server:compileJava :datastream-server:checkstyleMain` pass.
- `./gradlew :datastream-server:test --tests "*TestLoadBasedPartitionAssigner" --tests "*TestLoadBasedPartitionAssignmentStrategy"` — 15/15 pass.
