### PR TITLE
Gate leader task assignment behind a dynamic ZooKeeper flag

### DIFF
--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1681,10 +1681,17 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
     boolean succeeded = true;
     _log.info("START: Coordinator::handleLeaderDoAssignment.");
 
-    // Honor the dynamic ZooKeeper assignment-enabled flag. If assignment is disabled, block here and keep
-    // re-checking at a fixed interval until it is re-enabled (or the flag znode is deleted), we lose leadership,
-    // or the coordinator is shutting down.
-    blockUntilAssignmentEnabled();
+    // Honor the dynamic ZooKeeper assignment-enabled flag. If assignment is disabled, skip this cycle and
+    // reschedule a LEADER_DO_ASSIGNMENT event after the configured check period instead of blocking the
+    // Coordinator event thread. This keeps the event loop (heartbeats, partition ops, this leader's own
+    // assignment changes, shutdown) responsive while assignment is paused.
+    if (!_adapter.isAssignmentEnabled()) {
+      _log.warn("Datastream task assignment is disabled via the ZooKeeper assignment-enabled flag. "
+          + "Skipping assignment and re-checking in {} ms.", _config.getAssignmentEnabledCheckPeriodMs());
+      scheduleLeaderDoAssignmentWhenReEnabled(isNewlyElectedLeader);
+      _log.info("END: Coordinator::handleLeaderDoAssignment.");
+      return;
+    }
 
     List<String> liveInstances = Collections.emptyList();
     Map<String, Set<DatastreamTask>> previousAssignmentByInstance = Collections.emptyMap();
@@ -1758,33 +1765,23 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   }
 
   /**
-   * Block the leader Coordinator while datastream task assignment is disabled via the dynamic ZooKeeper flag
-   * (see {@link com.linkedin.datastream.server.zk.KeyBuilder#assignmentEnabled(String)}).
+   * Reschedule a {@code LEADER_DO_ASSIGNMENT} event after the configured assignment-enabled check period
+   * (see {@link CoordinatorConfig#getAssignmentEnabledCheckPeriodMs()}) so the leader re-evaluates the dynamic
+   * ZooKeeper assignment-enabled flag (see {@link com.linkedin.datastream.server.zk.KeyBuilder#assignmentEnabled(String)})
+   * without blocking the Coordinator event thread.
    *
-   * The flag defaults to enabled, so this method returns immediately when the flag znode is absent or does not
-   * hold the value {@code "false"}. When assignment is disabled, this method re-checks the flag at a fixed
-   * interval ({@link CoordinatorConfig#getAssignmentEnabledCheckPeriodMs()}) and returns once assignment is
-   * re-enabled, the flag znode is deleted, this instance is no longer the leader, or the thread is interrupted.
+   * The rescheduled event is only handled while this instance is still the leader (see {@link #handleEvent}),
+   * so leadership loss or shutdown naturally stops the re-check loop. This is a no-op if a
+   * {@code LEADER_DO_ASSIGNMENT} is already scheduled, avoiding piling up redundant futures.
    */
