### PR TITLE
Bump version to 5.5.24

### DIFF
--- a/gradle/maven.gradle
+++ b/gradle/maven.gradle
@@ -1,5 +1,5 @@
 allprojects {
-  version = "5.5.23"
+  version = "5.5.24"
 }
 
 subprojects {


### PR DESCRIPTION
## Summary
- Bump project version from `5.5.23` to `5.5.24` in `gradle/maven.gradle`.
- `5.5.23` is already published to Artifactory as an immutable release, so re-publishing fails with a 403; a new version is required for the next `artifactoryPublish`.

## Testing Done
- [x] Local code review completed

Single-line version bump with no functional code changes. Verified the commit diff contains only the `version` string change (no credentials or other files).

🤖 Generated with [GitHub Copilot CLI](https://docs.github.com/copilot/github-copilot-cli)