-  private void blockUntilAssignmentEnabled() {
-    boolean wasDisabled = false;
-    while (_adapter.isLeader() && !_adapter.isAssignmentEnabled()) {
-      wasDisabled = true;
-      _log.warn("Datastream task assignment is disabled via the ZooKeeper assignment-enabled flag. "
-          + "Skipping assignment and re-checking in {} ms.", _config.getAssignmentEnabledCheckPeriodMs());
-      try {
-        Thread.sleep(_config.getAssignmentEnabledCheckPeriodMs());
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-        _log.warn("Interrupted while waiting for datastream task assignment to be re-enabled. "
-            + "Proceeding without further waiting.");
-        return;
-      }
+  private void scheduleLeaderDoAssignmentWhenReEnabled(boolean isNewlyElectedLeader) {
+    if (!_leaderDoAssignmentScheduled.compareAndSet(false, true)) {
+      return;
     }
-
-    if (wasDisabled) {
-      _log.info("Datastream task assignment is enabled again. Resuming assignment.");
-    }
+    _leaderDoAssignmentScheduledFuture = _scheduledExecutor.schedule(() -> {
+      _eventQueue.putFirst(CoordinatorEvent.createLeaderDoAssignmentEvent(isNewlyElectedLeader));
+      _leaderDoAssignmentScheduled.set(false);
+    }, _config.getAssignmentEnabledCheckPeriodMs(), TimeUnit.MILLISECONDS);
   }
 
   private void scheduleLeaderDoAssignmentRetry(boolean isNewlyElectedLeader) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/Coordinator.java
@@ -1680,6 +1680,12 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
   private void handleLeaderDoAssignment(boolean isNewlyElectedLeader) {
     boolean succeeded = true;
     _log.info("START: Coordinator::handleLeaderDoAssignment.");
+
+    // Honor the dynamic ZooKeeper assignment-enabled flag. If assignment is disabled, block here and keep
+    // re-checking at a fixed interval until it is re-enabled (or the flag znode is deleted), we lose leadership,
+    // or the coordinator is shutting down.
+    blockUntilAssignmentEnabled();
+
     List<String> liveInstances = Collections.emptyList();
     Map<String, Set<DatastreamTask>> previousAssignmentByInstance = Collections.emptyMap();
     Map<String, List<DatastreamTask>> newAssignmentsByInstance = Collections.emptyMap();
@@ -1749,6 +1755,36 @@ public class Coordinator implements ZkAdapter.ZkAdapterListener, MetricsAware {
       scheduleLeaderDoAssignmentRetry(isNewlyElectedLeader);
     }
     _log.info("END: Coordinator::handleLeaderDoAssignment.");
+  }
+
+  /**
+   * Block the leader Coordinator while datastream task assignment is disabled via the dynamic ZooKeeper flag
+   * (see {@link com.linkedin.datastream.server.zk.KeyBuilder#assignmentEnabled(String)}).
+   *
+   * The flag defaults to enabled, so this method returns immediately when the flag znode is absent or does not
+   * hold the value {@code "false"}. When assignment is disabled, this method re-checks the flag at a fixed
+   * interval ({@link CoordinatorConfig#getAssignmentEnabledCheckPeriodMs()}) and returns once assignment is
+   * re-enabled, the flag znode is deleted, this instance is no longer the leader, or the thread is interrupted.
+   */
+  private void blockUntilAssignmentEnabled() {
+    boolean wasDisabled = false;
+    while (_adapter.isLeader() && !_adapter.isAssignmentEnabled()) {
+      wasDisabled = true;
+      _log.warn("Datastream task assignment is disabled via the ZooKeeper assignment-enabled flag. "
+          + "Skipping assignment and re-checking in {} ms.", _config.getAssignmentEnabledCheckPeriodMs());
+      try {
+        Thread.sleep(_config.getAssignmentEnabledCheckPeriodMs());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        _log.warn("Interrupted while waiting for datastream task assignment to be re-enabled. "
+            + "Proceeding without further waiting.");
+        return;
+      }
+    }
+
+    if (wasDisabled) {
+      _log.info("Datastream task assignment is enabled again. Resuming assignment.");
+    }
   }
 
   private void scheduleLeaderDoAssignmentRetry(boolean isNewlyElectedLeader) {

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/CoordinatorConfig.java
@@ -57,6 +57,8 @@ public final class CoordinatorConfig {
   // SLA threshold for stream provisioning: a datastream's INITIALIZING -> READY duration at or below this
   // is counted as within SLA, above it as outside SLA
   public static final String CONFIG_PROVISIONING_SLA_THRESHOLD_MS = PREFIX + "provisioningSlaThresholdMs";
+  // how long the leader waits between checks of the ZooKeeper assignment-enabled flag while assignment is disabled
+  public static final String CONFIG_ASSIGNMENT_ENABLED_CHECK_PERIOD_MS = PREFIX + "assignmentEnabledCheckPeriodMs";
 
   public static final int DEFAULT_MAX_ASSIGNMENT_RETRY_COUNT = 100;
   public static final long DEFAULT_STOP_PROPAGATION_TIMEOUT_MS = 60 * 1000;
@@ -68,6 +70,7 @@ public final class CoordinatorConfig {
   public static final long DEFAULT_PROVISIONING_SLA_THRESHOLD_MS = Duration.ofMinutes(10).toMillis();
   public static final long DEFAULT_THROUGHPUT_VIOLATING_TOPICS_REFRESH_PERIOD_MS = Duration.ofMinutes(5).toMillis();
   public static final boolean DEFAULT_ENABLE_THROUGHPUT_VIOLATING_TOPICS_PERIODIC_REFRESH = true;
+  public static final long DEFAULT_ASSIGNMENT_ENABLED_CHECK_PERIOD_MS = Duration.ofSeconds(5).toMillis();
 
   private final String _cluster;
   private final String _zkAddress;
@@ -97,6 +100,7 @@ public final class CoordinatorConfig {
   private final boolean _enableThroughputViolatingTopicsPeriodicRefresh;
   private final double _logSizeLimitInBytes;
   private final long _provisioningSlaThresholdMs;
+  private final long _assignmentEnabledCheckPeriodMs;
 
 
   /**
@@ -144,6 +148,8 @@ public final class CoordinatorConfig {
     _logSizeLimitInBytes = _properties.getDouble(CONFIG_LOG_SIZE_LIMIT_IN_BYTES, DEFAULT_LOG_SIZE_LIMIT_IN_BYTES);
     _provisioningSlaThresholdMs = _properties.getLong(CONFIG_PROVISIONING_SLA_THRESHOLD_MS,
         DEFAULT_PROVISIONING_SLA_THRESHOLD_MS);
+    _assignmentEnabledCheckPeriodMs = _properties.getLong(CONFIG_ASSIGNMENT_ENABLED_CHECK_PERIOD_MS,
+        DEFAULT_ASSIGNMENT_ENABLED_CHECK_PERIOD_MS);
   }
 
   public Properties getConfigProperties() {
@@ -254,5 +260,9 @@ public final class CoordinatorConfig {
 
   public long getProvisioningSlaThresholdMs() {
     return _provisioningSlaThresholdMs;
+  }
+
+  public long getAssignmentEnabledCheckPeriodMs() {
+    return _assignmentEnabledCheckPeriodMs;
   }
 }

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/KeyBuilder.java
@@ -26,6 +26,7 @@ public final class KeyBuilder {
   private static final String DATASTREAM_ASSIGNMENT_TOKEN_FOR_INSTANCE = "/%s/dms/%s/assignmentTokens/%s";
   private static final String CONNECTORS = "/%s/connectors";
   private static final String CONNECTOR = "/%s/connectors/%s";
+  private static final String ASSIGNMENT_ENABLED = "/%s/assignmentEnabled";
 
   // Suppresses default constructor, ensuring non-instantiability.
   private KeyBuilder() {
@@ -249,6 +250,24 @@ public final class KeyBuilder {
    */
   public static String connectors(String cluster) {
     return String.format(CONNECTORS, cluster);
+  }
+
+  /**
+   * Get the ZooKeeper znode that acts as a dynamic flag controlling whether the leader Coordinator is
+   * allowed to perform datastream task assignment.
+   *
+   * <pre>Example: /{cluster}/assignmentEnabled</pre>
+   *
+   * The flag is interpreted as follows:
+   * <ul>
+   *   <li>Absent znode: assignment is enabled (this is the default).</li>
+   *   <li>Znode present with value {@code "false"} (case-insensitive): assignment is disabled.</li>
+   *   <li>Znode present with any other value: assignment is enabled.</li>
+   * </ul>
+   * @param cluster Brooklin cluster name
+   */
+  public static String assignmentEnabled(String cluster) {
+    return String.format(ASSIGNMENT_ENABLED, cluster);
   }
 
   /**

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -468,6 +468,32 @@ public class ZkAdapter {
   }
 
   /**
+   * Check whether the leader Coordinator is currently allowed to perform datastream task assignment,
+   * based on a dynamic flag stored in ZooKeeper at {@link KeyBuilder#assignmentEnabled(String)}.
+   *
+   * The flag defaults to enabled. Assignment is considered disabled only when the znode exists and holds
+   * the value {@code "false"} (case-insensitive). An absent znode, an empty/null value, or any other value
+   * is treated as enabled.
+   * @return true if assignment is enabled, false if it is explicitly disabled
+   */
+  public boolean isAssignmentEnabled() {
+    String path = KeyBuilder.assignmentEnabled(_cluster);
+    if (!_zkclient.exists(path)) {
+      // No znode means assignment is enabled (the default).
+      return true;
+    }
+
+    // Use returnNullIfPathNotExists=true to gracefully handle the node being deleted between the
+    // exists() check and this read.
+    String data = _zkclient.readData(path, true);
+    if (data == null || data.trim().isEmpty()) {
+      return true;
+    }
+
+    return !Boolean.FALSE.toString().equalsIgnoreCase(data.trim());
+  }
+
+  /**
    * Update ZooKeeper znode of a datastream
    * @param datastream Datastream name
    * @return true if the update is successful

--- a/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
+++ b/datastream-server/src/main/java/com/linkedin/datastream/server/zk/ZkAdapter.java
@@ -477,15 +477,9 @@ public class ZkAdapter {
    * @return true if assignment is enabled, false if it is explicitly disabled
    */
   public boolean isAssignmentEnabled() {
-    String path = KeyBuilder.assignmentEnabled(_cluster);
-    if (!_zkclient.exists(path)) {
-      // No znode means assignment is enabled (the default).
-      return true;
-    }
-
-    // Use returnNullIfPathNotExists=true to gracefully handle the node being deleted between the
-    // exists() check and this read.
-    String data = _zkclient.readData(path, true);
+    // Pass returnNullIfPathNotExists=true so an absent znode returns null instead of throwing; a null or
+    // empty value means assignment is enabled (the default).
+    String data = _zkclient.readData(KeyBuilder.assignmentEnabled(_cluster), true);
     if (data == null || data.trim().isEmpty()) {
       return true;
     }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/TestCoordinatorConfig.java
@@ -110,4 +110,17 @@ public class TestCoordinatorConfig {
     CoordinatorConfig overridden = createCoordinatorConfig(props);
     Assert.assertFalse(overridden.getEnableThroughputViolatingTopicsPeriodicRefresh());
   }
+
+  @Test
+  public void testAssignmentEnabledCheckPeriodConfig() {
+    Properties props = new Properties();
+    CoordinatorConfig config = createCoordinatorConfig(props);
+    Assert.assertEquals(config.getAssignmentEnabledCheckPeriodMs(),
+        CoordinatorConfig.DEFAULT_ASSIGNMENT_ENABLED_CHECK_PERIOD_MS);
+    Assert.assertEquals(config.getAssignmentEnabledCheckPeriodMs(), Duration.ofSeconds(5).toMillis());
+
+    props.put(CoordinatorConfig.CONFIG_ASSIGNMENT_ENABLED_CHECK_PERIOD_MS, "1000");
+    CoordinatorConfig overridden = createCoordinatorConfig(props);
+    Assert.assertEquals(overridden.getAssignmentEnabledCheckPeriodMs(), 1000L);
+  }
 }

--- a/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
+++ b/datastream-server/src/test/java/com/linkedin/datastream/server/zk/TestZkAdapter.java
@@ -135,6 +135,51 @@ public class TestZkAdapter {
   }
 
   @Test
+  public void testIsAssignmentEnabled() {
+    String testCluster = "test_adapter_assignment_enabled";
+
+    ZkAdapter adapter = createZkAdapter(testCluster);
+    adapter.connect();
+
+    String flagPath = KeyBuilder.assignmentEnabled(testCluster);
+    ZkClient client = new ZkClient(_zkConnectionString);
+
+    // No znode means assignment is enabled (the default).
+    Assert.assertFalse(client.exists(flagPath));
+    Assert.assertTrue(adapter.isAssignmentEnabled());
+
+    // Explicit "false" disables assignment.
+    client.ensurePath(flagPath);
+    client.writeData(flagPath, "false");
+    Assert.assertFalse(adapter.isAssignmentEnabled());
+
+    // Case-insensitive "false" also disables assignment.
+    client.writeData(flagPath, "FALSE");
+    Assert.assertFalse(adapter.isAssignmentEnabled());
+
+    // "true" re-enables assignment.
+    client.writeData(flagPath, "true");
+    Assert.assertTrue(adapter.isAssignmentEnabled());
+
+    // Any other/unrecognized value is treated as enabled.
+    client.writeData(flagPath, "yes");
+    Assert.assertTrue(adapter.isAssignmentEnabled());
+
+    // Empty value is treated as enabled.
+    client.writeData(flagPath, "");
+    Assert.assertTrue(adapter.isAssignmentEnabled());
+
+    // Deleting the znode restores the enabled default.
+    client.writeData(flagPath, "false");
+    Assert.assertFalse(adapter.isAssignmentEnabled());
+    client.delete(flagPath);
+    Assert.assertTrue(adapter.isAssignmentEnabled());
+
+    adapter.disconnect();
+    client.close();
+  }
+
+  @Test
   public void testLeaderElection() {
     String testCluster = "test_adapter_leader";
 


### PR DESCRIPTION
# Gate leader task assignment behind a dynamic ZooKeeper flag

## Summary
Adds a dynamic ZooKeeper-backed **kill-switch** for datastream task assignment. The leader `Coordinator` now consults a `/{cluster}/assignmentEnabled` znode before performing assignment, allowing operators to pause/resume assignment at runtime **without a redeploy or restart**.

## Motivation
During incidents or maintenance, we sometimes need to temporarily stop the leader from (re)assigning datastream tasks. Previously this required code/config changes and a restart. This change introduces a runtime toggle controlled purely via ZooKeeper.

## Behavior
The flag at `/{cluster}/assignmentEnabled` is interpreted as:

| Znode state | Assignment |
|---|---|
| Absent (default) | **Enabled** |
| Value `"false"` (case-insensitive) | **Disabled** |
| Empty / null value | Enabled |
| Any other value (e.g. `"true"`, `"yes"`) | Enabled |

When assignment is **disabled**, the leader does **not** block the Coordinator event thread. Instead, `handleLeaderDoAssignment` skips the current cycle and reschedules a `LEADER_DO_ASSIGNMENT` event after the configured check period (default **5s**). This keeps the Coordinator event loop responsive (heartbeats, partition operations, the leader's own assignment changes, and graceful shutdown) while assignment is paused. Assignment resumes automatically once the flag is re-enabled or the znode is deleted; the rescheduled event is a no-op if the instance is no longer the leader, so leadership loss and shutdown naturally stop the re-check loop.

## Changes

**Production code**
- **`KeyBuilder.java`** — New `assignmentEnabled(String cluster)` helper returning the `/{cluster}/assignmentEnabled` znode path, with Javadoc describing the flag semantics.
- **`ZkAdapter.java`** — New `isAssignmentEnabled()` method that reads the flag from ZooKeeper. Defaults to enabled; treats only a case-insensitive `"false"` as disabled. Safely handles the znode being deleted between the `exists()` check and read (`returnNullIfPathNotExists=true`).
- **`Coordinator.java`** — `handleLeaderDoAssignment` checks `isAssignmentEnabled()` at the top; if assignment is disabled it logs, reschedules a `LEADER_DO_ASSIGNMENT` event via `_scheduledExecutor` after the configured check period (new `scheduleLeaderDoAssignmentWhenReEnabled(...)` helper), and returns immediately instead of blocking. The scheduler is guarded so it does not pile up redundant futures.
- **`CoordinatorConfig.java`** — New config `brooklin.server.coordinator.assignmentEnabledCheckPeriodMs` (default **5000 ms**) controlling the re-check interval, with getter `getAssignmentEnabledCheckPeriodMs()`.

**Tests**
- **`TestZkAdapter.java`** — `testIsAssignmentEnabled()` covering: absent znode (enabled), `"false"`/`"FALSE"` (disabled), `"true"` (enabled), unrecognized value (enabled), empty value (enabled), and znode deletion restoring the default.
- **`TestCoordinatorConfig.java`** — `testAssignmentEnabledCheckPeriodConfig()` validating the default (5s) and an override.

## Operational usage
- **Disable assignment:** create/set `/{cluster}/assignmentEnabled` to `false`.
- **Re-enable assignment:** set the value to anything else (e.g. `true`) or delete the znode.

## Testing Done
- Added unit tests for `ZkAdapter.isAssignmentEnabled()` (all flag states) and the new `CoordinatorConfig` property (default + override).
- `mint build` / `mint test` on `datastream-server`.

## Risk / Compatibility
Low risk and backward compatible — the flag defaults to **enabled** when the znode is absent, so existing clusters behave exactly as before until an operator explicitly sets the flag.